### PR TITLE
install mina packages from the build context, not a local apt repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ _coverage/
 
 CLAUDE.local.md
 /.claude/
+
+# Debian packages staged into the Docker build context
+dockerfiles/*.deb

--- a/Makefile
+++ b/Makefile
@@ -688,20 +688,16 @@ cache-put-debian: ## Upload debian packages for prefork genesis creation
 ########################################
 # Docker images
 
-.PHONY: start-local-debian-repo
-start-local-debian-repo: ## Start a local Debian repository
-	$(info 📦 Starting local Debian repository with codename $(CODENAME))
+.PHONY: stage-debians-for-docker
+stage-debians-for-docker: ## Copy the built Debian packages into the Docker build context
+	$(info 📦 Staging Debian packages from _build into dockerfiles/)
 
-	@./scripts/debian/aptly.sh stop || true
+	@if ! ls _build/*.deb >/dev/null 2>&1; then \
+		echo "Error: no .deb in _build. Build the packages first, for example 'make debian-build-daemon-devnet'." >&2; \
+		exit 1; \
+	fi
 
-	@./scripts/debian/aptly.sh start \
-		--codename $(CODENAME) \
-		--debians _build \
-		--component unstable \
-		--clean \
-		--background \
-		--wait \
-		&& echo "✅ Build complete"
+	@cp _build/*.deb dockerfiles/ && echo "✅ $$(ls -1 dockerfiles/*.deb | wc -l) package(s) staged"
 
 # General function for building Docker images
 define build_docker_image
@@ -723,8 +719,8 @@ define build_docker_image
 		--network $(2) \
 		--no-cache
 
-	$(info 📦 stopping local Debian repository)
-	@./scripts/debian/aptly.sh stop
+	$(info 🧹 removing the staged Debian packages)
+	@rm -f dockerfiles/*.deb
 endef
 
 
@@ -738,42 +734,42 @@ docker-build-toolchain: ## Build the toolchain to be used in CI
 
 .PHONY: docker-build-archive-devnet
 docker-build-archive-devnet: SHELL := /bin/bash
-docker-build-archive-devnet: start-local-debian-repo ## Build the archive Docker image for devnet
+docker-build-archive-devnet: stage-debians-for-docker ## Build the archive Docker image for devnet
 	$(call build_docker_image,mina-archive,devnet)
 
 .PHONY: docker-build-archive-mainnet
 docker-build-archive-mainnet: SHELL := /bin/bash
-docker-build-archive-mainnet: start-local-debian-repo ## Build the archive Docker image for mainnet
+docker-build-archive-mainnet: stage-debians-for-docker ## Build the archive Docker image for mainnet
 	$(call build_docker_image,mina-archive,mainnet)
 
 .PHONY: docker-build-daemon-devnet-generic
 docker-build-daemon-devnet-generic: SHELL := /bin/bash
-docker-build-daemon-devnet-generic: start-local-debian-repo ## Build the daemon Docker image
+docker-build-daemon-devnet-generic: stage-debians-for-docker ## Build the daemon Docker image
 	$(call build_docker_image,mina-daemon,devnet-generic)
 
 .PHONY: docker-build-daemon-devnet
 docker-build-daemon-devnet: SHELL := /bin/bash
-docker-build-daemon-devnet: start-local-debian-repo ## Build the daemon Docker image for devnet
+docker-build-daemon-devnet: stage-debians-for-docker ## Build the daemon Docker image for devnet
 	$(call build_docker_image,mina-daemon,devnet)
 
 .PHONY: docker-build-daemon-mainnet
 docker-build-daemon-mainnet: SHELL := /bin/bash
-docker-build-daemon-mainnet: start-local-debian-repo ## Build the daemon Docker image for mainnet
+docker-build-daemon-mainnet: stage-debians-for-docker ## Build the daemon Docker image for mainnet
 	$(call build_docker_image,mina-daemon,mainnet)
 
 .PHONY: docker-build-rosetta
 docker-build-rosetta-devnet-generic: SHELL := /bin/bash
-docker-build-rosetta-devnet-generic: start-local-debian-repo ## Build the Rosetta Docker image
+docker-build-rosetta-devnet-generic: stage-debians-for-docker ## Build the Rosetta Docker image
 	$(call build_docker_image,mina-rosetta,devnet-generic)
 
 .PHONY: docker-build-rosetta-devnet
 docker-build-rosetta-devnet: SHELL := /bin/bash
-docker-build-rosetta-devnet: start-local-debian-repo ## Build the Rosetta Docker image for devnet
+docker-build-rosetta-devnet: stage-debians-for-docker ## Build the Rosetta Docker image for devnet
 	$(call build_docker_image,mina-rosetta,devnet)
 
 .PHONY: docker-build-rosetta-mainnet
 docker-build-rosetta-mainnet: SHELL := /bin/bash
-docker-build-rosetta-mainnet: start-local-debian-repo ## Build the Rosetta Docker image for mainnet
+docker-build-rosetta-mainnet: stage-debians-for-docker ## Build the Rosetta Docker image for mainnet
 	$(call build_docker_image,mina-rosetta,mainnet)
 
 ########################################
@@ -806,7 +802,7 @@ docker-build-daemon-hardfork-docker: ## Generate hardfork packages
 	$(call check_env_var,BRANCH_NAME)
 
 	$(MAKE) debian-build-config-$(NETWORK_NAME)
-	$(MAKE) start-local-debian-repo
+	$(MAKE) stage-debians-for-docker
 
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
@@ -824,8 +820,6 @@ docker-build-daemon-hardfork-docker: ## Generate hardfork packages
 		--load-only
 		--no-cache
 
-	cp _build/mina-devnet-config_*.deb .
-
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
 	export KEEP_MY_TAGS_INTACT=true && \
@@ -841,8 +835,8 @@ docker-build-daemon-hardfork-docker: ## Generate hardfork packages
 		--no-cache \
 		--load-only
 
-	$(info 📦 stopping local Debian repository)
-	@./scripts/debian/aptly.sh stop
+	$(info 🧹 removing the staged Debian packages)
+	@rm -f dockerfiles/*.deb
 
 .PHONY: docker-build-hardfork-rosetta-docker
 docker-build-hardfork-rosetta-docker: SHELL := /bin/bash
@@ -853,7 +847,7 @@ docker-build-hardfork-rosetta-docker: ## Generate hardfork packages
 	$(call check_env_var,BRANCH_NAME)
 
 	$(MAKE) debian-build-config-$(NETWORK_NAME)
-	$(MAKE) start-local-debian-repo
+	$(MAKE) stage-debians-for-docker
 
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
@@ -870,8 +864,6 @@ docker-build-hardfork-rosetta-docker: ## Generate hardfork packages
 		--custom-suffix generic \
 		--load-only \
 		--no-cache
-
-	cp _build/mina-devnet-config_*.deb .
 
 	@export BUILD_DIR=./_build && \
 	export MINA_DEB_CODENAME=$(CODENAME) && \
@@ -890,8 +882,8 @@ docker-build-hardfork-rosetta-docker: ## Generate hardfork packages
 		--load-only
 
 
-	$(info 📦 stopping local Debian repository)
-	@./scripts/debian/aptly.sh stop
+	$(info 🧹 removing the staged Debian packages)
+	@rm -f dockerfiles/*.deb
 
 ########################################
 # Generate odoc documentation

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -34,7 +34,7 @@ let Arch = ../Constants/Arch.dhall
 
 let DebianInstallMode
     : Type
-    = < ThroughLocalRepo | NoInstall | DownloadOnly >
+    = < NoInstall | DownloadOnly >
 
 let ReleaseSpec =
       { Type =
@@ -74,7 +74,7 @@ let ReleaseSpec =
           , service = Artifacts.Type.Daemon
           , branch = "\\\${BUILDKITE_BRANCH}"
           , repo = "\\\${BUILDKITE_REPO}"
-          , deb_install_mode = DebianInstallMode.ThroughLocalRepo
+          , deb_install_mode = DebianInstallMode.DownloadOnly
           , deb_root_folder = "\\\${BUILDKITE_BUILD_ID}"
           , deb_codename = DebianVersions.DebVersion.Bullseye
           , deb_release = "unstable"
@@ -120,23 +120,11 @@ let generateStep =
 
           let maybeCacheOption = if spec.no_cache then "--no-cache" else ""
 
-          let maybeStartDebianRepo =
+          let maybeReadDebians =
                 merge
-                  { ThroughLocalRepo =
-                      " && ./buildkite/scripts/debian/start_local_repo.sh --root ${spec.deb_root_folder} --arch ${Arch.lowerName
-                                                                                                                    spec.arch}"
-                  , DownloadOnly =
+                  { DownloadOnly =
                       " && ROOT=${spec.deb_root_folder} LOCAL_DEB_FOLDER=\"dockerfiles\" ./buildkite/scripts/debian/read_all_from_cache.sh "
-                  , NoInstall = " && echo Skipping local debian repo setup "
-                  }
-                  spec.deb_install_mode
-
-          let maybeStopDebianRepo =
-                merge
-                  { ThroughLocalRepo = " && ./scripts/debian/aptly.sh stop"
-                  , DownloadOnly =
-                      " && echo Skipping local debian repo teardown "
-                  , NoInstall = " && echo Skipping local debian repo teardown "
+                  , NoInstall = " && echo This image installs no Mina package "
                   }
                   spec.deb_install_mode
 
@@ -235,7 +223,6 @@ let generateStep =
                 ++  " ${maybeCacheOption} "
                 ++  " --deb-codename ${DebianVersions.lowerName
                                          spec.deb_codename}"
-                ++  " --deb-repo ${DebianRepo.address spec.deb_repo}"
                 ++  " --deb-release ${spec.deb_release}"
                 ++  " --deb-version ${spec.deb_version}"
                 ++  " --deb-profile ${Profiles.lowerName spec.deb_profile}"
@@ -275,11 +262,10 @@ let generateStep =
                           ++  exportBranchNameCmd
                           ++  " && "
                           ++  pruneDockerImages
-                          ++  maybeStartDebianRepo
+                          ++  maybeReadDebians
                           ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
                           ++  " && "
                           ++  buildDockerCmd
-                          ++  maybeStopDebianRepo
                           ++  maybeVerify
                         )
                     ]

--- a/buildkite/src/Jobs/Test/DockerBuildScriptTest.dhall
+++ b/buildkite/src/Jobs/Test/DockerBuildScriptTest.dhall
@@ -1,0 +1,46 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Docker = ../../Command/Docker/Type.dhall
+
+let Size = ../../Command/Size.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen =
+          [ S.exactly "scripts/docker/build" "sh"
+          , S.exactly "scripts/docker/helper" "sh"
+          , S.strictlyStart (S.contains "scripts/docker/tests")
+          , S.exactly "scripts/export-git-env-vars" "sh"
+          , S.exactly "buildkite/src/Jobs/Test/DockerBuildScriptTest" "dhall"
+          ]
+        , path = "Test"
+        , name = "DockerBuildScriptTest"
+        , tags =
+          [ PipelineTag.Type.Fast
+          , PipelineTag.Type.Test
+          , PipelineTag.Type.Stable
+          , PipelineTag.Type.Docker
+          ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands = [ Cmd.run "./scripts/docker/tests/test_build.sh" ]
+            , label = "Docker build script tests"
+            , key = "docker-build-script-tests"
+            , target = Size.Small
+            , docker = None Docker.Type
+            }
+        ]
+      }

--- a/dockerfiles/Dockerfile-delegation-stateless-verifier
+++ b/dockerfiles/Dockerfile-delegation-stateless-verifier
@@ -10,7 +10,6 @@ ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
@@ -28,10 +27,17 @@ else \
 fi
 
 # install mina delegation verifier
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/deb-files.sh
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" | tee /etc/apt/sources.list.d/mina.list \
-  && apt-get update\
-  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades "mina-delegation-verify=$deb_version" \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  apt-get update \
+  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades \
+  $(/usr/local/bin/deb-files.sh /debs "mina-delegation-verify=${deb_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 # awscli and cqlsh-expansion are used by the delegation verification tool

--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -8,7 +8,6 @@ ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_profile
 ARG deb_suffix
 ARG apt_cache_url=""
@@ -29,10 +28,11 @@ RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 COPY scripts/archive-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -87,9 +87,13 @@ ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 
 # archive-node package
-RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
-  && apt-get update --quiet --yes \
-  && apt-get install --no-install-recommends --quiet --yes "${MINA_DEB}=$deb_version" \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  apt-get update --quiet --yes \
+  && apt-get install --no-install-recommends --quiet --yes \
+  $(/usr/local/bin/deb-files.sh /debs "${MINA_DEB}=${deb_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -8,7 +8,6 @@ ARG deb_version
 ARG deb_release=unstable
 ARG deb_codename=bullseye
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG deb_profile
 ARG deb_suffix
 ARG deb_legacy_version
@@ -47,10 +46,11 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libjemalloc2
 #    libssl
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -101,13 +101,20 @@ ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 # Mina daemon package
 # jemalloc is also installed automatically here to match the package dependencies for this $deb_codename
-RUN echo "Building image with version $deb_version from repo $deb_release $deb_codename for network $network" \
-  && echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  echo "Building image with version $deb_version for network $network from the build context" \
   && apt-get update --quiet --yes \
-  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "${MINA_DEB}=$deb_version" \
+  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades \
+  $(/usr/local/bin/deb-files.sh /debs \
+  "${MINA_DEB}=${deb_version}" \
+  "mina-logproc=${deb_version}" \
+  "?mina-${network}-config=${deb_version}" \
   "${MINA_STORAGE_DEB}=${deb_version}" \
-  "${MINA_CREATE_GENESIS_DEB}=${deb_legacy_version}" \
-  "${MINA_STORAGE_REPAIR_DEB}=${deb_storage_repair_version}" \
+  "?${MINA_CREATE_GENESIS_DEB}=${deb_legacy_version}" \
+  "?${MINA_STORAGE_REPAIR_DEB}=${deb_storage_repair_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 

--- a/dockerfiles/Dockerfile-mina-daemon-hardfork
+++ b/dockerfiles/Dockerfile-mina-daemon-hardfork
@@ -4,7 +4,6 @@ ARG network=mainnet
 ARG docker_repo=gcr.io/o1labs-192920
 ARG deb_release=unstable
 ARG deb_legacy_version
-ARG deb_repo="http://packages.o1test.net"
 
 FROM ${docker_repo}/mina-daemon:${deb_version}-${deb_codename}-${network} AS mina_daemon_hardfork
 
@@ -17,13 +16,15 @@ ARG deb_codename
 ARG network
 ARG deb_release
 ARG deb_legacy_version
-ARG deb_repo
 
-RUN echo "Installing legacy package with version $deb_version from repo $deb_release $deb_codename for network $network" \
-  && echo "deb [trusted=yes] ${deb_repo} ${deb_codename} ${deb_release}" > /etc/apt/sources.list.d/o1.list \
-  && cat /etc/apt/sources.list.d/o1.list \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  echo "Installing legacy package with version $deb_legacy_version for network $network from the build context" \
   && apt-get update --quiet --yes \
-  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades "mina-${network}-prefork-mesa=$deb_legacy_version" \
+  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades \
+  $(/usr/local/bin/deb-files.sh /debs "mina-${network}-prefork-mesa=${deb_legacy_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 ## Reset workdir, USER, and ${UID} for root-owned version

--- a/dockerfiles/Dockerfile-mina-rosetta
+++ b/dockerfiles/Dockerfile-mina-rosetta
@@ -4,7 +4,6 @@ ARG deb_codename=focal
 ARG deb_version
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG TARGETARCH
 
 ARG psql_version=15
@@ -48,10 +47,11 @@ ENV MINA_ROSETTA_DEB=mina-rosetta-${network}
 #    libjemalloc2
 #    libssl
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -131,10 +131,20 @@ RUN mkdir -p ${MINA_CONFIG_DIR}/wallets/store/ \
 
 # Mina daemon package
 # jemalloc is also installed automatically here to match the package dependencies for this $deb_codename
-RUN echo "Building image with version $deb_version from repo $deb_release $deb_codename for network $network" \
-    && echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+    echo "Building image with version $deb_version for network $network from the build context" \
     && apt-get update --quiet --yes \
-    && apt-get install --no-install-recommends --quiet --yes --allow-downgrades "${MINA_DEB}=$deb_version" "${MINA_ARCHIVE_DEB}=$deb_version" "${MINA_ROSETTA_DEB}=$deb_version" "mina-zkapp-test-transaction=$deb_version" \
+    && apt-get install --no-install-recommends --quiet --yes --allow-downgrades \
+    $(/usr/local/bin/deb-files.sh /debs \
+    "${MINA_DEB}=${deb_version}" \
+    "mina-logproc=${deb_version}" \
+    "?mina-${network}-config=${deb_version}" \
+    "${MINA_ARCHIVE_DEB}=${deb_version}" \
+    "${MINA_ROSETTA_DEB}=${deb_version}" \
+    "mina-zkapp-test-transaction=${deb_version}") \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Set up postgres

--- a/dockerfiles/Dockerfile-mina-test-suite
+++ b/dockerfiles/Dockerfile-mina-test-suite
@@ -6,7 +6,6 @@ ARG TARGETARCH
 ARG deb_codename=bullseye
 ARG deb_version
 ARG deb_release=unstable
-ARG deb_repo="http://packages.o1test.net"
 ARG network=mainnet
 
 ARG psql_version=13
@@ -24,10 +23,11 @@ ENV DEBIAN_FRONTEND noninteractive
 #    libprocps8
 #    libjemalloc2
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -94,10 +94,20 @@ RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
 RUN locale-gen en_US.UTF-8
 
 # jemalloc is also installed automatically here to match the package dependencies for this $deb_codename
-RUN echo "Building image with version $deb_version from repo $deb_release $deb_codename " \
-  && echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  echo "Building image with version $deb_version from the build context" \
   && apt-get update --quiet --yes \
-  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades -o Dpkg::Options::="--force-overwrite" "mina-test-suite=$deb_version" "mina-$network-instrumented=$deb_version" "mina-archive-$network-instrumented=$deb_version" "mina-rosetta-$network=$deb_version" \
+  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades -o Dpkg::Options::="--force-overwrite" \
+  $(/usr/local/bin/deb-files.sh /debs \
+  "mina-test-suite=${deb_version}" \
+  "mina-logproc=${deb_version}" \
+  "?mina-${network}-config=${deb_version}" \
+  "mina-${network}-instrumented=${deb_version}" \
+  "mina-archive-${network}-instrumented=${deb_version}" \
+  "mina-rosetta-${network}=${deb_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["sleep","infinity"]

--- a/dockerfiles/Dockerfile-txn-burst
+++ b/dockerfiles/Dockerfile-txn-burst
@@ -11,16 +11,16 @@ ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
 ARG network=mainnet
-ARG deb_repo="http://packages.o1test.net"
 ARG apt_cache_url=""
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -51,10 +51,17 @@ RUN apt-get -y update \
 
 #install mina and txn burst tool
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" | tee /etc/apt/sources.list.d/mina.list \
-  && apt-get update\
-  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades "mina-$network=$deb_version" \
-  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades "mina-batch-txn=$deb_version" \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  apt-get update \
+  && apt-get install --quiet --yes --no-install-recommends --allow-downgrades \
+  $(/usr/local/bin/deb-files.sh /debs \
+  "mina-${network}=${deb_version}" \
+  "mina-logproc=${deb_version}" \
+  "?mina-${network}-config=${deb_version}" \
+  "mina-batch-txn=${deb_version}") \
   && rm -rf /var/lib/apt/lists/*
 
 USER root

--- a/dockerfiles/Dockerfile-zkapp-test-transaction
+++ b/dockerfiles/Dockerfile-zkapp-test-transaction
@@ -5,16 +5,16 @@ FROM ${image}
 ARG deb_version
 ARG deb_codename=bullseye
 ARG deb_release=unstable
-ARG deb_repo="http://packages.o1test.net"
 ARG apt_cache_url=""
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
-# Optional: configure APT caching proxy (bypass proxy for deb_repo)
+# Optional: configure APT caching proxy for the distribution packages
 COPY scripts/configure-apt-proxy.sh /usr/local/bin/configure-apt-proxy.sh
-RUN chmod +x /usr/local/bin/configure-apt-proxy.sh \
-  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url" "$deb_repo"
+COPY scripts/deb-files.sh /usr/local/bin/deb-files.sh
+RUN chmod +x /usr/local/bin/configure-apt-proxy.sh /usr/local/bin/deb-files.sh \
+  && /usr/local/bin/configure-apt-proxy.sh "$apt_cache_url"
 
 # Install ca-certificates using HTTP
 RUN apt-get update --quiet --yes \
@@ -43,10 +43,11 @@ RUN apt-get -y update \
     && rm -rf /var/lib/apt/lists/*
 
 # Snapp test transaction package
-RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" > /etc/apt/sources.list.d/o1.list \
-  && apt-get -y update \
-  || sleep 10s && apt-get -y update \
-  || sleep 10s && apt-get -y update \
-  || sleep 10s && apt-get -y update \
-  && apt-get install -y --no-install-recommends "mina-zkapp-test-transaction=$deb_version" \
+# deb-files.sh writes a list of paths separated by spaces, and the list must
+# divide into one argument for each package.
+# hadolint ignore=SC2046
+RUN --mount=type=bind,source=.,target=/debs \
+  apt-get -y update \
+  && apt-get install -y --no-install-recommends \
+  $(/usr/local/bin/deb-files.sh /debs "mina-zkapp-test-transaction=${deb_version}") \
   && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/scripts/deb-files.sh
+++ b/dockerfiles/scripts/deb-files.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Find the Debian package files that an image must install.
+#
+# The Docker build installs the Mina packages from files in the build context,
+# not from an apt repository. This script changes a list of "name=version" into
+# a list of paths, so that each Dockerfile keeps a readable list of packages and
+# only this script knows how a package file is named.
+#
+# Usage: deb-files.sh <deb-dir> <name=version> [<name=version> ...]
+#
+#   A specification that starts with "?" is optional: if no file matches, the
+#   script writes a note on stderr and continues. Use it for a package that the
+#   build gives only in some conditions, such as the storage repair package.
+#
+# The file name of a Debian package is "<name>_<version>_<arch>.deb". The
+# architecture is not known here (it is amd64, arm64 or all), so the script
+# matches it with a pattern.
+#
+# Example:
+#   apt-get install $(deb-files.sh /debs "mina-devnet=3.1.0-abc" "?mina-x=3.1.0")
+
+set -eu
+
+if [ "$#" -lt 2 ]; then
+    echo "deb-files.sh: usage: deb-files.sh <deb-dir> <name=version> ..." >&2
+    exit 1
+fi
+
+DEB_DIR="$1"
+shift
+
+if [ ! -d "$DEB_DIR" ]; then
+    echo "deb-files.sh: '$DEB_DIR' is not a directory." >&2
+    exit 1
+fi
+
+FILES=""
+MISSING=""
+
+for spec in "$@"; do
+    optional=0
+    case "$spec" in
+        \?*) optional=1; spec="${spec#?}" ;;
+    esac
+
+    name="${spec%%=*}"
+    version="${spec#*=}"
+
+    # An empty name or version means that the caller gave no value for a build
+    # argument. Such a package is not requested at all.
+    if [ -z "$name" ] || [ -z "$version" ] || [ "$name" = "$spec" ]; then
+        if [ "$optional" -eq 1 ]; then
+            continue
+        fi
+        echo "deb-files.sh: '$spec' is not in the form name=version." >&2
+        exit 1
+    fi
+
+    # The architecture is not known, so match it.
+    match=""
+    for candidate in "$DEB_DIR/${name}_${version}_"*.deb; do
+        if [ -f "$candidate" ]; then
+            match="$candidate"
+            break
+        fi
+    done
+
+    if [ -n "$match" ]; then
+        FILES="${FILES} ${match}"
+    elif [ "$optional" -eq 1 ]; then
+        echo "deb-files.sh: optional package ${name}=${version} is not in ${DEB_DIR}, skipping." >&2
+    else
+        MISSING="${MISSING} ${name}=${version}"
+    fi
+done
+
+if [ -n "$MISSING" ]; then
+    echo "deb-files.sh: these packages are not in ${DEB_DIR}:${MISSING}" >&2
+    echo "deb-files.sh: the directory holds:" >&2
+    found=0
+    for f in "$DEB_DIR"/*.deb; do
+        if [ -f "$f" ]; then
+            echo "  $(basename "$f")" >&2
+            found=1
+        fi
+    done
+    [ "$found" -eq 1 ] || echo "  (no .deb file)" >&2
+    exit 1
+fi
+
+echo "${FILES# }"

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -70,7 +70,6 @@ while [[ "$#" -gt 0 ]]; do case $1 in
   --deb-legacy-version) INPUT_LEGACY_VERSION="$2"; shift;;
   --deb-storage-repair-version) INPUT_STORAGE_REPAIR_VERSION="$2"; shift;;
   --deb-profile) DEB_PROFILE="$2"; shift;;
-  --deb-repo) INPUT_REPO="$2"; shift;;
   --deb-arch) DEB_ARCH="$2"; shift;;
   --deb-build-flags) DEB_BUILD_FLAGS="$2"; shift;;
   --deb-suffix) export DOCKER_DEB_SUFFIX="$2"; shift;;
@@ -189,28 +188,22 @@ else
   CACHE="--cache-from $INPUT_CACHE"
 fi
 
-if [[ -z "${INPUT_REPO:-}" ]]; then
-  echo "Debian repository is not set. Using the default (http://localhost:8080)"
-  DEB_REPO="--build-arg deb_repo=http://localhost:8080"
-else
-  echo "Using provided Debian repository: $INPUT_REPO"
-  DEB_REPO="--build-arg deb_repo=$INPUT_REPO"
-fi
-
-GW=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')
-LOCALHOST_REPLACEMENT=$GW
-if [[ -z "${INPUT_REPO:-}" ]]; then
-  echo "Debian repository is not set. Using the default (http://$LOCALHOST_REPLACEMENT:8080)"
-  DEB_REPO="--build-arg deb_repo=http://$LOCALHOST_REPLACEMENT:8080"
-else
-  echo "Converting localhost to $LOCALHOST_REPLACEMENT in repository URL"
-  CONVERTED_REPO=$(echo "$INPUT_REPO" | sed "s/localhost/$LOCALHOST_REPLACEMENT/g")
-  DEB_REPO="--build-arg deb_repo=$CONVERTED_REPO"
-fi
-
+# The images install the Mina packages from files in the build context, so the
+# build needs no Debian repository. Only the APT cache proxy, which serves the
+# packages of the distribution, can still name the host as "localhost". The
+# build container cannot reach the host under that name, so change it to the
+# address of the gateway of the docker bridge network.
 APT_CACHE_ARG=""
 if [[ -n "${APT_CACHE_PROXY:-}" ]]; then
-  CONVERTED_PROXY=$(echo "$APT_CACHE_PROXY" | sed "s/localhost/$LOCALHOST_REPLACEMENT/g")
+  CONVERTED_PROXY="$APT_CACHE_PROXY"
+  if [[ "$CONVERTED_PROXY" == *localhost* ]]; then
+    if GW=$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null) \
+       && [[ -n "$GW" ]]; then
+      CONVERTED_PROXY=${CONVERTED_PROXY//localhost/$GW}
+    else
+      echo "WARNING: cannot read the gateway of the docker bridge network, keeping 'localhost'"
+    fi
+  fi
   # Probe proxy reachability before passing to Docker build; fall back to direct if unreachable
   if curl -so /dev/null --connect-timeout 2 --max-time 4 "$CONVERTED_PROXY" 2>/dev/null; then
     APT_CACHE_ARG="--build-arg apt_cache_url=$CONVERTED_PROXY"
@@ -290,6 +283,8 @@ case "${SERVICE}" in
         ;;
     mina-delegation-verifier)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-delegation-stateless-verifier"
+        # A build context is needed: the image installs its package from a file.
+        DOCKER_CONTEXT="dockerfiles/"
         ;;
     delegation-backend-toolchain)
         DOCKERFILE_PATH="dockerfiles/Dockerfile-delegation-backend-toolchain"
@@ -320,9 +315,9 @@ BUILD_NETWORK="--allow=network.host"
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 if [[ -z "${DOCKER_CONTEXT:-}" ]]; then
   cat $DOCKERFILE_PATH | docker buildx build  --network=host \
-  --"$DOCKER_ACTION" --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_STORAGE_REPAIR_VERSION $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG -t "$TAG" -t "$HASHTAG" -
+  --"$DOCKER_ACTION" --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_STORAGE_REPAIR_VERSION $DEB_ARCH $IMAGE_NAME_ARG $VERSION_ARG -t "$TAG" -t "$HASHTAG" -
 else
-  docker buildx build --"$DOCKER_ACTION" --network=host --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $DEB_REPO $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $DEB_STORAGE_REPAIR_VERSION $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
+  docker buildx build --"$DOCKER_ACTION" --network=host --progress=plain $PLATFORM $DOCKER_REPO_ARG $NO_CACHE $BUILD_NETWORK $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_SUFFIX_ARG $BUILD_FLAGS_SUFFIX_ARG $APT_CACHE_ARG $BRANCH $REPO $LEGACY_VERSION $CUSTOM_SUFFIX_ARG $CUSTOM_ARG $DEB_ARCH $DEB_STORAGE_REPAIR_VERSION $IMAGE_NAME_ARG $VERSION_ARG "$DOCKER_CONTEXT" -t "$TAG" -t "$HASHTAG" -f $DOCKERFILE_PATH
 fi
 
 # Clean up temp Dockerfile if one was created

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -1,0 +1,603 @@
+#!/bin/bash
+set -euo pipefail
+
+################################################################################
+# Test suite for scripts/docker/build.sh
+#
+# Usage:
+#   bash scripts/docker/tests/test_build.sh
+#
+# The tests are black box: they run build.sh as a program, with a stub "docker"
+# program on the PATH. The stub writes each argument of "docker buildx build" on
+# one line of a file, so a test can examine the complete docker command without
+# a build. No test calls a function of helper.sh.
+#
+# The suite is black box on purpose. It is a specification of what build.sh must
+# do, and it stays valid if the script is later refactored, or moved to another
+# language. A test that calls an internal function does not stay valid.
+#
+# Two groups of tests are below:
+# - "Behaviour": what build.sh must always do.
+# - "Known defects": what build.sh does today, which is not correct. Each of
+#   these tests has a DEFECT note. When you repair a defect, the related test
+#   fails. That is the intention: change the test in the same change-set.
+################################################################################
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+################################################################################
+# Test framework
+################################################################################
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+FAILURES=()
+CURRENT_TEST=""
+
+log_pass() {
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+}
+
+log_fail() {
+    local msg="$1"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("${CURRENT_TEST}: ${msg}")
+    echo "  FAIL: ${msg}" >&2
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        log_pass
+    else
+        log_fail "${label}: expected '${expected}', got '${actual}'"
+    fi
+}
+
+assert_file_absent() {
+    local label="$1" path="$2"
+    if [[ -e "$path" ]]; then
+        log_fail "${label}: '${path}' exists"
+    else
+        log_pass
+    fi
+}
+
+assert_file_exists() {
+    local label="$1" path="$2"
+    if [[ -e "$path" ]]; then
+        log_pass
+    else
+        log_fail "${label}: '${path}' does not exist"
+    fi
+}
+
+# The stub writes one argument on each line, so an exact line match is precise.
+assert_has_line() {
+    local label="$1" file="$2" line="$3"
+    if grep -qFx -- "$line" "$file"; then
+        log_pass
+    else
+        log_fail "${label}: the docker command has no argument '${line}'"
+    fi
+}
+
+assert_no_line() {
+    local label="$1" file="$2" line="$3"
+    if grep -qFx -- "$line" "$file"; then
+        log_fail "${label}: the docker command must not have the argument '${line}'"
+    else
+        log_pass
+    fi
+}
+
+assert_matches() {
+    local label="$1" file="$2" pattern="$3"
+    if grep -qE -- "$pattern" "$file"; then
+        log_pass
+    else
+        log_fail "${label}: no argument matches '${pattern}'"
+    fi
+}
+
+run_test() {
+    CURRENT_TEST="$1"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local failures_before=${TESTS_FAILED}
+
+    echo -n "TEST: ${CURRENT_TEST} ... "
+
+    # "|| true" stops an error in one test from stopping the suite.
+    "$1" || true
+
+    if [[ ${TESTS_FAILED} -eq ${failures_before} ]]; then
+        echo "OK"
+    else
+        echo "FAILED"
+    fi
+}
+
+################################################################################
+# Stub docker
+################################################################################
+
+STUB_DIR=""
+LAST_EXIT=0
+
+setup_stub_docker() {
+    STUB_DIR="$(mktemp -d)"
+    cat > "${STUB_DIR}/docker" <<'STUB'
+#!/usr/bin/env bash
+# Record the arguments of the build only. The other calls (the setup of buildx,
+# the inspection of the network) must not change the recorded command.
+if [[ "${1:-}" == "buildx" && "${2:-}" == "build" ]]; then
+    printf '%s\n' "$@" > "${DOCKER_ARGS_FILE}"
+    exit 0
+fi
+# "docker network inspect" gives the gateway of the bridge network.
+if [[ "${1:-}" == "network" ]]; then
+    echo "172.17.0.1"
+    exit 0
+fi
+exit 0
+STUB
+    chmod +x "${STUB_DIR}/docker"
+}
+
+teardown_stub_docker() {
+    [[ -n "$STUB_DIR" && -d "$STUB_DIR" ]] && rm -rf "$STUB_DIR"
+    return 0
+}
+
+# Run build.sh with fixed git values, so that the tags are the same on every
+# machine. OVERRIDE_TAG also stops export-git-env-vars.sh from doing a network
+# "git fetch --tags".
+#
+# The exit code goes into LAST_EXIT. The output goes into "<args file>.log".
+run_build() {
+    local args_file="$1"
+    shift
+    rm -f "$args_file"
+    set +e
+    ( cd "$REPO_ROOT" && \
+      PATH="${STUB_DIR}:${PATH}" \
+      DOCKER_ARGS_FILE="$args_file" \
+      OVERRIDE_GITHASH="abcdefgh" \
+      OVERRIDE_TAG="3.0.0" \
+      BRANCH_NAME="test-branch" \
+      MINA_DEB_CODENAME="bullseye" \
+      KEEP_MY_TAGS_INTACT="true" \
+      CI="" BUILDKITE="" GITHUB_ACTIONS="" \
+      ./scripts/docker/build.sh "$@" ) > "${args_file}.log" 2>&1
+    LAST_EXIT=$?
+    set -e
+    touch "$args_file"
+}
+
+################################################################################
+# Behaviour
+################################################################################
+
+test_daemon_command() {
+    local args="${STUB_DIR}/daemon.args"
+    run_build "$args" \
+        --service mina-daemon \
+        --version 3.1.0 \
+        --network devnet \
+        --docker-registry testreg \
+        --deb-codename bullseye \
+        --deb-build-flags none
+
+    assert_eq "exit code" 0 "$LAST_EXIT"
+    assert_has_line "dockerfile" "$args" "dockerfiles/Dockerfile-mina-daemon"
+    assert_has_line "context" "$args" "dockerfiles/"
+    assert_has_line "base image" "$args" "image=debian:bullseye-slim"
+    assert_has_line "network" "$args" "network=devnet"
+    assert_has_line "codename" "$args" "deb_codename=bullseye"
+    assert_has_line "release defaults to unstable" "$args" "deb_release=unstable"
+    assert_has_line "architecture defaults to all" "$args" "deb_arch=all"
+    assert_has_line "branch defaults to compatible" "$args" "MINA_BRANCH=compatible"
+    assert_has_line "the debian version defaults to the version" "$args" "deb_version=3.1.0"
+    # The build argument "version" keeps the version without the network.
+    assert_has_line "version build argument" "$args" "version=3.1.0"
+    assert_has_line "readable tag" "$args" "testreg/mina-daemon:3.1.0-devnet"
+    assert_has_line "hash tag" "$args" "testreg/mina-daemon:abcdefg-bullseye-devnet"
+    assert_has_line "push by default" "$args" "--push"
+}
+
+test_load_only_does_not_push() {
+    local args="${STUB_DIR}/load.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none --load-only
+
+    assert_has_line "load" "$args" "--load"
+    assert_no_line "no push" "$args" "--push"
+}
+
+test_archive_mainnet_noble() {
+    local args="${STUB_DIR}/archive.args"
+    run_build "$args" \
+        --service mina-archive --version 3.1.0 --network mainnet \
+        --docker-registry testreg --deb-codename noble --deb-build-flags none
+
+    assert_has_line "dockerfile" "$args" "dockerfiles/Dockerfile-mina-archive"
+    assert_has_line "ubuntu base image" "$args" "image=ubuntu:noble"
+    assert_has_line "tag holds the network" "$args" "testreg/mina-archive:3.1.0-mainnet"
+    assert_has_line "hash tag holds the codename" "$args" \
+        "testreg/mina-archive:abcdefg-noble-mainnet"
+}
+
+test_generic_suffix_reaches_tag_and_build_arg() {
+    local args="${STUB_DIR}/generic.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-suffix generic --deb-build-flags none
+
+    assert_has_line "the build argument has no dash at the start" "$args" "deb_suffix=generic"
+    assert_has_line "tag holds the suffix" "$args" "testreg/mina-daemon:3.1.0-devnet-generic"
+}
+
+# The order of the parts must be the same as the Debian package naming in
+# scripts/debian/builder-helpers.sh: custom suffix, profile, build flags.
+test_suffix_order_is_generic_lightnet_instrumented() {
+    local args="${STUB_DIR}/instr.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg \
+        --deb-suffix generic --deb-profile lightnet --deb-build-flags instrumented
+
+    assert_has_line "complete suffix" "$args" "deb_suffix=generic-lightnet-instrumented"
+    assert_has_line "build flags suffix" "$args" "build_flags_suffix=-instrumented"
+    assert_has_line "tag" "$args" \
+        "testreg/mina-daemon:3.1.0-devnet-generic-lightnet-instrumented"
+}
+
+# A *-configured service starts FROM the image that --version names, but its own
+# tag uses MINA_DOCKER_TAG, because the image holds the configuration of this
+# commit. Here MINA_DOCKER_TAG is 3.0.0-test-branch-abcdefg-bullseye.
+test_configured_service_uses_docker_tag_for_the_output() {
+    local args="${STUB_DIR}/configured.args"
+    run_build "$args" \
+        --service mina-daemon-configured --version 3.1.0 --network devnet \
+        --docker-registry testreg --custom-suffix configured --deb-build-flags none
+
+    assert_has_line "dockerfile" "$args" "dockerfiles/stages/install-config"
+    assert_has_line "the version names the base image" "$args" "version=3.1.0"
+    assert_has_line "output tag" "$args" \
+        "testreg/mina-daemon:3.0.0-test-branch-abcdefg-bullseye-devnet-configured"
+    assert_has_line "custom suffix has a dash at the start" "$args" "custom_suffix=-configured"
+}
+
+# A value that holds a space must stay one argument.
+test_custom_arg_keeps_a_value_with_a_space() {
+    local args="${STUB_DIR}/custom.args"
+    run_build "$args" \
+        --service mina-rosetta-configured --version 3.1.0 --network devnet \
+        --docker-registry testreg --custom-suffix configured --deb-build-flags none \
+        --custom-arg "--build-arg image_name=mina-rosetta"
+
+    assert_has_line "the option of the custom argument" "$args" "--build-arg"
+    assert_has_line "the value of the custom argument" "$args" "image_name=mina-rosetta"
+    assert_has_line "the rosetta image keeps its own name" "$args" \
+        "testreg/mina-rosetta:3.0.0-test-branch-abcdefg-bullseye-devnet-configured"
+}
+
+test_arm64_gets_a_platform_suffix() {
+    local args="${STUB_DIR}/arm.args"
+    run_build "$args" \
+        --service mina-archive --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none --platform linux/arm64
+
+    assert_has_line "platform" "$args" "linux/arm64"
+    assert_has_line "the tag has the platform suffix" "$args" \
+        "testreg/mina-archive:3.1.0-devnet-arm64"
+}
+
+test_toolchain_joins_the_stage_files() {
+    local args="${STUB_DIR}/toolchain.args"
+    run_build "$args" \
+        --service mina-toolchain --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    # The Dockerfile is a temporary file, so only the start of the path is fixed.
+    assert_matches "a temporary Dockerfile holds the joined stages" "$args" \
+        "^/tmp/Dockerfile-toolchain\."
+    assert_has_line "the toolchain tag has no network" "$args" "testreg/mina-toolchain:3.1.0"
+}
+
+# A service without a build context sends the Dockerfile to docker on stdin.
+test_delegation_verifier_has_no_build_context() {
+    local args="${STUB_DIR}/deleg.args"
+    run_build "$args" \
+        --service mina-delegation-verifier --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_has_line "stdin" "$args" "-"
+    assert_no_line "no context directory" "$args" "dockerfiles/"
+    assert_has_line "tag" "$args" "testreg/mina-delegation-verifier:3.1.0"
+}
+
+# The docker build cannot reach the host on "localhost". The address must become
+# the gateway of the docker bridge network, which the stub reports as
+# 172.17.0.1.
+test_localhost_becomes_the_bridge_gateway() {
+    local args="${STUB_DIR}/repo.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none \
+        --deb-repo "http://localhost:8080"
+
+    assert_has_line "gateway address" "$args" "deb_repo=http://172.17.0.1:8080"
+}
+
+test_cache_options() {
+    local args="${STUB_DIR}/cache.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none \
+        --no-cache --cache-from testreg/cache:x
+
+    assert_has_line "no cache" "$args" "--no-cache"
+    assert_has_line "cache source" "$args" "testreg/cache:x"
+}
+
+test_optional_build_args_are_absent_when_not_given() {
+    local args="${STUB_DIR}/optional.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_no_line "no legacy version" "$args" "deb_legacy_version="
+    assert_no_line "no storage repair version" "$args" "deb_storage_repair_version="
+    assert_no_line "no custom suffix" "$args" "custom_suffix="
+    assert_no_line "no image name" "$args" "image_name="
+}
+
+test_auto_hardfork_needs_a_legacy_version() {
+    local args="${STUB_DIR}/hf.args"
+    run_build "$args" \
+        --service mina-daemon-auto-hardfork --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "the build must stop when --deb-legacy-version is missing"
+    else
+        log_pass
+    fi
+}
+
+test_unknown_service_stops_the_build() {
+    local args="${STUB_DIR}/bad.args"
+    run_build "$args" --service not-a-service --version 3.1.0 --network devnet
+
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "an unknown service must stop the build"
+    else
+        log_pass
+    fi
+}
+
+test_unknown_codename_stops_the_build() {
+    local args="${STUB_DIR}/badcode.args"
+    run_build "$args" --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-codename sid
+
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "an unknown codename must stop the build"
+    else
+        log_pass
+    fi
+}
+
+test_missing_service_or_version_stops_the_build() {
+    local args="${STUB_DIR}/missing.args"
+
+    run_build "$args" --version 3.1.0 --network devnet
+    if [[ "$LAST_EXIT" -eq 0 ]]; then log_fail "no --service must stop the build"; else log_pass; fi
+
+    run_build "$args" --service mina-daemon --network devnet
+    if [[ "$LAST_EXIT" -eq 0 ]]; then log_fail "no --version must stop the build"; else log_pass; fi
+}
+
+################################################################################
+# Known defects
+#
+# These tests hold the behaviour of build.sh as it is today. Each one names a
+# defect. When the defect is repaired, the test fails, and you must change it in
+# the same change-set.
+################################################################################
+
+# DEFECT: build.sh has code that gives --network the default "devnet", but that
+# code cannot run. scripts/export-git-env-vars.sh does "set -euo pipefail" and
+# build.sh sources it, so build.sh runs with "set -u". The test of
+# $INPUT_NETWORK then stops the script before the default is used.
+# Result: "make docker-build-toolchain", which gives no --network, is broken.
+test_DEFECT_network_has_no_working_default() {
+    local args="${STUB_DIR}/nonet.args"
+    run_build "$args" --service mina-daemon --version 3.1.0 --docker-registry testreg
+
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "REPAIRED: --network now has a default. Delete this test."
+    else
+        log_pass
+    fi
+    if grep -q "INPUT_NETWORK: unbound variable" "${args}.log"; then
+        log_pass
+    else
+        log_fail "the reason of the stop changed; read ${args}.log"
+    fi
+}
+
+# DEFECT: when --deb-build-flags is not given, the build flags suffix is a
+# single dash. dockerfiles/stages/install-config puts this value in the name of
+# the base image, so the name gets two dashes and the image is not found. The
+# value must be empty, as it is for "none".
+test_DEFECT_build_flags_suffix_is_a_lone_dash() {
+    local args="${STUB_DIR}/flags.args"
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet --docker-registry testreg
+
+    if grep -qFx -- "build_flags_suffix=-" "$args"; then
+        log_pass
+    else
+        log_fail "REPAIRED: the suffix is no longer a lone dash. Change this test to expect an empty value."
+    fi
+}
+
+# DEFECT: the service check uses a substring match:
+#   echo "${VALID_SERVICES[@]}" | grep -o "$SERVICE"
+# So a partial name passes the check and the build stops later, at the "case"
+# statement, with a message that is less clear. Before August 2026 the Makefile
+# used the name "mina-daemon-config" and this hid the error.
+test_DEFECT_a_partial_service_name_passes_the_check() {
+    local args="${STUB_DIR}/partial.args"
+    run_build "$args" --service mina-daemon-config --version 3.1.0 --network devnet \
+        --docker-registry testreg
+
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "a partial service name must not build"
+    else
+        log_pass
+    fi
+    # The message shows which check stopped the build. "Unsupported service"
+    # comes from the "case" statement, after the check accepted the name.
+    if grep -q "Unsupported service" "${args}.log"; then
+        log_pass
+    else
+        log_fail "REPAIRED: the name check now refuses a partial name. Change this test."
+    fi
+}
+
+# DEFECT: VALID_SERVICES holds two names that the "case" statement in build.sh
+# does not know, so they always stop the build. Delete them.
+test_DEFECT_valid_services_holds_names_that_cannot_build() {
+    local args="${STUB_DIR}/ghost.args"
+    local service
+    for service in mina-daemon-generic mina-rosetta-generic; do
+        if grep -q "'${service}'" "${REPO_ROOT}/scripts/docker/helper.sh"; then
+            log_pass
+        else
+            log_fail "REPAIRED: ${service} is no longer in VALID_SERVICES. Change this test."
+        fi
+        run_build "$args" --service "$service" --version 3.1.0 --network devnet \
+            --docker-registry testreg
+        if [[ "$LAST_EXIT" -eq 0 ]]; then
+            log_fail "${service} builds now; VALID_SERVICES and the case statement agree"
+        else
+            log_pass
+        fi
+    done
+}
+
+# DEFECT: three services point to a Dockerfile that is not in the repository.
+# The applications were deleted (commits fa3c67d67c and ca46cf2fc3), but the
+# branches in build.sh stayed. Delete them.
+test_DEFECT_three_services_point_to_a_dockerfile_that_is_absent() {
+    assert_file_absent "leaderboard" "${REPO_ROOT}/frontend/leaderboard/Dockerfile"
+    assert_file_absent "delegation-backend" \
+        "${REPO_ROOT}/dockerfiles/Dockerfile-delegation-backend"
+    assert_file_absent "delegation-backend-toolchain" \
+        "${REPO_ROOT}/dockerfiles/Dockerfile-delegation-backend-toolchain"
+}
+
+# DEFECT: build.sh maps the service "mina-daemon-auto-hardfork" to
+# dockerfiles/Dockerfile-mina-daemon-auto-hardfork, and that file is not in this
+# branch. Six rendered pipelines call the service, in the MainlineNightly and
+# Release scopes, so the fault appears only in a nightly or a release build.
+# Either add the Dockerfile, or point the service to
+# dockerfiles/Dockerfile-mina-daemon-hardfork, which does exist.
+test_DEFECT_auto_hardfork_dockerfile_is_absent() {
+    assert_file_absent "auto hardfork dockerfile" \
+        "${REPO_ROOT}/dockerfiles/Dockerfile-mina-daemon-auto-hardfork"
+    # The service is still declared, so the fault is reachable.
+    if grep -rq "DaemonAutoHardfork" "${REPO_ROOT}/buildkite/src/Command/MinaArtifact.dhall"; then
+        log_pass
+    else
+        log_fail "REPAIRED: CI no longer builds DaemonAutoHardfork. Change this test."
+    fi
+}
+
+# The services that CI and the Makefile use must point to a Dockerfile that
+# exists. This test finds a Dockerfile that a rename or a deletion has lost.
+test_live_services_have_a_dockerfile() {
+    local f
+    for f in \
+        dockerfiles/Dockerfile-mina-archive \
+        dockerfiles/Dockerfile-mina-daemon \
+        dockerfiles/Dockerfile-mina-rosetta \
+        dockerfiles/Dockerfile-txn-burst \
+        dockerfiles/Dockerfile-zkapp-test-transaction \
+        dockerfiles/Dockerfile-mina-test-suite \
+        dockerfiles/Dockerfile-delegation-stateless-verifier \
+        dockerfiles/stages/install-config \
+        dockerfiles/stages/1-build-deps \
+        dockerfiles/stages/2-opam-deps \
+        dockerfiles/stages/3-toolchain
+    do
+        assert_file_exists "$f" "${REPO_ROOT}/${f}"
+    done
+}
+
+################################################################################
+# Main
+################################################################################
+
+main() {
+    setup_stub_docker
+
+    # Behaviour
+    run_test test_daemon_command
+    run_test test_load_only_does_not_push
+    run_test test_archive_mainnet_noble
+    run_test test_generic_suffix_reaches_tag_and_build_arg
+    run_test test_suffix_order_is_generic_lightnet_instrumented
+    run_test test_configured_service_uses_docker_tag_for_the_output
+    run_test test_custom_arg_keeps_a_value_with_a_space
+    run_test test_arm64_gets_a_platform_suffix
+    run_test test_toolchain_joins_the_stage_files
+    run_test test_delegation_verifier_has_no_build_context
+    run_test test_localhost_becomes_the_bridge_gateway
+    run_test test_cache_options
+    run_test test_optional_build_args_are_absent_when_not_given
+    run_test test_auto_hardfork_needs_a_legacy_version
+    run_test test_unknown_service_stops_the_build
+    run_test test_unknown_codename_stops_the_build
+    run_test test_missing_service_or_version_stops_the_build
+    run_test test_live_services_have_a_dockerfile
+
+    # Known defects
+    run_test test_DEFECT_network_has_no_working_default
+    run_test test_DEFECT_build_flags_suffix_is_a_lone_dash
+    run_test test_DEFECT_a_partial_service_name_passes_the_check
+    run_test test_DEFECT_valid_services_holds_names_that_cannot_build
+    run_test test_DEFECT_three_services_point_to_a_dockerfile_that_is_absent
+    run_test test_DEFECT_auto_hardfork_dockerfile_is_absent
+
+    teardown_stub_docker
+
+    echo ""
+    echo "========================================"
+    echo "Results: ${TESTS_RUN} tests, ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+    echo "========================================"
+
+    if [[ ${#FAILURES[@]} -gt 0 ]]; then
+        echo ""
+        echo "Failures:"
+        for f in "${FAILURES[@]}"; do
+            echo "  - ${f}"
+        done
+    fi
+
+    echo ""
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then
+        exit 1
+    else
+        echo "All tests passed."
+        exit 0
+    fi
+}
+
+main "$@"

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -308,29 +308,45 @@ test_toolchain_joins_the_stage_files() {
     assert_has_line "the toolchain tag has no network" "$args" "testreg/mina-toolchain:3.1.0"
 }
 
-# A service without a build context sends the Dockerfile to docker on stdin.
-test_delegation_verifier_has_no_build_context() {
+# Every service has a build context now: each image installs its packages from
+# files in that context.
+test_delegation_verifier_has_a_build_context() {
     local args="${STUB_DIR}/deleg.args"
     run_build "$args" \
         --service mina-delegation-verifier --version 3.1.0 --network devnet \
         --docker-registry testreg --deb-build-flags none
 
-    assert_has_line "stdin" "$args" "-"
-    assert_no_line "no context directory" "$args" "dockerfiles/"
+    assert_has_line "context" "$args" "dockerfiles/"
+    assert_has_line "dockerfile" "$args" \
+        "dockerfiles/Dockerfile-delegation-stateless-verifier"
+    assert_no_line "the Dockerfile does not come on stdin" "$args" "-"
     assert_has_line "tag" "$args" "testreg/mina-delegation-verifier:3.1.0"
 }
 
-# The docker build cannot reach the host on "localhost". The address must become
-# the gateway of the docker bridge network, which the stub reports as
-# 172.17.0.1.
-test_localhost_becomes_the_bridge_gateway() {
+# The images install their packages from files in the build context, so no
+# Debian repository reaches the build, and --deb-repo is not an option any more.
+test_no_debian_repository_reaches_the_build() {
     local args="${STUB_DIR}/repo.args"
     run_build "$args" \
         --service mina-daemon --version 3.1.0 --network devnet \
-        --docker-registry testreg --deb-build-flags none \
-        --deb-repo "http://localhost:8080"
+        --docker-registry testreg --deb-build-flags none
 
-    assert_has_line "gateway address" "$args" "deb_repo=http://172.17.0.1:8080"
+    if grep -q "^deb_repo=" "$args"; then
+        log_fail "the build still gets a deb_repo build argument"
+    else
+        log_pass
+    fi
+
+    # An old caller that still gives --deb-repo must stop, not build with a
+    # repository that the image ignores.
+    run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-repo http://localhost:8080
+    if [[ "$LAST_EXIT" -eq 0 ]]; then
+        log_fail "--deb-repo must not be accepted"
+    else
+        log_pass
+    fi
 }
 
 test_cache_options() {
@@ -542,8 +558,8 @@ main() {
     run_test test_custom_arg_keeps_a_value_with_a_space
     run_test test_arm64_gets_a_platform_suffix
     run_test test_toolchain_joins_the_stage_files
-    run_test test_delegation_verifier_has_no_build_context
-    run_test test_localhost_becomes_the_bridge_gateway
+    run_test test_delegation_verifier_has_a_build_context
+    run_test test_no_debian_repository_reaches_the_build
     run_test test_cache_options
     run_test test_optional_build_args_are_absent_when_not_given
     run_test test_auto_hardfork_needs_a_legacy_version

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -503,23 +503,6 @@ test_DEFECT_three_services_point_to_a_dockerfile_that_is_absent() {
         "${REPO_ROOT}/dockerfiles/Dockerfile-delegation-backend-toolchain"
 }
 
-# DEFECT: build.sh maps the service "mina-daemon-auto-hardfork" to
-# dockerfiles/Dockerfile-mina-daemon-auto-hardfork, and that file is not in this
-# branch. Six rendered pipelines call the service, in the MainlineNightly and
-# Release scopes, so the fault appears only in a nightly or a release build.
-# Either add the Dockerfile, or point the service to
-# dockerfiles/Dockerfile-mina-daemon-hardfork, which does exist.
-test_DEFECT_auto_hardfork_dockerfile_is_absent() {
-    assert_file_absent "auto hardfork dockerfile" \
-        "${REPO_ROOT}/dockerfiles/Dockerfile-mina-daemon-auto-hardfork"
-    # The service is still declared, so the fault is reachable.
-    if grep -rq "DaemonAutoHardfork" "${REPO_ROOT}/buildkite/src/Command/MinaArtifact.dhall"; then
-        log_pass
-    else
-        log_fail "REPAIRED: CI no longer builds DaemonAutoHardfork. Change this test."
-    fi
-}
-
 # The services that CI and the Makefile use must point to a Dockerfile that
 # exists. This test finds a Dockerfile that a rename or a deletion has lost.
 test_live_services_have_a_dockerfile() {
@@ -528,6 +511,7 @@ test_live_services_have_a_dockerfile() {
         dockerfiles/Dockerfile-mina-archive \
         dockerfiles/Dockerfile-mina-daemon \
         dockerfiles/Dockerfile-mina-rosetta \
+        dockerfiles/Dockerfile-mina-daemon-hardfork \
         dockerfiles/Dockerfile-txn-burst \
         dockerfiles/Dockerfile-zkapp-test-transaction \
         dockerfiles/Dockerfile-mina-test-suite \
@@ -574,7 +558,6 @@ main() {
     run_test test_DEFECT_a_partial_service_name_passes_the_check
     run_test test_DEFECT_valid_services_holds_names_that_cannot_build
     run_test test_DEFECT_three_services_point_to_a_dockerfile_that_is_absent
-    run_test test_DEFECT_auto_hardfork_dockerfile_is_absent
 
     teardown_stub_docker
 


### PR DESCRIPTION
> **Stacked on #19186** (the test suite). Review that one first; the base of
> this branch is `dkijania/docker-script-tests`. It also touches the Makefile,
> so it conflicts lightly with #19185.
>
> **This must run in CI before it merges.** See "What CI must prove" below.

Every Docker image installed its Mina packages over apt from a Debian
repository that the build machine started for itself: `start_local_repo.sh`
starts an `aptly` daemon on `localhost:8080`, the build writes
`deb [trusted=yes] http://<gateway>:8080 ...` into the image, installs, and
`aptly.sh stop` stops the daemon. This PR removes that. Each image now installs
the same package files directly from the build context.

### Why this is safe

`start_local_repo.sh` fills aptly by calling `read_all_from_cache.sh`, which is
the **same script** the `DownloadOnly` mode already calls. Both modes therefore
deliver an identical set of package files, from the same two CI cache paths.
Only the delivery into the image changes: an apt repository on the host becomes
a file in the build context. Two of the thirteen Docker specs
(`DaemonConfig`, `RosettaConfig`) already worked this way.

No Docker spec installs from a remote repository: all 13 use
`DebianRepo.Type.Local`. So the apt-source path in the Dockerfiles was dead
weight for every image, and this PR deletes it.

### How the install works now

```dockerfile
# hadolint ignore=SC2046
RUN --mount=type=bind,source=.,target=/debs \
  apt-get update --quiet --yes \
  && apt-get install --no-install-recommends --quiet --yes --allow-downgrades \
  $(/usr/local/bin/deb-files.sh /debs \
  "${MINA_DEB}=${deb_version}" \
  "mina-logproc=${deb_version}" \
  "?mina-${network}-config=${deb_version}" \
  ...) \
  && rm -rf /var/lib/apt/lists/*
```

`--mount=type=bind` is used, not `COPY`, so **no package file becomes an image
layer**. A `COPY` of the daemon package would add about 250 MB to every image.

The new `dockerfiles/scripts/deb-files.sh` changes `name=version` into a path.
It is the only place that knows how a package file is named
(`<name>_<version>_<arch>.deb`), so no Dockerfile has to guess the
architecture. A specification that starts with `?` is optional: the script skips
it and says so. This covers the packages that only some builds produce, such as
the prefork genesis ledger and the storage repair toolbox.

Two package names are new in the lists, because apt can no longer find them by
itself: `mina-logproc` and `mina-<network>-config`. Both are real dependencies —
`DAEMON_DEPS` in `builder-helpers.sh` ends with `mina-logproc`, and the network
daemon declares `mina-<network>-config (= <version>)`.

### What changed

| Area | Change |
|---|---|
| 8 Dockerfiles | apt source line → install from `/debs` |
| `dockerfiles/scripts/deb-files.sh` | new, 91 lines |
| `DockerImage.dhall` | `DebianInstallMode` loses `ThroughLocalRepo`; default is `DownloadOnly`; the aptly start and stop commands are gone; `--deb-repo` is no longer passed |
| `scripts/docker/build.sh` | `--deb-repo` removed; the `localhost` → bridge-gateway change now applies only to the APT cache proxy; the delegation verifier gets a build context, because it needs one for the mount |
| `Makefile` | `start-local-debian-repo` → `stage-debians-for-docker`, which copies `_build/*.deb` into `dockerfiles/`; teardown removes them; the two redundant `cp _build/mina-devnet-config_*.deb .` lines are gone |
| `.gitignore` | `dockerfiles/*.deb` |

`--network=host` **stays**. It is not part of the local repository: the CI apt
cache proxy is reached by a cluster DNS name that only resolves in the host
network namespace. Removing it is a separate question.

### Verification done locally

- **The install mechanism was proved with real packages.** Four synthetic
  `.deb` files (including `mina-devnet` with a real
  `mina-devnet-config (= <version>)` dependency) were built with `dpkg-deb` and
  installed by a Docker build that uses the new block. All four were installed
  from the context, the exact-version dependency resolved from the file, the two
  absent optional packages were skipped, and `test ! -e /debs` confirmed that
  nothing was left in the image.
- A first probe with a real 254 MB Mina package confirmed that
  `RUN --mount=type=bind` needs no `# syntax=` directive with our buildx
  (v0.23.0) and adds no layer: the image stayed at 53 MB.
- `make all` in `buildkite/`: 42 tests pass. The rendered pipelines hold no
  `start_local_repo.sh`, no `aptly.sh stop` and no `--deb-repo`.
- `scripts/docker/tests/test_build.sh`: 23 tests, 77 assertions, all pass.
- `hadolint`: no new finding. The 12 `DL3066` notes are on `compatible` too.
- `shellcheck` on `build.sh`: 45 findings before, 41 after.
- `make -n` for the local Docker targets shows the staging step, the build and
  the cleanup.

### What CI must prove

Nothing above uses a real Mina package set out of the CI cache. CI must show:

1. `read_all_from_cache.sh` puts **all** needed packages into `dockerfiles/`,
   for each codename and architecture. If one is absent, `deb-files.sh` stops
   the build and lists what the directory holds.
2. The daemon image resolves `mina-logproc` and `mina-<network>-config` from
   files, for the generic variant as well (the generic daemon has no config
   dependency; the config package is optional in the list for that reason).
3. The arm64 build works: the architecture in the file name is matched with a
   pattern, not fixed.
4. The auto-hardfork image finds `mina-<network>-prefork-mesa` at
   `deb_legacy_version`, which comes from the `legacy/debians` cache path.
