### PR TITLE
ci: run local integration tests from the apps cache, not the test-executive deb

### DIFF
--- a/buildkite/scripts/run-test-executive-local.sh
+++ b/buildkite/scripts/run-test-executive-local.sh
@@ -74,9 +74,11 @@ DISK_PRUNE_THRESHOLD=0 ./buildkite/scripts/docker/disk-cleanup.sh
 ./buildkite/scripts/docker/load_from_cache.sh "$ARCHIVE_IMAGE" \
   || echo "cache miss for $ARCHIVE_IMAGE"
 
-source buildkite/scripts/debian/update.sh --verbose
-
-source buildkite/scripts/debian/install.sh "mina-test-executive"
+# Restore mina-test-executive and mina-logproc bare from the apps cache. Their
+# .deb comes from the packaging job, which the nightly no longer runs; the agent
+# image already carries the runtime libraries the .deb pulled in.
+./buildkite/scripts/apps/restore_app.sh test_executive.exe mina-test-executive
+./buildkite/scripts/apps/restore_app.sh logproc.exe mina-logproc
 
 # Continuously snapshot each swarm service's container logs while the test runs,
 # so the seed daemon's own output survives test_executive's teardown and can be

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -26,6 +26,7 @@ in  Pipeline.build
           , S.exactly "buildkite/src/Constants/IntegrationImages" "dhall"
           , S.strictlyStart
               (S.contains "buildkite/scripts/run-test-executive-local")
+          , S.strictlyStart (S.contains "buildkite/scripts/apps")
           ]
         , path = "Test"
         , name = "TestnetIntegrationTests"

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTestsLong.dhall
@@ -24,6 +24,9 @@ in  Pipeline.build
               (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
           , S.strictlyStart (S.contains "buildkite/src/Command/TestExecutive")
           , S.exactly "buildkite/src/Constants/IntegrationImages" "dhall"
+          , S.strictlyStart
+              (S.contains "buildkite/scripts/run-test-executive-local")
+          , S.strictlyStart (S.contains "buildkite/scripts/apps")
           ]
         , path = "Test"
         , name = "TestnetIntegrationTestsLong"


### PR DESCRIPTION
Fixes the 14 `* integration test local` jobs that fail in every `develop` nightly since build 1577.

### What happens

```
cp: cannot stat '/var/storagebox/<root>/debians/bullseye/mina-test-executive_4.0.0-rc1-develop-6359e26_*':
    No such file or directory
!! There are some errors while copying files to cache. Exiting...
```
Exit status 2, in `fetch_debs`, before the test starts. Every local integration test fails the same way (`block-prod-prio` only "passes" because the script skips it).

### Why

`run-test-executive-local.sh` installs the `mina-test-executive` .deb, which the packaging job `MinaArtifactBullseye` writes to the CI cache. Commit 2ee630be3e ("Move packaging jobs out of the long test stage") retagged every `MinaArtifact*` packaging pipeline from `PipelineTag.Type.Long` to `PipelineTag.Type.Packaging`. The nightly runs two tag stages, `FastOnly` (`Fast`) and `LongAndVeryLong` (`Long`, `VeryLong`), and has no `Packaging` stage, so the packaging job never runs. Confirmed on the cache root of build 1579: `apps/bullseye/` holds all 38 binaries, `debians/` holds only `noble/minimina_*.deb`.

`IntegrationTestDockerImages`, the job these tests already depend on, was moved bottom-to-top onto the apps cache earlier for the same reason. The `.deb` install in `run-test-executive-local.sh` is the last link from the local integration tests to the packaging job.

### Change

`test_executive.exe` and `logproc.exe` are restored bare from the apps cache with the existing `buildkite/scripts/apps/restore_app.sh`, installed on PATH as `mina-test-executive` and `mina-logproc` — the same names the .debs provide, so the rest of the script is unchanged. `dirtyWhen` of both integration-test jobs now covers `buildkite/scripts/apps`, and the Long job also gets the `run-test-executive-local` entry it was missing.

No new `depends_on` is needed: the tests depend on the `IntegrationTestDockerImages` steps, and those depend on `MinaArtifactBullseyeApps/build-apps`, so the apps cache is always populated when a test runs.

### Runtime libraries

A bare binary carries no dpkg dependencies, but nothing needs to be installed: the agent image already provides every library.

The integration agents run `buildkite-generic-agent:pr-77-acc2adc` — gitops-infrastructure `platform/hetzner-rivendell-1/applications/buildkite-agents/values.yaml.gotmpl`; `integration-values.yaml.gotmpl` overrides placement and resources but not `agent.image`. That image (gitops-images `buildkite-generic-agent/Dockerfile`) is `buildkite/agent:3.104.0-ubuntu-20.04`, installs `libjemalloc-dev` and `tzdata`, and then installs the released `mina-devnet` from `packages.o1test.net focal stable`. The newest `mina-devnet` there (3.2.0-97ad487) declares:

```
Depends: libssl1.1, libgmp10, libgomp1, tzdata, rocksdb-tools, liblmdb0,
         libffi7, libjemalloc2, libpq-dev, libprocps8, mina-logproc
```

Checked against the binary rather than inferred: running the build-1579 `apps/bullseye/test_executive.exe` inside that image gives

```
OS: Ubuntu 20.04.6 LTS
--- missing libraries:
(none)
        libjemalloc.so.2  => /lib/x86_64-linux-gnu/libjemalloc.so.2
        libstdc++.so.6    => /lib/x86_64-linux-gnu/libstdc++.so.6
        libpq.so.5        => /lib/x86_64-linux-gnu/libpq.so.5
        libssl.so.1.1     => /lib/x86_64-linux-gnu/libssl.so.1.1
        libcrypto.so.1.1  => /lib/x86_64-linux-gnu/libcrypto.so.1.1
        libffi.so.7       => /lib/x86_64-linux-gnu/libffi.so.7
        libgmp.so.10      => /lib/x86_64-linux-gnu/libgmp.so.10
--- can it run?
       test_executive - Run mina integration test(s).
```

The image also already ships a released `mina-logproc` at `/usr/local/bin/mina-logproc`, which `restore_app.sh` replaces with this build's binary, exactly as the .deb install did. The `apt-get update` that preceded the .deb install is dropped with it.

### Verification

`cd buildkite && make all` — 45/45 monorepo tests pass, Dhall syntax/lint/format/dirtyWhen/duplicates/job-names clean. `shellcheck` reports no new findings on the changed script.
