### PR TITLE
ci: allow core dumps in the unit-test job

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -18,6 +18,21 @@ export MINA_LIBP2P_PASS="naughty blue worm"
 export NO_JS_BUILD=1 # skip some JS targets which have extra implicit dependencies
 export LAGRANGE_CACHE_DIR="/tmp/lagrange-cache"
 
+# Allow core dumps.
+#
+# Both failure paths below already call scripts/link-coredumps.sh, which
+# collects core.<pid>.* into core_dumps/ for the artifact upload, but nothing
+# ever raised the core-file limit, so the tests ran with the container default
+# of 0 and no core file was ever written.
+#
+# A test that dies in C code produces no OCaml output at all. In nightly build
+# 1579 the src/lib/lmdb_storage test printed the name of its second case and
+# then vanished, on the first run and again on the retry; core_dumps/ was
+# empty, so there was nothing left to diagnose. Raising the limit costs nothing
+# on a passing run.
+ulimit -c unlimited 2>/dev/null || echo "could not raise the core file limit"
+echo "core file limit: $(ulimit -c), core_pattern: $(cat /proc/sys/kernel/core_pattern 2>/dev/null || echo unknown)"
+
 echo "--- Make libp2p helper"
 export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
 time make libp2p_helper


### PR DESCRIPTION
Makes the silent `dev unit-tests` crash of nightly build 1579 diagnosable. It does not fix that crash — see "What is still unknown".

### What happens

In build 1579 `dune` reported the `src/lib/lmdb_storage` test as failed and printed its captured output:

```
File "src/lib/lmdb_storage/test/dune", line 2, characters 8-25:
2 |  (names test_lmdb_storage)
             ^^^^^^^^^^^^^^^^^
Testing LMDB Storage.
This run has ID `12BB1EAC-F8DA-4570-B6F4-4A75BC9F7576`.
 ...   Basic Operations   0   MMAP resize.[OK]   Basic Operations   0   MMAP resize.
 ...   Basic Operations   1   Iterations with removal and reopening.
```

The output stops there. No exception, no Alcotest failure line, no backtrace — the test binary disappeared. It behaved the same way on the retry. In build 1577 the same suite reported `Test Successful in 20.000s. 5 tests run.`

A death with no output means the process took a signal in C code. The only artefact that could tell us where is a core dump, and the job uploaded none:

```
$ buildkite-agent artifact upload core_dumps/*
No files matched paths: core_dumps/*
```

### Why there was no core dump

`unit-test.sh` calls `scripts/link-coredumps.sh` on both failure paths, which collects `core.<pid>.*` into `core_dumps/` for the artifact upload. But the script never raised the core-file limit, so the tests ran with the container default of 0 and the kernel wrote no core file. The collector had nothing to collect.

### Change

Raise the core-file limit before the tests run, and log the resulting limit and `/proc/sys/kernel/core_pattern` so a future empty `core_dumps/` can be told apart from "the limit is still 0" and from "the pattern pipes the core to a handler outside the container". A passing run is unaffected.

### What is still unknown

The crash itself. It is not a code regression: between builds 1577 (this suite passed) and 1579 (it died) only `Makefile` changed. It does not reproduce locally — 144 runs of `test_lmdb_storage.exe`, 12 at a time to imitate the 32-way parallel `dune runtest`, all passed, as did runs with a forced major GC between the cases.

One hypothesis is worth recording. `Lmdb.Map.create` installs `Gc.finalise (fun {env; dbi; _} -> Mdb.dbi_close env dbi)`, while `Lmdb_storage.Generic.close` calls `Lmdb.Env.close`, which frees the `MDB_env`. `Lmdb_storage.Generic.t` does not hold the map handles, so it cannot disarm those finalisers. A map value collected after its environment was closed therefore calls `mdb_dbi_close` on freed memory. `test_mmap_resize` closes its environment and drops the handle just before the case that died, which fits the timing, and use-after-free on a freed-but-not-reused block usually does nothing — which fits how rare this is. It stays a hypothesis until a core dump confirms or refutes it, which is what this change is for.
