### PR TITLE
ci: write cache entries atomically and fail the app build on a failed write

### DIFF
--- a/buildkite/scripts/apps/write_to_cache.sh
+++ b/buildkite/scripts/apps/write_to_cache.sh
@@ -30,14 +30,31 @@ fi
 
 DEST="apps/${CODENAME}${VARIANT:+/${VARIANT}}"
 
-find _build -type f -name "*.exe" | while read -r entry; do
+# A failed write must fail the job. It used to be ignored: the loop below ran
+# the cache manager without checking its status, so a manager exiting 2 only
+# printed "There are some errors while copying files to cache" and the loop
+# carried on. The job went green having published an incomplete apps cache, and
+# the missing binary surfaced hours later in restore_build_tree.sh on a
+# different agent. Collect the failures and report them all at the end, so one
+# run names every entry that did not make it rather than only the first.
+failed=()
+
+cache_write() {
+  if ! ./buildkite/scripts/cache/manager.sh write-to-dir "$1" "$DEST"; then
+    failed+=("$1")
+  fi
+}
+
+# Fed by process substitution, not a pipe: a pipe would run the loop in a
+# subshell and the failures recorded in it would be lost.
+while read -r entry; do
   # Exclude files ending with ppx.exe
   if [[ "$entry" == *ppx.exe ]]; then
     continue
   fi
 
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$entry" "$DEST"
-done
+  cache_write "$entry"
+done < <(find _build -type f -name "*.exe")
 
 # libp2p_helper is a Go binary (built under src/app/libp2p_helper/result/bin,
 # not a dune _build/*.exe), but the daemon needs it at runtime. Cache it
@@ -45,7 +62,7 @@ done
 # mirroring what the .deb installs.
 HELPER="src/app/libp2p_helper/result/bin/libp2p_helper"
 if [[ -f "$HELPER" ]]; then
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$HELPER" "$DEST"
+  cache_write "$HELPER"
 fi
 
 # minimina is a Rust binary (built under src/app/minimina/target/release, not a
@@ -53,5 +70,11 @@ fi
 # restore it into the build tree without a separate copy of the binaries.
 MINIMINA="src/app/minimina/target/release/minimina"
 if [[ -f "$MINIMINA" ]]; then
-  ./buildkite/scripts/cache/manager.sh write-to-dir "$MINIMINA" "$DEST"
+  cache_write "$MINIMINA"
+fi
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+  echo "write_to_cache: ${#failed[@]} file(s) could not be written to ${DEST}:" >&2
+  printf '  %s\n' "${failed[@]}" >&2
+  exit 1
 fi

--- a/buildkite/scripts/cache/manager.sh
+++ b/buildkite/scripts/cache/manager.sh
@@ -40,6 +40,48 @@ CACHE_BASE_URL="${CACHE_BASE_URL:-/var/storagebox}"
 # functions
 ################################################################################
 
+# Copy files into a cache directory without ever leaving an entry missing.
+#
+# `cp -f` is not atomic: when the destination already exists it unlinks the file
+# and creates it again. Two jobs writing the same cache entry at the same time
+# therefore race -- which is not hypothetical, apps/<codename> is written by the
+# devnet AND the mainnet app build, both producing the same basenames. The loser
+# of the race reports
+#   cp: cannot create regular file '<dest>': File exists
+# once the entry has already been unlinked, so the cache is left with a hole
+# that only surfaces much later, in a consumer such as restore_build_tree.sh.
+#
+# Copying to a unique temporary name in the destination directory and renaming
+# it into place avoids that: rename(2) inside one directory is atomic, so the
+# entry stays readable throughout and the last writer simply wins.
+function copy_into_dir(){
+    local __dest_dir="$1"; shift
+    local __flags="$1"; shift
+    local rc=0
+    local src base tmp
+
+    for src in "$@"; do
+        if [[ -d "$src" ]]; then
+            # A directory keeps the plain recursive copy: there is no atomic
+            # rename that merges a tree into an existing one.
+            # shellcheck disable=SC2086
+            cp -R ${__flags} "$src" "$__dest_dir" || rc=1
+            continue
+        fi
+
+        base="$(basename "$src")"
+        tmp="${__dest_dir}/.tmp.$$.${base}"
+        # shellcheck disable=SC2086
+        if cp -R ${__flags} "$src" "$tmp" && mv -f "$tmp" "${__dest_dir}/${base}"; then
+            continue
+        fi
+        rm -f "$tmp"
+        rc=1
+    done
+
+    return $rc
+}
+
 # Display the main help message
 function main_help(){
     echo Read/Write file or files from/to CI cache.
@@ -212,6 +254,7 @@ function write(){
     local __root="$BUILDKITE_BUILD_ID"
     local __input=""
     local __to=""
+    local __tmp=""
 
     while [ "$#" -gt 0 ]; do
         error_message="Error: a value is needed for '$1'";
@@ -256,7 +299,12 @@ function write(){
     mkdir -p "$(dirname "$__to")"
 
     echo "..Copying $__input -> $__to"
-    if ! cp -R ${EXTRA_FLAGS} "$__input" "$__to"; then
+    # Written through a temporary name and renamed, for the same reason as
+    # write-to-dir: see copy_into_dir.
+    __tmp="$(dirname "$__to")/.tmp.$$.$(basename "$__to")"
+    # shellcheck disable=SC2086
+    if ! { cp -R ${EXTRA_FLAGS} "$__input" "$__tmp" && mv -f "$__tmp" "$__to"; }; then
+        rm -f "$__tmp"
         echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
         exit 2
     fi
@@ -347,7 +395,8 @@ function write-to-dir(){
 
     for input_path in "${__inputs[@]}"; do
         echo "..Copying $input_path -> $__to"
-        if ! cp -R ${EXTRA_FLAGS} $input_path "$__to"; then
+        # shellcheck disable=SC2086
+        if ! copy_into_dir "$__to" "$EXTRA_FLAGS" $input_path; then
             echo -e "${RED} !! There are some errors while copying files to cache. Exiting... ${CLEAR}\n";
             exit 2
         fi

--- a/buildkite/scripts/cache/tests/cache-parity-test.sh
+++ b/buildkite/scripts/cache/tests/cache-parity-test.sh
@@ -105,4 +105,51 @@ cache_verb read "hardfork/ledgers/ledger_*.tar.gz" "$OUT2"
 assert_file_equals "$OUT2/ledger_a.tar.gz" "ledger-a"
 assert_file_equals "$OUT2/ledger_b.tar.gz" "ledger-b"
 
+# ------------------------------------------------------------------------------
+# write-to-dir: rewriting an entry must never make it unreadable
+# ------------------------------------------------------------------------------
+# apps/<codename> is written by the devnet AND the mainnet app build, so the
+# same entry is rewritten while other jobs read it. A copy straight onto the
+# destination truncates it first, and on the shared storage box two writers
+# racing that way have left an entry deleted and never recreated
+# ("cp: cannot create regular file '<dest>': File exists"), which surfaced much
+# later as a missing binary in restore_build_tree.sh.
+#
+# Sample the entry from a reader while a writer rewrites it: it must always be
+# the complete old or the complete new file, never short and never absent.
+#
+# Bash engine only for now. The assertion holds for any implementation that
+# renames into place, but buildkite-cache-manager ships in the release-toolkit
+# image from another repository and has not been checked, so gating it here
+# would fail a build for something this repository cannot fix.
+if [[ "$CACHE_ENGINE" == "bash" ]]; then
+  log "write-to-dir (concurrent rewrite stays readable)"
+
+  BIG="$SRC/big.bin"
+  dd if=/dev/urandom of="$BIG" bs=1M count=64 status=none
+  BIG_SIZE="$(stat -c%s "$BIG")"
+
+  cache_verb write-to-dir "$BIG" apps/
+  DEST_BIG="$CACHE_BASE_URL/$BUILDKITE_BUILD_ID/apps/big.bin"
+
+  ( for _ in 1 2 3; do cache_verb write-to-dir "$BIG" apps/ >/dev/null; done ) &
+  WRITER=$!
+
+  torn=0
+  while kill -0 "$WRITER" 2>/dev/null; do
+    if [[ ! -e "$DEST_BIG" ]] \
+      || [[ "$(stat -c%s "$DEST_BIG" 2>/dev/null || echo 0)" -ne "$BIG_SIZE" ]]; then
+      torn=$((torn + 1))
+    fi
+  done
+  wait "$WRITER"
+
+  [[ "$torn" -eq 0 ]] \
+    || fail "cache entry was absent or short in $torn samples while being rewritten"
+
+  # The temporary the writer renames from must not be left behind.
+  leftovers="$(find "$CACHE_BASE_URL/$BUILDKITE_BUILD_ID/apps" -name '.tmp.*' | wc -l)"
+  [[ "$leftovers" -eq 0 ]] || fail "$leftovers temporary file(s) left in the cache"
+fi
+
 log "All cache operations executed and verified successfully"


### PR DESCRIPTION
Fixes the `develop` nightly 1581 failure where the apps cache came out one binary short and every consumer of the build tree died hours later.

### What happened

```
cp: cannot stat '/var/storagebox/019fe8f8-.../apps/bullseye/gen_values.exe': No such file or directory
restore_build_tree: gen_values.exe not found in apps/bullseye
```

Both `IntegrationTestDockerImages` steps failed on that, taking 15 `* integration test local` jobs with them, plus `Debian upgrade test (bullseye)`, `Debian automode transition test (bullseye, devnet)` and `Auto Hardfork: Dispatcher Tests`.

The cache directory really was missing exactly one entry. Diffing it against the previous nightly:

```
$ comm -23 apps_1579.txt apps_1581.txt
gen_values.exe
$ comm -13 apps_1579.txt apps_1581.txt        # nothing else differs
```

The manifest, written by the same job, still listed all 38 binaries.

### Why

`apps/<codename>` is written by **two** jobs. `MinaArtifactBullseyeApps` and `MinaArtifactMainnetBullseyeApps` both run `write_to_cache.sh bullseye ""` and produce the same 38 basenames — deliberately, since the binaries are network-agnostic (see the header of `write_to_cache.sh`). In build 1581 they overlapped, and the cache manager copies straight onto the destination with `cp -R -f`, which is not atomic: for an existing file it unlinks and recreates. The two writers raced on that one path:

```
devnet  t=788737  ..Copying .../gen_values/gen_values.exe -> .../apps/bullseye
mainnet t=791267  ..Copying .../gen_values/gen_values.exe -> .../apps/bullseye
mainnet t=791365  cp: cannot create regular file '.../apps/bullseye/gen_values.exe': File exists
```

and the entry was left deleted.

Two independent defects made that possible:

1. **The write is not atomic.** Copying onto the destination truncates it, so an entry is unreadable while it is being rewritten, and two writers can lose it entirely.
2. **A failed write is silent.** `write_to_cache.sh` ran the cache manager inside a `find | while read` loop without checking its status. The manager exited 2 and printed "There are some errors while copying files to cache. Exiting…", and the loop simply moved on to the next file (`t=791374`, `run_snark_worker.exe`). The job went green and published a 38-entry manifest describing a 37-entry cache.

### Change

- `cache/manager.sh` — `write` and `write-to-dir` copy to a unique temporary name **in the destination directory** and `mv -f` it into place. `rename(2)` within one directory is atomic, so a reader always sees the complete old or the complete new entry and concurrent writers simply let the last one win. Directories keep the plain recursive copy (no atomic rename merges a tree) and the temporary is removed if the copy fails.
- `apps/write_to_cache.sh` — collects failed writes and exits 1 naming each one, instead of ignoring them. It still attempts every file, so one run reports everything that did not make it.
- `cache/tests/cache-parity-test.sh` — regression test: sample an entry from a reader while a writer rewrites it; it must never be short or absent, and no `.tmp.*` may be left behind.

### Verification

The new test is a real gate — against the current `manager.sh` it fails, against the fixed one it passes:

```
before:  [cache-parity][bash][ERROR] cache entry was absent or short in 111 samples while being rewritten   (rc=1)
after:   [cache-parity][bash] All cache operations executed and verified successfully                       (rc=0)
```

Measured directly with a 200 MB entry and a sampling reader, before and after:

```
BEFORE (origin/develop)  reader samples: complete=691  short=764  absent=0
AFTER  (atomic rename)   reader samples: complete=1363 short=0    absent=0
```

Failure propagation, with a stub manager that fails one file: the old script exits 0, the new one exits 1 and names `_build/default/src/app/b/bad.exe`. `shellcheck` reports no findings in any of the three changed files (and the change removes one pre-existing SC2086).

The test is gated to the bash engine. The assertion holds for any implementation that renames into place, but `buildkite-cache-manager` ships in the release-toolkit image from another repository and has not been checked; gating it here would fail builds for something this repository cannot fix. Worth raising there separately.
