### PR TITLE
add artifact dependency closure

### DIFF
--- a/buildkite/src/Constants/Artifact/Artifacts.dhall
+++ b/buildkite/src/Constants/Artifact/Artifacts.dhall
@@ -279,9 +279,123 @@ let networks =
                 )
                 ([] : List Network.Type)
 
+let ordinal =
+          \(artifact : Artifact)
+      ->  merge
+            { Daemon = \(a : { network : Network.Type }) -> 0
+            , DaemonGeneric = 1
+            , DaemonProfiled = \(a : { profile : Profiles.Type }) -> 2
+            , DaemonLegacyHardfork = \(a : { network : Network.Type }) -> 3
+            , DaemonAutoHardfork = \(a : { network : Network.Type }) -> 4
+            , DaemonPrefork = \(a : { network : Network.Type }) -> 5
+            , DaemonPostfork = \(a : { network : Network.Type }) -> 6
+            , CreatePreforkGenesis = \(a : { network : Network.Type }) -> 7
+            , DaemonStorageToolbox = 8
+            , LogProc = 9
+            , ArchiveGeneric = 10
+            , Archive = \(a : { network : Network.Type }) -> 11
+            , RosettaGeneric = 12
+            , Rosetta = \(a : { network : Network.Type }) -> 13
+            , TestExecutive = 14
+            , TxTools = 15
+            , FunctionalTestSuite = 16
+            , DelegationVerifier = 17
+            , Toolchain = 18
+            }
+            artifact
+
+let requires =
+          \(artifact : Artifact)
+      ->  let daemonBase =
+                [ Artifact.DaemonGeneric
+                , Artifact.LogProc
+                , Artifact.DaemonStorageToolbox
+                ]
+
+          let none = [] : List Artifact
+
+          in  merge
+                { Daemon = \(a : { network : Network.Type }) -> daemonBase
+                , DaemonGeneric =
+                  [ Artifact.LogProc, Artifact.DaemonStorageToolbox ]
+                , DaemonProfiled =
+                    \(a : { profile : Profiles.Type }) -> daemonBase
+                , DaemonLegacyHardfork =
+                        \(a : { network : Network.Type })
+                    ->  [ Artifact.Daemon { network = a.network } ]
+                , DaemonAutoHardfork =
+                        \(a : { network : Network.Type })
+                    ->  [ Artifact.Daemon { network = a.network } ]
+                , DaemonPrefork = \(a : { network : Network.Type }) -> none
+                , DaemonPostfork = \(a : { network : Network.Type }) -> none
+                , CreatePreforkGenesis =
+                    \(a : { network : Network.Type }) -> none
+                , DaemonStorageToolbox = none
+                , LogProc = none
+                , ArchiveGeneric = none
+                , Archive = \(a : { network : Network.Type }) -> none
+                , RosettaGeneric = [ Artifact.LogProc ]
+                , Rosetta =
+                        \(a : { network : Network.Type })
+                    ->  [ Artifact.RosettaGeneric
+                        , Artifact.Daemon { network = a.network }
+                        , Artifact.LogProc
+                        ]
+                , TestExecutive = none
+                , TxTools = none
+                , FunctionalTestSuite = none
+                , DelegationVerifier = none
+                , Toolchain = none
+                }
+                artifact
+
+let hasOrdinal =
+          \(artifacts : List Artifact)
+      ->  \(artifact : Artifact)
+      ->  Prelude.List.any
+            Artifact
+            (     \(other : Artifact)
+              ->  Prelude.Natural.equal (ordinal other) (ordinal artifact)
+            )
+            artifacts
+
+let dedupe =
+          \(artifacts : List Artifact)
+      ->  Prelude.List.reverse
+            Artifact
+            ( Prelude.List.fold
+                Artifact
+                artifacts
+                (List Artifact)
+                (     \(artifact : Artifact)
+                  ->  \(kept : List Artifact)
+                  ->        if hasOrdinal kept artifact
+
+                      then  kept
+
+                      else  [ artifact ] # kept
+                )
+                ([] : List Artifact)
+            )
+
+let addRequired =
+          \(artifacts : List Artifact)
+      ->  dedupe
+            (   artifacts
+              # Prelude.List.concatMap Artifact Artifact requires artifacts
+            )
+
+let close =
+          \(artifacts : List Artifact)
+      ->  addRequired (addRequired (addRequired (addRequired artifacts)))
+
 in  { Type = Artifact
     , capitalName = capitalName
     , lowerName = lowerName
+    , ordinal = ordinal
+    , requires = requires
+    , dedupe = dedupe
+    , close = close
     , isNetworked = isNetworked
     , network = network
     , resolvedNetwork = resolvedNetwork


### PR DESCRIPTION
First piece of the artifact-selection work. It adds three functions to
`Constants/Artifact/Artifacts.dhall` and changes no existing behaviour: nothing
calls them yet, and `make all` in `buildkite/` still passes 45/45.

The goal is `!ci-docker-me artifacts=daemonAutoHardfork`: build one image, not
all of them. Choosing artifacts is only safe if everything the chosen ones need
comes with them, and that closure is what this PR provides.

### Why a number for each artifact

Dhall has equality for neither a union nor Text, so there is no direct way to
know that two artifacts are the same one. `ordinal` gives each constructor a
number, and the deduplication compares those. The payload (the network, the
profile) is left out on purpose: one run uses one network and one profile for
every artifact it builds.

### Two kinds of need, in one place

`requires` holds both, which is the point of the PR: today this knowledge is
spread over the Dhall and the Dockerfiles, and `GenerateHardforkPackage.dhall`
keeps a hand-written copy of it (its artifact list carries `LogProc` and
`DaemonStorageToolbox` for exactly this reason).

1. **An image is FROM the image of an other artifact**, so both steps must be in
   the same pipeline. From the rendered `depends_on`: `daemon <- daemonGeneric`,
   `daemonAutoHardfork <- daemon`, `rosetta <- rosettaGeneric`.
2. **An image installs the Debian package of an other artifact from a file in
   the build context.** There is no apt repository in the build (see the
   `install-mina-debs.sh` calls under `dockerfiles/stages/`), so every Mina
   package an image needs must be built by the same pipeline. Each daemon image
   installs `mina-logproc` and `mina-daemon-storage-toolbox`; the rosetta image
   also installs the config package, which the `Daemon` artifact produces.

`close` applies `requires` until the set stops growing. Dhall has no recursion,
so the step is repeated a fixed number of times: the longest chain today is
three hops (`daemonAutoHardfork -> daemon -> daemonGeneric -> logProc`) and four
repetitions leave one in reserve.

### Verified by evaluation

```
daemonAutoHardfork -> daemon, daemonStorageToolbox, logProc, daemonGeneric, daemonAutoHardfork
rosetta            -> logProc, daemon, rosettaGeneric, daemonStorageToolbox, daemonGeneric, rosetta
archive            -> archive          (pulls in nothing)
logProc            -> logProc
close (close xs) == close xs           (idempotent)
```

### Next

An entrypoint (`Entrypoints/BuildArtifacts.dhall`) plus a
`run-build-artifacts.sh` that turns `ARTIFACTS=...` into a typed Dhall list, in
the same shape as `run-hardfork-package-gen.sh` already does for
`CODENAMES_CONFIG`. That entrypoint route avoids the `TagFilter` enumeration and
the fact that Dhall cannot parse a name list at all.
