### PR TITLE
release manager: handle the mina-automode docker image

### DIFF
--- a/buildkite/scripts/release/manager.sh
+++ b/buildkite/scripts/release/manager.sh
@@ -14,6 +14,12 @@
 # - PERSIST: Archive artifacts to long-term storage backends
 #
 # Supported artifacts: mina-daemon, mina-archive, mina-rosetta, mina-logproc, mina-config, mina-automode, mina-prefork, mina-postfork, mina-generic, rosetta-generic, mina-postfork-mesa, mina-prefork-mesa, minimina
+#
+# Artifacts that carry a docker image as well as a debian package:
+#   mina-daemon (mina-daemon), mina-generic (mina-daemon), mina-archive (mina-archive),
+#   mina-rosetta / rosetta-generic (mina-rosetta), mina-automode (mina-daemon-auto-hardfork)
+# See get_docker_image_name for the artifact -> image name mapping.
+#
 # Supported networks: devnet, mainnet
 # Supported platforms: Debian (bullseye, focal), Docker (GCR, Docker.io)
 # Supported channels: unstable, alpha, beta, stable
@@ -301,6 +307,13 @@ function get_docker_image_name() {
         ;;
         rosetta-generic)
             echo "mina-rosetta"
+        ;;
+        mina-automode)
+            # The automode image is built by the DaemonAutoHardfork artifact
+            # (buildkite/src/Constants/Docker/Package.dhall), which names it
+            # mina-daemon-auto-hardfork. Its tag is
+            # "<version>-<codename>-<network>", the same shape as mina-daemon.
+            echo "mina-daemon-auto-hardfork"
         ;;
         *)
             echo "$__artifact"
@@ -1084,7 +1097,31 @@ function publish(){
                                     fi
                                 done
                             ;;
-                            mina-automode|mina-prefork|mina-postfork)
+                            mina-automode)
+                                for network in "${__networks_arr[@]}"; do
+                                    if [[ $__only_dockers == 0 ]]; then
+                                        publish_debian $artifact \
+                                                $__codename \
+                                                $__source_version \
+                                                $__target_version \
+                                                $__channel \
+                                                $network \
+                                                $__profile \
+                                                $__verify \
+                                                $__dry_run \
+                                                $__backend \
+                                                $__debian_repo \
+                                                "$__arch" \
+                                                "$__force_upload_debians" \
+                                                "$__debian_sign_key"
+                                    fi
+
+                                    if [[ $__only_debians == 0 ]]; then
+                                        promote_and_verify_docker $artifact $__source_version $__target_version $__codename $network $__profile $__source_docker_repo $__target_docker_repo $__verify $__arch $__dry_run
+                                    fi
+                                done
+                            ;;
+                            mina-prefork|mina-postfork)
                                 for network in "${__networks_arr[@]}"; do
                                     if [[ $__only_dockers == 0 ]]; then
                                         publish_debian $artifact \
@@ -1539,7 +1576,30 @@ function promote(){
                                 fi
                             done
                         ;;
-                        mina-automode|mina-prefork|mina-postfork)
+                        mina-automode)
+                            for network in "${__networks_arr[@]}"; do
+                                if [[ $__only_dockers == 0 ]]; then
+                                    promote_debian $artifact \
+                                        $__codename \
+                                        $__source_version \
+                                        $__target_version \
+                                        $__source_channel \
+                                        $__target_channel \
+                                        $network \
+                                        "$__profile" \
+                                        $__verify \
+                                        $__dry_run \
+                                        $__debian_repo \
+                                        "$__arch" \
+                                        $__debian_sign_key
+                                fi
+
+                                if [[ $__only_debians == 0 ]]; then
+                                    promote_and_verify_docker $artifact $__source_version $__target_version $__codename $network $__profile $__source_docker_repo $__target_docker_repo $__verify $__arch $__dry_run
+                                fi
+                            done
+                        ;;
+                        mina-prefork|mina-postfork)
                             for network in "${__networks_arr[@]}"; do
                                 if [[ $__only_dockers == 0 ]]; then
                                     promote_debian $artifact \
@@ -1989,7 +2049,50 @@ function verify(){
                                     fi
                                 done
                             ;;
-                            mina-automode|mina-prefork|mina-postfork)
+                            mina-automode)
+                                for network in "${__networks_arr[@]}"; do
+                                    local __artifact_full_name
+                                    __artifact_full_name=$(get_artifact_with_suffix $artifact $network)
+
+                                    local __docker_name
+                                    __docker_name=$(get_docker_image_name $artifact)
+
+                                    local __docker_suffix_combined
+                                    __docker_suffix_combined=$(combine_docker_suffixes "$network" "$__profile" "$__build_flag" "$__generic")
+
+                                    if [[ $__only_dockers == 0 ]]; then
+                                        echo "     📋  Verifying: $__artifact_full_name debian on $__channel channel with $__version version for $__codename codename"
+                                        echo ""
+
+                                        prefix_cmd "$SUBCOMMAND_TAB" $SCRIPTPATH/../../../scripts/debian/verify.sh \
+                                            -p $__artifact_full_name \
+                                            --version $__version \
+                                            -m $__codename \
+                                            -r $__debian_repo \
+                                            -c $__channel \
+                                            -a "$__arch" \
+                                            ${__signed_debian_repo:+--signed}
+
+                                        echo ""
+                                    fi
+
+                                    if [[ $__only_debians == 0 ]]; then
+                                        echo "      📋  Verifying: $__docker_name docker on $(calculate_docker_tag "$__docker_repo" $artifact $__version $__codename "$network" "$__profile")"
+                                        echo ""
+
+                                        prefix_cmd "$SUBCOMMAND_TAB" $SCRIPTPATH/../../../scripts/docker/verify.sh \
+                                            -p "$__docker_name" \
+                                            -v $__version \
+                                            -c "$__codename" \
+                                            -s "$__docker_suffix_combined" \
+                                            -r "$__docker_repo" \
+                                            -a "$__arch"
+
+                                        echo ""
+                                    fi
+                                done
+                            ;;
+                            mina-prefork|mina-postfork)
                                 for network in "${__networks_arr[@]}"; do
                                     local __artifact_full_name
                                     __artifact_full_name=$(get_artifact_with_suffix $artifact $network)
@@ -3409,9 +3512,12 @@ function progress(){
 
         for artifact in "${__artifacts_arr[@]}"; do
             # Skip artifacts that have no docker image
-            if [[ "$artifact" == "mina-logproc" || "$artifact" == "minimina" || "$artifact" == "mina-config" || "$artifact" == "mina-automode" || "$artifact" == "mina-prefork" || "$artifact" == "mina-postfork" || "$artifact" == "mina-postfork-mesa" || "$artifact" == "mina-prefork-mesa" ]]; then
+            if [[ "$artifact" == "mina-logproc" || "$artifact" == "minimina" || "$artifact" == "mina-config" || "$artifact" == "mina-prefork" || "$artifact" == "mina-postfork" || "$artifact" == "mina-postfork-mesa" || "$artifact" == "mina-prefork-mesa" ]]; then
                 continue
             fi
+
+            local docker_name
+            docker_name=$(get_docker_image_name "$artifact")
 
             for codename in "${__codenames_arr[@]}"; do
                 # Determine architectures based on codename
@@ -3430,11 +3536,11 @@ function progress(){
                     local tag="$__version-$codename$network_suffix$arch_suffix"
 
                     ((total_docker_checks=total_docker_checks+1))
-                    if check_docker_image "$docker_repo" "$artifact" "$tag"; then
-                        echo "    ✅  $artifact:$tag"
+                    if check_docker_image "$docker_repo" "$docker_name" "$tag"; then
+                        echo "    ✅  $docker_name:$tag"
                         ((passed_docker_checks=passed_docker_checks+1))
                     else
-                        echo "    ❌  $artifact:$tag - MISSING"
+                        echo "    ❌  $docker_name:$tag - MISSING"
                     fi
                 done
             done

--- a/buildkite/scripts/tests/release-manager/README.md
+++ b/buildkite/scripts/tests/release-manager/README.md
@@ -22,6 +22,14 @@ The test suite includes the following test cases:
 5. **Manager Promote Command - Signed (Dry-run)**: Tests promotion in signed repository with GPG signing key
 6. **Manager Publish Command - Signed (Dry-run)**: Tests publishing to signed repository with GPG signing key
 
+The suite also covers the per-artifact dry-run cases in `run_dry_run_tests`
+(`mina-config`, `mina-generic`, `rosetta-generic`, `mina-automode`, mixed
+artifact lists, and rejection of an unknown artifact). The two `mina-automode`
+cases pin the docker image name: that artifact publishes as
+`mina-daemon-auto-hardfork`, not under its own name, so they assert the exact
+`mina-daemon-auto-hardfork:<version>-<codename>-<network>` tag appears in the
+publish and promote output.
+
 **Non-dry-run Tests (Actual operations that make changes):**
 7. **Manager Promote - Unsigned (Real)**: Actually promotes packages in unsigned test repository with verification
 8. **Manager Promote - Signed (Real)**: Actually promotes packages in signed test repository with GPG signing and verification

--- a/buildkite/scripts/tests/release-manager/lib.sh
+++ b/buildkite/scripts/tests/release-manager/lib.sh
@@ -515,6 +515,80 @@ test_manager_publish_rosetta_generic() {
     fi
 }
 
+# Test: Test publish operation (dry-run) for the mina-automode docker image
+#
+# mina-automode carries a docker image whose name differs from the artifact
+# name: CI publishes it as mina-daemon-auto-hardfork (see get_docker_image_name
+# in manager.sh and Docker/Package.dhall). This test pins that mapping, and the
+# "<version>-<codename>-<network>" tag shape, so a rename cannot pass silently.
+test_manager_publish_mina_automode() {
+    log_info "========================================="
+    log_info "TEST: Test manager.sh publish mina-automode docker (dry-run)"
+    log_info "========================================="
+
+    local target_version="3.3.0-test-automode-${RANDOM_SUFFIX}"
+    local expected_image="mina-daemon-auto-hardfork:${target_version}-${TEST_CODENAME}-devnet"
+
+    if "${MANAGER_SCRIPT}" publish \
+        --buildkite-build-id "test_data" \
+        --source-version "3.3.0-test-automode" \
+        --target-version "${target_version}" \
+        --channel "${TEST_COMPONENT_TEST}" \
+        --artifacts "mina-automode" \
+        --networks "devnet" \
+        --codenames "${TEST_CODENAME}" \
+        --archs "${TEST_ARCH}" \
+        --debian-repo "${TEST_BUCKET}" \
+        --backend "${BACKEND}" \
+        --only-dockers \
+        --skip-cache-invalidation \
+        --dry-run 2>&1 | tee "${TEST_TEMP_DIR}/publish_mina_automode_dry_run.log"; then
+
+        if grep -q "${expected_image}" "${TEST_TEMP_DIR}/publish_mina_automode_dry_run.log"; then
+            assert_success "Manager publish mina-automode docker (dry-run)" 0
+        else
+            log_error "Expected docker image ${expected_image} in publish output"
+            assert_success "Manager publish mina-automode docker (dry-run)" 1
+        fi
+    else
+        assert_success "Manager publish mina-automode docker (dry-run)" 1
+    fi
+}
+
+# Test: Test promote operation (dry-run) for the mina-automode docker image
+test_manager_promote_mina_automode() {
+    log_info "========================================="
+    log_info "TEST: Test manager.sh promote mina-automode docker (dry-run)"
+    log_info "========================================="
+
+    local target_version="3.3.0-automode-${RANDOM_SUFFIX}"
+    local expected_image="mina-daemon-auto-hardfork:${target_version}-${TEST_CODENAME}-devnet"
+
+    if "${MANAGER_SCRIPT}" promote \
+        --source-version "3.3.0-alpha1-compatible-918b8c0" \
+        --target-version "${target_version}" \
+        --source-channel "${TEST_COMPONENT_CI}" \
+        --target-channel "${TEST_COMPONENT_TEST}" \
+        --artifacts "mina-automode" \
+        --networks "devnet" \
+        --codenames "${TEST_CODENAME}" \
+        --arch "${TEST_ARCH}" \
+        --debian-repo "${TEST_BUCKET}" \
+        --only-dockers \
+        --skip-cache-invalidation \
+        --dry-run 2>&1 | tee "${TEST_TEMP_DIR}/promote_mina_automode_dry_run.log"; then
+
+        if grep -q "${expected_image}" "${TEST_TEMP_DIR}/promote_mina_automode_dry_run.log"; then
+            assert_success "Manager promote mina-automode docker (dry-run)" 0
+        else
+            log_error "Expected docker image ${expected_image} in promote output"
+            assert_success "Manager promote mina-automode docker (dry-run)" 1
+        fi
+    else
+        assert_success "Manager promote mina-automode docker (dry-run)" 1
+    fi
+}
+
 # Test: Test publish with mixed artifacts including mina-config (dry-run)
 test_manager_publish_mixed_with_config() {
     log_info "========================================="
@@ -609,7 +683,9 @@ run_dry_run_tests() {
     test_manager_publish_mina_config
     test_manager_publish_mina_generic
     test_manager_publish_rosetta_generic
+    test_manager_publish_mina_automode
     test_manager_publish_mixed_with_config
     test_manager_promote_mina_config
+    test_manager_promote_mina_automode
     test_manager_unknown_artifact_rejected
 }

--- a/scripts/verify/check-daemon-auto-hardfork.sh
+++ b/scripts/verify/check-daemon-auto-hardfork.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Verification checks for the mina-daemon-auto-hardfork image.
+#
+# This image is NOT a normal daemon image, so check-daemon.sh does not apply:
+#   - /usr/local/bin/mina is the mina-dispatch script, not a daemon binary. The
+#     dispatcher only forwards "daemon", "client", "libp2p" and "--version";
+#     every other subcommand (including "--help") exits 1 by design, so the
+#     "mina --help" step of check-daemon.sh would always fail here.
+#   - The image carries TWO runtimes side by side, under
+#     ${RUNTIMES_BASE_PATH}/berkeley (pre-fork) and .../mesa (post-fork).
+#
+# Checks:
+#   1. The dispatcher config /etc/default/mina-dispatch exists and defines the
+#      variables the dispatcher needs.
+#   2. /usr/local/bin/mina resolves to the dispatcher.
+#   3. Both runtime binaries exist, are executable, and report a version.
+#   4. The two runtimes report DIFFERENT commit hashes. Two identical runtimes
+#      mean the image was built from the wrong deb pair and cannot hardfork.
+#   5. "mina --version" works through the dispatcher. With no activation state
+#      file present, the dispatcher selects the berkeley runtime, so the version
+#      it reports must be the berkeley one.
+#   6. If a genesis config file is shipped, its commit hash matches the berkeley
+#      runtime (the pre-fork config is the only one this image carries; the
+#      post-fork config comes from the mina-<network>-config package).
+set -euo pipefail
+
+DISPATCH_ENV=/etc/default/mina-dispatch
+
+# --- 1. Dispatcher configuration -------------------------------------------
+echo "Checking dispatcher configuration $DISPATCH_ENV ..."
+if [ ! -f "$DISPATCH_ENV" ]; then
+  echo "FAIL: $DISPATCH_ENV not found"
+  exit 1
+fi
+cat "$DISPATCH_ENV"
+
+# shellcheck disable=SC1090
+source "$DISPATCH_ENV"
+
+for var in MINA_NETWORK MINA_PROFILE RUNTIMES_BASE_PATH; do
+  if [ -z "${!var:-}" ]; then
+    echo "FAIL: $var is not defined in $DISPATCH_ENV"
+    exit 1
+  fi
+done
+echo "OK: MINA_NETWORK=$MINA_NETWORK MINA_PROFILE=$MINA_PROFILE RUNTIMES_BASE_PATH=$RUNTIMES_BASE_PATH"
+
+# --- 2. The mina entrypoint is the dispatcher ------------------------------
+MINA_BIN=$(command -v mina)
+echo "Checking that $MINA_BIN is the dispatcher ..."
+if [ "$(basename "$(readlink -f "$MINA_BIN")")" != "mina-dispatch" ]; then
+  echo "FAIL: $MINA_BIN does not resolve to mina-dispatch"
+  readlink -f "$MINA_BIN"
+  exit 1
+fi
+echo "OK: $MINA_BIN -> mina-dispatch"
+
+# --- 3. Both runtimes are present and runnable -----------------------------
+PREFORK_BIN="$RUNTIMES_BASE_PATH/berkeley/mina"
+POSTFORK_BIN="$RUNTIMES_BASE_PATH/mesa/mina"
+
+# Extracts the first 8 characters of the commit hash from a "mina --version"
+# output. Matches both the JSON ("commit_hash": "<sha>") and the plain
+# ("Commit <sha>") shapes, exactly like check-daemon.sh does.
+extract_commit() {
+  grep -oP '(?:commit_hash": "|Commit )\K[a-f0-9]+' | head -c 8
+}
+
+for bin in "$PREFORK_BIN" "$POSTFORK_BIN"; do
+  echo "Checking runtime $bin ..."
+  if [ ! -x "$bin" ]; then
+    echo "FAIL: $bin not found or not executable"
+    exit 1
+  fi
+  "$bin" --version
+done
+
+PREFORK_COMMIT=$("$PREFORK_BIN" --version 2>&1 | extract_commit)
+POSTFORK_COMMIT=$("$POSTFORK_BIN" --version 2>&1 | extract_commit)
+echo "Pre-fork  (berkeley) commit: $PREFORK_COMMIT"
+echo "Post-fork (mesa)     commit: $POSTFORK_COMMIT"
+
+if [ -z "$PREFORK_COMMIT" ] || [ -z "$POSTFORK_COMMIT" ]; then
+  echo "FAIL: could not read a commit hash from one of the runtimes"
+  exit 1
+fi
+
+# --- 4. The two runtimes must differ ---------------------------------------
+if [ "$PREFORK_COMMIT" = "$POSTFORK_COMMIT" ]; then
+  echo "FAIL: both runtimes report the same commit ($PREFORK_COMMIT);"
+  echo "      the image was built from the wrong prefork/postfork deb pair"
+  exit 1
+fi
+echo "OK: the two runtimes are built from different commits"
+
+# --- 5. The dispatcher passes --version through ----------------------------
+echo "Running mina --version through the dispatcher ..."
+DISPATCHED_COMMIT=$(mina --version 2>&1 | extract_commit)
+echo "Dispatched commit: $DISPATCHED_COMMIT"
+
+# No activation state file is present in a fresh container, so the dispatcher
+# must select the pre-fork runtime.
+if [ "$DISPATCHED_COMMIT" != "$PREFORK_COMMIT" ]; then
+  echo "FAIL: mina --version reported $DISPATCHED_COMMIT, expected the pre-fork"
+  echo "      runtime ($PREFORK_COMMIT) because no activation state file exists"
+  exit 1
+fi
+echo "OK: the dispatcher selects the pre-fork runtime before activation"
+
+# --- 6. Genesis config matches the pre-fork runtime ------------------------
+CONFIG_FILE=$(ls /var/lib/coda/config_*.json 2>/dev/null | head -1 || true)
+
+if [ -z "$CONFIG_FILE" ]; then
+  echo "No genesis config file found in /var/lib/coda/ — skipping hash check"
+  exit 0
+fi
+
+echo "Found genesis config: $CONFIG_FILE"
+CONFIG_COMMIT=$(basename "$CONFIG_FILE" | grep -oP 'config_\K[a-f0-9]+')
+echo "Config file commit hash: $CONFIG_COMMIT"
+
+if [ "$PREFORK_COMMIT" = "$CONFIG_COMMIT" ]; then
+  echo "OK: pre-fork runtime commit ($PREFORK_COMMIT) matches genesis config commit ($CONFIG_COMMIT)"
+else
+  echo "FAIL: pre-fork runtime commit ($PREFORK_COMMIT) does not match genesis config commit ($CONFIG_COMMIT)"
+  exit 1
+fi

--- a/scripts/verify/resolve-check-script.sh
+++ b/scripts/verify/resolve-check-script.sh
@@ -10,6 +10,9 @@ case "${1:?package name required}" in
   mina-archive*) CHECK_SCRIPT="$VERIFY_DIR/check-archive.sh" ;;
   mina-logproc)  CHECK_SCRIPT="$VERIFY_DIR/check-logproc.sh" ;;
   mina-rosetta*) CHECK_SCRIPT="$VERIFY_DIR/check-rosetta.sh" ;;
+  # The auto-hardfork image ships two runtimes behind the mina-dispatch script,
+  # so the plain daemon checks do not apply. Must stay above the mina-* catch-all.
+  mina-daemon-auto-hardfork*) CHECK_SCRIPT="$VERIFY_DIR/check-daemon-auto-hardfork.sh" ;;
   mina-*)        CHECK_SCRIPT="$VERIFY_DIR/check-daemon.sh" ;;
   *) echo "Unknown package: $1"; exit 1 ;;
 esac


### PR DESCRIPTION
## Problem

CI builds and publishes the `mina-daemon-auto-hardfork` docker image for the
`DaemonAutoHardfork` artifact, but `buildkite/scripts/release/manager.sh` knew
nothing about it. `mina-automode` was grouped with the debian-only
`mina-prefork` / `mina-postfork` artifacts, so `publish`, `promote` and `verify`
all printed

```
ℹ️  There is no mina-automode docker image to publish. skipping
```

and `progress` skipped it outright. The image therefore never moved between
channels with the rest of a release.

## Changes

**`buildkite/scripts/release/manager.sh`**

- `get_docker_image_name`: map `mina-automode` → `mina-daemon-auto-hardfork`
  (the artifact name and the image name differ, like `mina-generic` →
  `mina-daemon`).
- `publish` / `promote` / `verify`: split `mina-automode` out of the
  `mina-prefork|mina-postfork` case and route it through
  `promote_and_verify_docker` / `scripts/docker/verify.sh`.
- `progress`: drop `mina-automode` from the docker-skip list, and resolve image
  names through `get_docker_image_name`.

**`scripts/verify/check-daemon-auto-hardfork.sh`** (new), wired up in
`resolve-check-script.sh`

The existing `check-daemon.sh` **fails** on this image: `/usr/local/bin/mina` is
the `mina-dispatch` script, which only forwards `daemon`, `client`, `libp2p` and
`--version`, so the `mina --help` step exits 1. The image also carries two
runtimes rather than one. The new script checks what the image actually is:

1. `/etc/default/mina-dispatch` exists and defines the dispatcher variables.
2. `/usr/local/bin/mina` resolves to `mina-dispatch`.
3. Both runtimes (`.../berkeley/mina`, `.../mesa/mina`) exist and report a version.
4. The two runtimes report **different** commits — identical ones mean the image
   was built from the wrong prefork/postfork deb pair and cannot hardfork.
5. `mina --version` selects the pre-fork runtime, since a fresh container has no
   activation state file.
6. The shipped `config_<hash>.json` matches the pre-fork runtime.

**`buildkite/scripts/tests/release-manager/lib.sh`** — two dry-run tests that
pin the image name and the `<version>-<codename>-<network>` tag shape for
publish and promote.

## Verification

| Check | Result |
|---|---|
| Tag computed by `promote`/`publish`/`verify` | `mina-daemon-auto-hardfork:4.0.0-rc1-devnet-dryrun-22291cf-jammy-devnet` — byte-identical to a real published image |
| New check script against that image | passes (berkeley `b3762e1c` / mesa `22291cf8`; config matches) |
| Old `check-daemon.sh` against the same image | fails on `mina --help`, confirming the new script is needed |
| 12 other artifacts, `publish` + `promote` dry-run | output unchanged vs. base |
| Mutation test (break the name mapping) | both new tests fail |
| `shellcheck -S error` | clean on all touched files |

## Side effect

`progress` was checking for images literally named `mina-generic` and
`rosetta-generic`, which do not exist — CI publishes those as `mina-daemon` and
`mina-rosetta`, so they always reported MISSING. Routing through
`get_docker_image_name` fixes that too.

## Not included

`docker_step` for `DaemonAutoHardfork` in `buildkite/src/Command/MinaArtifact.dhall`
omits `arch = spec.arch`, which `DaemonLegacyHardfork` passes, so it always
renders `--platform linux/amd64`. Harmless today (no arm64 job lists this
artifact) and out of scope here.

No changelog entry: release-tooling only, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
