### PR TITLE
Fix docker build script tests against the overwrite guard

### DIFF
--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -168,6 +168,14 @@ if [[ "${1:-}" == "network" ]]; then
     echo "172.17.0.1"
     exit 0
 fi
+# "docker manifest inspect" asks the registry whether a tag is published.
+# build.sh uses it to refuse to overwrite an image that already exists, so the
+# stub must answer truthfully: nothing is published in the tests, and the call
+# fails, unless a test asks for the tag to be there.
+if [[ "${1:-}" == "manifest" ]]; then
+    [[ -n "${STUB_TAG_IN_REGISTRY:-}" ]] && exit 0
+    exit 1
+fi
 exit 0
 STUB
     chmod +x "${STUB_DIR}/docker"
@@ -197,6 +205,8 @@ run_build() {
       BRANCH_NAME="test-branch" \
       MINA_DEB_CODENAME="bullseye" \
       KEEP_MY_TAGS_INTACT="true" \
+      STUB_TAG_IN_REGISTRY="${STUB_TAG_IN_REGISTRY:-}" \
+      FORCE_DOCKER_OVERWRITE="${FORCE_DOCKER_OVERWRITE:-}" \
       CI="" BUILDKITE="" GITHUB_ACTIONS="" \
       ./scripts/docker/build.sh "$@" ) > "${args_file}.log" 2>&1
     LAST_EXIT=$?
@@ -259,6 +269,43 @@ test_load_only_does_not_push() {
     assert_has_line "buildx still loads" "$args" "--load"
     assert_not_called "no push" "${args}.calls" "^push "
     assert_not_called "no registry tag" "${args}.calls" "^buildx imagetools"
+}
+
+# A tag that is already published is not overwritten. The check runs before the
+# build, so a build that would be refused costs nothing.
+test_published_tag_is_not_overwritten() {
+    local args="${STUB_DIR}/exists.args"
+    STUB_TAG_IN_REGISTRY="true" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_eq "exit code" 1 "$LAST_EXIT"
+    assert_not_called "nothing is built" "${args}.calls" "^buildx build"
+    assert_not_called "nothing is pushed" "${args}.calls" "^push "
+}
+
+# FORCE_DOCKER_OVERWRITE is the way past that refusal.
+test_force_overwrite_pushes_over_a_published_tag() {
+    local args="${STUB_DIR}/force.args"
+    STUB_TAG_IN_REGISTRY="true" FORCE_DOCKER_OVERWRITE="1" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_eq "exit code" 0 "$LAST_EXIT"
+    assert_called "push" "${args}.calls" "^push testreg/mina-daemon:3\.1\.0$"
+}
+
+# The refusal only guards a push. A load-only build never reaches the registry,
+# so it must not ask the registry anything.
+test_load_only_ignores_the_published_tag() {
+    local args="${STUB_DIR}/load-exists.args"
+    STUB_TAG_IN_REGISTRY="true" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none --load-only
+
+    assert_eq "exit code" 0 "$LAST_EXIT"
+    assert_not_called "the registry is not asked" "${args}.calls" \
+        "^manifest inspect"
 }
 
 # The archive and the rosetta images publish one image for each network, so the
@@ -555,6 +602,9 @@ main() {
     run_test test_daemon_command
     run_test test_push_is_a_separate_docker_call
     run_test test_load_only_does_not_push
+    run_test test_published_tag_is_not_overwritten
+    run_test test_force_overwrite_pushes_over_a_published_tag
+    run_test test_load_only_ignores_the_published_tag
     run_test test_archive_tag_holds_the_network
     run_test test_rosetta_tag_holds_the_network
     run_test test_base_image_service


### PR DESCRIPTION
## Problem

The `Docker build script tests` job fails on every develop nightly since #18765 merged — see [nightly 1583](https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1583#019feb92-f882-4ea6-9308-50b27ae06d64). Every test fails, all with the same shape:

```
FAIL: exit code: expected '0', got '1'
FAIL: target: expected 'mina-daemon', got ''
```

`build.sh` exits 1 before it ever calls `docker`, so nothing is recorded and every assertion misses.

## Root cause

A semantic merge conflict between two PRs that were each green on their own.

- #19186 (`5c07f11e0f`, Aug 7) added this suite. Its stub `docker` answers `exit 0` to any call it does not recognise.
- #18765 (`cae4fd992a`, authored in April, merged Aug 10) added an overwrite guard to `build.sh`:

```bash
if [[ "${DOCKER_ACTION}" == "push" ]]; then
  if docker manifest inspect "$TAG" > /dev/null 2>&1; then
    ...
    echo "❌ Image $TAG already exists in the registry. Refusing to overwrite."
    exit 1
```

The stub answers `exit 0` to `docker manifest inspect`, so the guard concludes every tag is already published and refuses to build. The guard branch was cut before the suite existed, so neither PR's CI could see the other.

The failure text never reaches the log, because the harness sends `build.sh` output to a per-test file. Running `scripts/docker/tests/test_build.sh` locally at that commit shows it:

```
❌ Image testreg/mina-daemon:3.1.0 already exists in the registry. Refusing to overwrite.
```

## Fix

The stub now answers `docker manifest inspect` truthfully: nothing is published during a test, so the call fails, and the tag counts as absent.

## Coverage

The guard reached develop with no test, which is what let this happen. Three tests now pin it:

- a published tag is not overwritten — exit 1, and neither `buildx build` nor `push` runs, so the check really does come before the build
- `FORCE_DOCKER_OVERWRITE=1` pushes over it
- `--load-only` never asks the registry at all

A test can now put a tag in the registry with `STUB_TAG_IN_REGISTRY`.

Verified non-vacuous: replacing the guard condition with `if false` fails `test_published_tag_is_not_overwritten` on all three of its assertions.

## Test plan

`./scripts/docker/tests/test_build.sh` — 24 tests, 95 assertions, all pass. `shellcheck -x` clean. Test-only change; `build.sh` is untouched.