### PR TITLE
Fix doubled network in the profiled docker hash tag

### DIFF
--- a/scripts/docker/helper.sh
+++ b/scripts/docker/helper.sh
@@ -49,40 +49,62 @@ function export_suffixes () {
     # - generic-lightnet
     # - generic-instrumented
     # - generic-lightnet-instrumented
+    #
+    # Two suffixes come out of this, because the two docker tags carry the
+    # network differently. The readable tag has no network of its own, so its
+    # suffix supplies one. The hash tag already names the network
+    # (<githash>-<codename>-<network>...), so its suffix must not repeat it.
+    # They differ only for a profiled image, whose profile is the network name:
+    #
+    #   readable  mina-daemon:4.0.0-...-bullseye-devnet-generic
+    #   hash      mina-daemon:<githash>-bullseye-devnet-generic
     local __raw_suffix=""
+    local __raw_hash_suffix=""
     local __sep=""
 
     if [[ "${PROFILED_TAG:-0}" == "1" ]]; then
-        # Profiled daemon images: tag suffix is "${profile}-profile" for
+        # Profiled daemon images: tag suffix is "${profile}-generic" for
         # devnet/mainnet, or just "lightnet" for lightnet (no -generic).
         if [[ "${DEB_PROFILE:-}" == "lightnet" ]]; then
             __raw_suffix="lightnet"
+            __raw_hash_suffix="lightnet"
         else
             __raw_suffix="${DEB_PROFILE}-generic"
+            __raw_hash_suffix="generic"
         fi
         __sep="-"
     else
         if [[ -n "${DOCKER_DEB_SUFFIX:-}" ]]; then
             __raw_suffix="${DOCKER_DEB_SUFFIX}"
+            __raw_hash_suffix="${DOCKER_DEB_SUFFIX}"
             __sep="-"
         fi
 
         if [[ "${DEB_PROFILE:-}" == "lightnet" ]]; then
             __raw_suffix="${__raw_suffix}${__sep}lightnet"
+            __raw_hash_suffix="${__raw_hash_suffix}${__sep}lightnet"
             __sep="-"
         fi
     fi
 
     if [[ "${DEB_BUILD_FLAGS:-}" == *instrumented* ]]; then
         __raw_suffix="${__raw_suffix}${__sep}instrumented"
+        __raw_hash_suffix="${__raw_hash_suffix}${__sep}instrumented"
         __sep="-"
     fi
 
-    # COMBINED_SUFFIX: used in docker tags, has leading dash when non-empty
+    # COMBINED_SUFFIX: used in the readable docker tag, has leading dash when
+    # non-empty. HASHTAG_SUFFIX: the same for the hash tag.
     if [[ -n "${__raw_suffix}" ]]; then
         export COMBINED_SUFFIX="-${__raw_suffix}"
     else
         export COMBINED_SUFFIX=""
+    fi
+
+    if [[ -n "${__raw_hash_suffix}" ]]; then
+        export HASHTAG_SUFFIX="-${__raw_hash_suffix}"
+    else
+        export HASHTAG_SUFFIX=""
     fi
 
     # DOCKER_DEB_SUFFIX_ARG: passed to Dockerfile as build arg (no leading dash,
@@ -141,7 +163,7 @@ function export_docker_tag() {
     export TAG_VERSION_PART="${VERSION}${COMBINED_SUFFIX}${PLATFORM_SUFFIX}${CUSTOM_SUFFIX}"
     export TAG="${DOCKER_REGISTRY}/${SERVICE}:${TAG_VERSION_PART}"
     export PLATFORM_SUFFIX
-    export HASHTAG_VERSION_PART="${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}${COMBINED_SUFFIX}${PLATFORM_SUFFIX}${CUSTOM_SUFFIX}"
+    export HASHTAG_VERSION_PART="${GITHASH}-${DEB_CODENAME##*=}-${NETWORK##*=}${HASHTAG_SUFFIX}${PLATFORM_SUFFIX}${CUSTOM_SUFFIX}"
     export HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${HASHTAG_VERSION_PART}"
 
 }

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -387,6 +387,47 @@ test_profiled_service_uses_its_own_dockerfile() {
     assert_has_line "dockerfile" "$args" "dockerfiles/Dockerfile-install-profile"
     assert_has_line "output tag" "$args" \
         "testreg/mina-daemon:3.0.0-test-branch-abcdefg-bullseye-devnet-generic"
+    # The hash tag already names the network, so the profile must not add it a
+    # second time. It did, and the integration tests could not find the image:
+    # they ask for "<githash>-<codename>-<network>-generic", which is also what
+    # the readable tag above says.
+    assert_has_line "hash tag names the network once" "$args" \
+        "testreg/mina-daemon:abcdefg-bullseye-devnet-generic"
+    assert_not_called "the network is not doubled" "$args" "devnet-devnet"
+
+    # The debian package inside the image is a different name: there the
+    # network is a prefix and the profile is part of the suffix, so
+    # "mina-devnet-devnet-generic" is correct and must stay.
+    assert_has_line "debian suffix keeps the profile" "$args" \
+        "deb_suffix=devnet-generic"
+}
+
+# A lightnet profiled image has no "-generic", and its suffix is the same in
+# both tags.
+test_profiled_lightnet_suffix() {
+    local args="${STUB_DIR}/profiled-lightnet.args"
+    run_build "$args" \
+        --service mina-daemon-profiled --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-profile lightnet --deb-build-flags none
+
+    assert_has_line "readable tag" "$args" \
+        "testreg/mina-daemon:3.0.0-test-branch-abcdefg-bullseye-lightnet"
+    assert_has_line "hash tag" "$args" \
+        "testreg/mina-daemon:abcdefg-bullseye-devnet-lightnet"
+}
+
+# Instrumented builds append to both suffixes, and the network still appears
+# once in the hash tag.
+test_profiled_instrumented_suffix() {
+    local args="${STUB_DIR}/profiled-instrumented.args"
+    run_build "$args" \
+        --service mina-daemon-profiled --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags instrumented
+
+    assert_has_line "readable tag" "$args" \
+        "testreg/mina-daemon:3.0.0-test-branch-abcdefg-bullseye-devnet-generic-instrumented"
+    assert_has_line "hash tag" "$args" \
+        "testreg/mina-daemon:abcdefg-bullseye-devnet-generic-instrumented"
 }
 
 test_rosetta_configured_keeps_the_rosetta_name() {
@@ -611,6 +652,8 @@ main() {
     run_test test_hardfork_targets
     run_test test_configured_service_uses_docker_tag_for_the_output
     run_test test_profiled_service_uses_its_own_dockerfile
+    run_test test_profiled_lightnet_suffix
+    run_test test_profiled_instrumented_suffix
     run_test test_rosetta_configured_keeps_the_rosetta_name
     run_test test_toolchain_joins_the_stage_files
     run_test test_delegation_verifier

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -168,6 +168,14 @@ if [[ "${1:-}" == "network" ]]; then
     echo "172.17.0.1"
     exit 0
 fi
+# "docker manifest inspect" asks the registry whether a tag is published.
+# build.sh uses it to refuse to overwrite an image that already exists, so the
+# stub must answer truthfully: nothing is published in the tests, and the call
+# fails, unless a test asks for the tag to be there.
+if [[ "${1:-}" == "manifest" ]]; then
+    [[ -n "${STUB_TAG_IN_REGISTRY:-}" ]] && exit 0
+    exit 1
+fi
 exit 0
 STUB
     chmod +x "${STUB_DIR}/docker"
@@ -197,6 +205,8 @@ run_build() {
       BRANCH_NAME="test-branch" \
       MINA_DEB_CODENAME="bullseye" \
       KEEP_MY_TAGS_INTACT="true" \
+      STUB_TAG_IN_REGISTRY="${STUB_TAG_IN_REGISTRY:-}" \
+      FORCE_DOCKER_OVERWRITE="${FORCE_DOCKER_OVERWRITE:-}" \
       CI="" BUILDKITE="" GITHUB_ACTIONS="" \
       ./scripts/docker/build.sh "$@" ) > "${args_file}.log" 2>&1
     LAST_EXIT=$?
@@ -259,6 +269,43 @@ test_load_only_does_not_push() {
     assert_has_line "buildx still loads" "$args" "--load"
     assert_not_called "no push" "${args}.calls" "^push "
     assert_not_called "no registry tag" "${args}.calls" "^buildx imagetools"
+}
+
+# A tag that is already published is not overwritten. The check runs before the
+# build, so a build that would be refused costs nothing.
+test_published_tag_is_not_overwritten() {
+    local args="${STUB_DIR}/exists.args"
+    STUB_TAG_IN_REGISTRY="true" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_eq "exit code" 1 "$LAST_EXIT"
+    assert_not_called "nothing is built" "${args}.calls" "^buildx build"
+    assert_not_called "nothing is pushed" "${args}.calls" "^push "
+}
+
+# FORCE_DOCKER_OVERWRITE is the way past that refusal.
+test_force_overwrite_pushes_over_a_published_tag() {
+    local args="${STUB_DIR}/force.args"
+    STUB_TAG_IN_REGISTRY="true" FORCE_DOCKER_OVERWRITE="1" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none
+
+    assert_eq "exit code" 0 "$LAST_EXIT"
+    assert_called "push" "${args}.calls" "^push testreg/mina-daemon:3\.1\.0$"
+}
+
+# The refusal only guards a push. A load-only build never reaches the registry,
+# so it must not ask the registry anything.
+test_load_only_ignores_the_published_tag() {
+    local args="${STUB_DIR}/load-exists.args"
+    STUB_TAG_IN_REGISTRY="true" run_build "$args" \
+        --service mina-daemon --version 3.1.0 --network devnet \
+        --docker-registry testreg --deb-build-flags none --load-only
+
+    assert_eq "exit code" 0 "$LAST_EXIT"
+    assert_not_called "the registry is not asked" "${args}.calls" \
+        "^manifest inspect"
 }
 
 # The archive and the rosetta images publish one image for each network, so the
@@ -555,6 +602,9 @@ main() {
     run_test test_daemon_command
     run_test test_push_is_a_separate_docker_call
     run_test test_load_only_does_not_push
+    run_test test_published_tag_is_not_overwritten
+    run_test test_force_overwrite_pushes_over_a_published_tag
+    run_test test_load_only_ignores_the_published_tag
     run_test test_archive_tag_holds_the_network
     run_test test_rosetta_tag_holds_the_network
     run_test test_base_image_service


### PR DESCRIPTION
Stacked on #19197 — that PR is the first commit here, and this one is the second. Merge #19197 first.

## Problem

Every `* integration test local` job in the develop nightly fails, e.g. [chain-reliability in 1583](https://buildkite.com/o-1-labs-2/mina-mainline-branches-nightlies/builds/1583#019feb93-1d08-4f6a-8daf-859a564961e5). The visible symptom is that no service ever starts:

```
Not all services could be deployed in time:
 [{"service_name":"..._node-a","status":"0/1"}, ... ]
```

with empty `docker service logs` for every one of them — the containers never ran, because the image is not there:

```
ERROR: cached image not found at /var/storagebox/docker-cache/mina-daemon/7283350-bullseye-devnet-generic.tar.zst
cache miss for .../mina-daemon:7283350-bullseye-devnet-generic
```

The archive image on the very next line loads fine, so this is specific to the daemon.

## Root cause

The daemon docker job did build and cache an image. It cached it under a different name:

| | tag |
|---|---|
| built and cached | `mina-daemon:7283350-bullseye-`**`devnet-devnet`**`-generic` |
| everything else asks for | `mina-daemon:7283350-bullseye-`**`devnet`**`-generic` |

`export_docker_tag` in `scripts/docker/helper.sh` builds the hash tag as

```bash
HASHTAG_VERSION_PART="${GITHASH}-${DEB_CODENAME}-${NETWORK}${COMBINED_SUFFIX}..."
```

and for a profiled image `COMBINED_SUFFIX` is `-${DEB_PROFILE}-generic`. The profile of a devnet build *is* `devnet`, so the network lands in the tag twice. The readable tag is correct, because it has no `${NETWORK}` of its own and relies on the suffix to supply one:

```
readable  mina-daemon:4.0.0-rc1-develop-7283350-bullseye-devnet-generic   ✅
hash      mina-daemon:7283350-bullseye-devnet-devnet-generic              ❌
```

The convention is written down in the consumer, `buildkite/scripts/run-test-executive-local.sh`:

```bash
# (<githash>-<codename>-<network>[-generic])
```

and `buildkite/scripts/nix/build-images.sh` builds the same shape independently. Both consumers agree with each other and with the readable tag; only the producer disagrees.

## Fix

`export_suffixes` now exports two suffixes. `COMBINED_SUFFIX` is unchanged and feeds the readable tag. `HASHTAG_SUFFIX` feeds the hash tag and omits the profile segment, which the hash tag already carries as `${NETWORK}`. They differ only for a profiled non-lightnet image.

`DOCKER_DEB_SUFFIX_ARG` is deliberately untouched: the debian package inside the image really is `mina-devnet-devnet-generic` — network prefix plus profile in the suffix — and that name is correct.

## Coverage

The suite asserted the hash tag for the plain daemon and the archive, but never for a profiled image, which is why this shipped. Now pinned:

- the profiled hash tag names the network once, and `devnet-devnet` appears nowhere in the command
- the debian suffix still keeps the profile
- lightnet (suffix is the same in both tags) and instrumented (appends to both)

Verified non-vacuous: restoring `${COMBINED_SUFFIX}` in the hash tag fails 3 of the new assertions.

## Test plan

`./scripts/docker/tests/test_build.sh` — 26 tests, 102 assertions, all pass. `shellcheck -x` clean.

Nightly is the real check: the daemon image should land in the cache under `<githash>-<codename>-devnet-generic` and the integration tests should find it.