### PR TITLE
Add artifact verification tooling and scheduled entrypoint

### DIFF
--- a/buildkite/scripts/entrypoints/run-verify-artifacts.sh
+++ b/buildkite/scripts/entrypoints/run-verify-artifacts.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Verify Artifacts Script
+#
+# Generates the Dhall pipeline for the artifact verification entrypoint. Both the
+# hourly canary and the daily artifact test come from this one entrypoint; the
+# mode picks which.
+#
+# USAGE:
+#   ./run-verify-artifacts.sh | buildkite-agent pipeline upload
+#
+# REQUIRED ENVIRONMENT VARIABLES:
+#   VERIFY_MODE  "infra" or "artifacts"
+#
+# The remaining variables are read by the step itself, not by this script, so a
+# scheduled build can set them without a pipeline change. See
+# buildkite/scripts/verify/run-verification.sh for the full list.
+#
+# EXAMPLES:
+#   # hourly canary
+#   export VERIFY_MODE="infra"
+#   ./run-verify-artifacts.sh | buildkite-agent pipeline upload
+#
+#   # daily artifact test
+#   export VERIFY_MODE="artifacts"
+#   export DEBIAN_CHANNEL="alpha"
+#   export PACKAGES="mina-devnet=3.5.0-devnet-stop-slot-98e7835"
+#   export AUTOMODE="mina-devnet-automode=4.0.0-devnet-ca2ccb1"
+#   ./run-verify-artifacts.sh | buildkite-agent pipeline upload
+
+RED='\033[0;31m'
+CLEAR='\033[0m'
+
+VERIFY_ARTIFACTS_DHALL_DEF="(./buildkite/src/Entrypoints/VerifyArtifacts.dhall)"
+
+function usage() {
+  if [[ -n "$1" ]]; then
+    echo -e "${RED}  $1${CLEAR}\n";
+  fi
+  cat << EOF
+  VERIFY_MODE  Required. One of:
+                 infra      hourly canary: is the apt repository serving and does
+                            the registry answer
+                 artifacts  daily test: install every package in a clean container
+                            of each codename, pull every image, and install the
+                            automode metapackage with no version pin
+
+  In artifacts mode set at least one of PACKAGES, IMAGES or AUTOMODE on the build.
+EOF
+  exit 1
+}
+
+if [[ -z "${VERIFY_MODE:-}" ]]; then
+  usage "VERIFY_MODE environment variable is required"
+fi
+
+case "${VERIFY_MODE}" in
+  infra)     DHALL_MODE="Infra" ;;
+  artifacts) DHALL_MODE="Artifacts" ;;
+  *)         usage "VERIFY_MODE must be 'infra' or 'artifacts', got '${VERIFY_MODE}'" ;;
+esac
+
+printf '%s.verify %s.Mode.%s\n' \
+  "$VERIFY_ARTIFACTS_DHALL_DEF" \
+  "$VERIFY_ARTIFACTS_DHALL_DEF" \
+  "$DHALL_MODE" \
+  | dhall-to-yaml --quoted

--- a/buildkite/scripts/entrypoints/run-verify-artifacts.sh
+++ b/buildkite/scripts/entrypoints/run-verify-artifacts.sh
@@ -35,12 +35,16 @@ CLEAR='\033[0m'
 
 VERIFY_ARTIFACTS_DHALL_DEF="(./buildkite/src/Entrypoints/VerifyArtifacts.dhall)"
 
+# Everything this script prints that is not the pipeline itself must go to stderr.
+# Standard output is piped straight into "buildkite-agent pipeline upload", so a
+# stray message there is uploaded as pipeline YAML and the build fails with a
+# confusing "Config file is empty" instead of the real reason.
 function usage() {
   if [[ -n "$1" ]]; then
-    echo -e "${RED}  $1${CLEAR}\n";
+    echo -e "${RED}  $1${CLEAR}\n" >&2;
   fi
-  cat << EOF
-  VERIFY_MODE  Required. One of:
+  cat >&2 << EOF
+  VERIFY_MODE  Optional, defaults to "infra". One of:
                  infra      hourly canary: is the apt repository serving and does
                             the registry answer
                  artifacts  daily test: install every package in a clean container
@@ -52,8 +56,12 @@ EOF
   exit 1
 }
 
-if [[ -z "${VERIFY_MODE:-}" ]]; then
-  usage "VERIFY_MODE environment variable is required"
+# The canary is the safe default: it needs no other variable and no credentials,
+# so a schedule that sets nothing still does something useful.
+VERIFY_MODE="${VERIFY_MODE:-infra}"
+
+if ! command -v dhall-to-yaml > /dev/null; then
+  usage "dhall-to-yaml is not on PATH. This script must run inside the toolchain image."
 fi
 
 case "${VERIFY_MODE}" in

--- a/buildkite/scripts/verify/run-verification.sh
+++ b/buildkite/scripts/verify/run-verification.sh
@@ -46,7 +46,9 @@
 #   DOCKER_SUFFIX    tag suffix after codename    (default: -devnet)
 #   JOBS             containers in parallel       (default: 4)
 #
-# At least one of PACKAGES, IMAGES or AUTOMODE must be set in artifacts mode.
+# With none of PACKAGES, IMAGES or AUTOMODE set, artifacts mode falls back to a
+# default set covering devnet (alpha) and mainnet (stable), so an unconfigured
+# daily schedule still tests both networks.
 
 set -eo pipefail
 
@@ -89,22 +91,29 @@ case "$VERIFY_MODE" in
     JOBS="${JOBS:-4}"
     OUTPUT_DIR="${OUTPUT_DIR:-${PWD}/verification-results}"
 
+    # Default coverage: both networks, no versions. Every entry is a bare name, so
+    # each resolves to whatever its channel offers on the day the schedule runs,
+    # and nothing here goes stale after a release. Devnet artifacts live in alpha
+    # and mainnet ones in stable, which is what the @stable entries are for.
+    #
+    # The prefork and postfork runtimes are not listed separately: the automode
+    # metapackage pulls both in, and installing it unpinned is the case that
+    # catches a channel unable to satisfy its own pin. That is how the devnet
+    # release broke twice in August, and the mainnet one after it.
+    #
+    # Docker images are not defaulted. A tag carries its version and has no
+    # channel to resolve against, so a schedule wanting image coverage must name
+    # the versions itself.
+    DEFAULT_PACKAGES="mina-devnet,mina-archive-devnet,mina-rosetta-devnet,mina-logproc"
+    DEFAULT_PACKAGES="${DEFAULT_PACKAGES},mina-mainnet@stable,mina-archive-mainnet@stable,mina-rosetta-mainnet@stable"
+    DEFAULT_AUTOMODE="mina-devnet-automode,mina-mainnet-automode@stable"
+
     if [[ -z "${PACKAGES:-}" && -z "${IMAGES:-}" && -z "${AUTOMODE:-}" ]]; then
-      echo "ERROR: artifacts mode needs at least one of PACKAGES, IMAGES or AUTOMODE." >&2
-      echo >&2
-      echo "For a recurring schedule prefer bare package names, so the schedule never" >&2
-      echo "carries a version that goes stale after a release. Add @channel to reach a" >&2
-      echo "second network, which lives in a different component:" >&2
-      echo "  PACKAGES=mina-devnet,mina-archive-devnet,mina-rosetta-devnet,mina-mainnet@stable" >&2
-      echo >&2
-      echo "Pin a version only when testing one specific release:" >&2
-      echo "  PACKAGES=mina-devnet=3.5.0-devnet-stop-slot-98e7835" >&2
-      echo "  AUTOMODE=mina-devnet-automode=4.0.0-devnet-ca2ccb1" >&2
-      echo >&2
-      echo "Docker images always need an explicit version, because a tag has no" >&2
-      echo "channel to resolve against:" >&2
-      echo "  IMAGES=mina-daemon=3.5.0-devnet-stop-slot-98e7835" >&2
-      exit 1
+      PACKAGES="$DEFAULT_PACKAGES"
+      AUTOMODE="$DEFAULT_AUTOMODE"
+      echo "No PACKAGES, IMAGES or AUTOMODE given; using the default both-network set:"
+      echo "  PACKAGES=$PACKAGES"
+      echo "  AUTOMODE=$AUTOMODE"
     fi
 
     ARGS=(

--- a/buildkite/scripts/verify/run-verification.sh
+++ b/buildkite/scripts/verify/run-verification.sh
@@ -28,11 +28,21 @@
 #   STRICT_INFRA     true -> a missing component fails (default: false)
 #
 # VERIFY_MODE=artifacts:
-#   DEBIAN_CHANNEL   single component to test     (default: alpha)
-#   PACKAGES         comma list of name=version, or bare names to test whatever
-#                    the channel currently offers (optional)
-#   IMAGES           comma list of name=version   (optional)
-#   AUTOMODE         name=version                 (optional)
+#   DEBIAN_CHANNEL   default component            (default: alpha)
+#   PACKAGES         comma list of name[=version][@channel]   (optional)
+#   IMAGES           comma list of name=version[:network]     (optional)
+#   AUTOMODE         comma list of name[=version][@channel]   (optional)
+#
+# The two networks do not share a channel: devnet artifacts sit in alpha and
+# mainnet ones in stable. Per-entry @channel and :network let a single run cover
+# both, so there is no second pipeline to keep in step. A bare package name means
+# the version the channel currently offers, which keeps a schedule from carrying
+# versions that go stale after every release. Docker images always need an
+# explicit version, because a tag has no channel to resolve against.
+#
+#   PACKAGES=mina-devnet,mina-rosetta-devnet,mina-mainnet@stable
+#   IMAGES=mina-daemon=3.5.0-x:devnet,mina-daemon=3.4.0-y:mainnet
+#   AUTOMODE=mina-devnet-automode,mina-mainnet-automode@stable
 #   DOCKER_SUFFIX    tag suffix after codename    (default: -devnet)
 #   JOBS             containers in parallel       (default: 4)
 #
@@ -83,8 +93,9 @@ case "$VERIFY_MODE" in
       echo "ERROR: artifacts mode needs at least one of PACKAGES, IMAGES or AUTOMODE." >&2
       echo >&2
       echo "For a recurring schedule prefer bare package names, so the schedule never" >&2
-      echo "carries a version that goes stale after a release:" >&2
-      echo "  PACKAGES=mina-devnet,mina-archive-devnet,mina-rosetta-devnet,mina-logproc" >&2
+      echo "carries a version that goes stale after a release. Add @channel to reach a" >&2
+      echo "second network, which lives in a different component:" >&2
+      echo "  PACKAGES=mina-devnet,mina-archive-devnet,mina-rosetta-devnet,mina-mainnet@stable" >&2
       echo >&2
       echo "Pin a version only when testing one specific release:" >&2
       echo "  PACKAGES=mina-devnet=3.5.0-devnet-stop-slot-98e7835" >&2

--- a/buildkite/scripts/verify/run-verification.sh
+++ b/buildkite/scripts/verify/run-verification.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# CI glue for the artifact verification tools.
+#
+# One entrypoint, selected by VERIFY_MODE:
+#
+#   infra      Cheap canary. Is the apt repository serving and does the docker
+#              registry answer? No credentials, no downloads. Safe to run hourly.
+#
+#   artifacts  Full test. Installs every listed package in a clean container of
+#              each codename, pulls every listed docker image, and runs the
+#              automode metapackage install with no version pin. Downloads a few
+#              gigabytes, so run it daily rather than hourly.
+#
+# Every input is an environment variable so a Buildkite scheduled build can set
+# them without changing the pipeline definition.
+#
+# Shared:
+#   VERIFY_MODE      infra | artifacts            (default: infra)
+#   CODENAMES        comma list                   (default: bullseye,focal,noble,jammy,bookworm)
+#   DEBIAN_REPO      apt host                     (default: packages.o1test.net)
+#   ARCH             amd64 | arm64                (default: amd64)
+#   DOCKER_REPO      registry namespace           (default: minaprotocol)
+#
+# VERIFY_MODE=infra:
+#   DEBIAN_CHANNELS  comma list of components     (default: unstable,alpha,beta,stable)
+#   DOCKER_IMAGES    comma list of repositories   (default: mina-daemon,mina-archive,mina-rosetta)
+#   STRICT_INFRA     true -> a missing component fails (default: false)
+#
+# VERIFY_MODE=artifacts:
+#   DEBIAN_CHANNEL   single component to test     (default: alpha)
+#   PACKAGES         comma list of name=version   (optional)
+#   IMAGES           comma list of name=version   (optional)
+#   AUTOMODE         name=version                 (optional)
+#   DOCKER_SUFFIX    tag suffix after codename    (default: -devnet)
+#   JOBS             containers in parallel       (default: 4)
+#
+# At least one of PACKAGES, IMAGES or AUTOMODE must be set in artifacts mode.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+VERIFY_MODE="${VERIFY_MODE:-infra}"
+CODENAMES="${CODENAMES:-bullseye,focal,noble,jammy,bookworm}"
+DEBIAN_REPO="${DEBIAN_REPO:-packages.o1test.net}"
+ARCH="${ARCH:-amd64}"
+DOCKER_REPO="${DOCKER_REPO:-minaprotocol}"
+
+echo "--- Verification mode: ${VERIFY_MODE}"
+
+case "$VERIFY_MODE" in
+
+  infra)
+    DEBIAN_CHANNELS="${DEBIAN_CHANNELS:-unstable,alpha,beta,stable}"
+    DOCKER_IMAGES="${DOCKER_IMAGES:-mina-daemon,mina-archive,mina-rosetta}"
+
+    ARGS=(
+      --repos "$DEBIAN_REPO"
+      --channels "$DEBIAN_CHANNELS"
+      --codenames "$CODENAMES"
+      --arch "$ARCH"
+      --docker-repo "$DOCKER_REPO"
+      --images "$DOCKER_IMAGES"
+    )
+
+    if [[ "${STRICT_INFRA:-false}" == "true" ]]; then
+      ARGS+=(--strict)
+    fi
+
+    exec "${REPO_ROOT}/scripts/verify/check-infra.sh" "${ARGS[@]}"
+    ;;
+
+  artifacts)
+    DEBIAN_CHANNEL="${DEBIAN_CHANNEL:-alpha}"
+    DOCKER_SUFFIX="${DOCKER_SUFFIX:--devnet}"
+    JOBS="${JOBS:-4}"
+    OUTPUT_DIR="${OUTPUT_DIR:-${PWD}/verification-results}"
+
+    if [[ -z "${PACKAGES:-}" && -z "${IMAGES:-}" && -z "${AUTOMODE:-}" ]]; then
+      echo "ERROR: artifacts mode needs at least one of PACKAGES, IMAGES or AUTOMODE."
+      echo "       Set them on the scheduled build, for example:"
+      echo "         PACKAGES=mina-devnet=3.5.0-devnet-stop-slot-98e7835"
+      echo "         IMAGES=mina-daemon=3.5.0-devnet-stop-slot-98e7835"
+      echo "         AUTOMODE=mina-devnet-automode=4.0.0-devnet-ca2ccb1"
+      exit 1
+    fi
+
+    ARGS=(
+      --codenames "$CODENAMES"
+      --channel "$DEBIAN_CHANNEL"
+      --repo "$DEBIAN_REPO"
+      --docker-repo "$DOCKER_REPO"
+      --suffix "$DOCKER_SUFFIX"
+      --arch "$ARCH"
+      --jobs "$JOBS"
+      --output "$OUTPUT_DIR"
+    )
+
+    if [[ -n "${PACKAGES:-}" ]]; then ARGS+=(--packages "$PACKAGES"); fi
+    if [[ -n "${IMAGES:-}" ]];   then ARGS+=(--images "$IMAGES"); fi
+    if [[ -n "${AUTOMODE:-}" ]]; then ARGS+=(--automode "$AUTOMODE"); fi
+
+    exec "${REPO_ROOT}/scripts/verify/test-release.sh" "${ARGS[@]}"
+    ;;
+
+  *)
+    echo "ERROR: unknown VERIFY_MODE '${VERIFY_MODE}'. Use 'infra' or 'artifacts'."
+    exit 1
+    ;;
+esac

--- a/buildkite/scripts/verify/run-verification.sh
+++ b/buildkite/scripts/verify/run-verification.sh
@@ -29,7 +29,8 @@
 #
 # VERIFY_MODE=artifacts:
 #   DEBIAN_CHANNEL   single component to test     (default: alpha)
-#   PACKAGES         comma list of name=version   (optional)
+#   PACKAGES         comma list of name=version, or bare names to test whatever
+#                    the channel currently offers (optional)
 #   IMAGES           comma list of name=version   (optional)
 #   AUTOMODE         name=version                 (optional)
 #   DOCKER_SUFFIX    tag suffix after codename    (default: -devnet)
@@ -79,11 +80,19 @@ case "$VERIFY_MODE" in
     OUTPUT_DIR="${OUTPUT_DIR:-${PWD}/verification-results}"
 
     if [[ -z "${PACKAGES:-}" && -z "${IMAGES:-}" && -z "${AUTOMODE:-}" ]]; then
-      echo "ERROR: artifacts mode needs at least one of PACKAGES, IMAGES or AUTOMODE."
-      echo "       Set them on the scheduled build, for example:"
-      echo "         PACKAGES=mina-devnet=3.5.0-devnet-stop-slot-98e7835"
-      echo "         IMAGES=mina-daemon=3.5.0-devnet-stop-slot-98e7835"
-      echo "         AUTOMODE=mina-devnet-automode=4.0.0-devnet-ca2ccb1"
+      echo "ERROR: artifacts mode needs at least one of PACKAGES, IMAGES or AUTOMODE." >&2
+      echo >&2
+      echo "For a recurring schedule prefer bare package names, so the schedule never" >&2
+      echo "carries a version that goes stale after a release:" >&2
+      echo "  PACKAGES=mina-devnet,mina-archive-devnet,mina-rosetta-devnet,mina-logproc" >&2
+      echo >&2
+      echo "Pin a version only when testing one specific release:" >&2
+      echo "  PACKAGES=mina-devnet=3.5.0-devnet-stop-slot-98e7835" >&2
+      echo "  AUTOMODE=mina-devnet-automode=4.0.0-devnet-ca2ccb1" >&2
+      echo >&2
+      echo "Docker images always need an explicit version, because a tag has no" >&2
+      echo "channel to resolve against:" >&2
+      echo "  IMAGES=mina-daemon=3.5.0-devnet-stop-slot-98e7835" >&2
       exit 1
     fi
 

--- a/buildkite/src/Entrypoints/VerifyArtifacts.dhall
+++ b/buildkite/src/Entrypoints/VerifyArtifacts.dhall
@@ -18,6 +18,12 @@
 -- scheduled build can change the package list, the channel or the codenames
 -- without a change to this file. See buildkite/scripts/verify/run-verification.sh
 -- for the full list of variables.
+--
+-- The artifact paths hold one pattern only. SelectFiles compiles a list into an
+-- egrep alternation, "a|b", which is what dirtyWhen wants but not what the agent
+-- wants: it reads the whole alternation as one path and matches no file, so the
+-- per container logs are lost exactly when a failure needs them. The single glob
+-- takes the results file and every log below it.
 
 let Cmd = ../Lib/Cmds.dhall
 

--- a/buildkite/src/Entrypoints/VerifyArtifacts.dhall
+++ b/buildkite/src/Entrypoints/VerifyArtifacts.dhall
@@ -1,0 +1,98 @@
+-- Verify Artifacts
+--
+-- One entrypoint for two scheduled checks against what we have already published.
+-- Both run against the live repository and registry, so neither needs a build.
+--
+--   Infra      A canary, cheap enough to run every hour. It asks whether the apt
+--              repository is serving a valid, non-empty index for every codename
+--              and component, and whether the docker registry answers. An index
+--              that returns 200 with zero packages counts as a failure, because
+--              apt reports no error and users simply find nothing.
+--
+--   Artifacts  The full daily test. It installs each package in a clean container
+--              of every codename, pulls each docker image, and installs the
+--              automode metapackage with no version pin. The unpinned install is
+--              the case that catches a dependency the channel cannot satisfy.
+--
+-- Everything else is passed through Buildkite environment variables, so a
+-- scheduled build can change the package list, the channel or the codenames
+-- without a change to this file. See buildkite/scripts/verify/run-verification.sh
+-- for the full list of variables.
+
+let Cmd = ../Lib/Cmds.dhall
+
+let Command = ../Command/Base.dhall
+
+let JobSpec = ../Pipeline/JobSpec.dhall
+
+let PipelineTag = ../Pipeline/Tag.dhall
+
+let Pipeline = ../Pipeline/Dsl.dhall
+
+let SelectFiles = ../Lib/SelectFiles.dhall
+
+let Size = ../Command/Size.dhall
+
+let Mode = < Infra | Artifacts >
+
+let modeName =
+      \(mode : Mode) -> merge { Infra = "infra", Artifacts = "artifacts" } mode
+
+let modeLabel =
+          \(mode : Mode)
+      ->  merge
+            { Infra = "Infrastructure canary"
+            , Artifacts = "Published artifact tests"
+            }
+            mode
+
+let modeArtifactPaths =
+          \(mode : Mode)
+      ->  merge
+            { Infra = [] : List SelectFiles.Type
+            , Artifacts =
+              [ SelectFiles.contains "verification-results/results.tsv"
+              , SelectFiles.contains "verification-results/logs/*.log"
+              ]
+            }
+            mode
+
+let verifyCmd =
+          \(mode : Mode)
+      ->  Cmd.run
+            (     "VERIFY_MODE=${modeName mode} "
+              ++  "./buildkite/scripts/verify/run-verification.sh"
+            )
+
+let verify =
+          \(mode : Mode)
+      ->  let steps = [ verifyCmd mode ]
+
+          let pipeline =
+                Pipeline.build
+                  Pipeline.Config::{
+                  , spec = JobSpec::{
+                    , dirtyWhen = [ SelectFiles.everything ]
+                    , path = "Entrypoints"
+                    , name = "VerifyArtifacts"
+                    , tags =
+                      [ PipelineTag.Type.Test
+                      , PipelineTag.Type.Debian
+                      , PipelineTag.Type.Docker
+                      ]
+                    }
+                  , steps =
+                    [ Command.build
+                        Command.Config::{
+                        , commands = steps
+                        , label = "Verify: ${modeLabel mode}"
+                        , key = "verify-${modeName mode}"
+                        , target = Size.Small
+                        , artifact_paths = modeArtifactPaths mode
+                        }
+                    ]
+                  }
+
+          in  pipeline.pipeline
+
+in  { Mode = Mode, verify = verify }

--- a/buildkite/src/Entrypoints/VerifyArtifacts.dhall
+++ b/buildkite/src/Entrypoints/VerifyArtifacts.dhall
@@ -50,10 +50,7 @@ let modeArtifactPaths =
           \(mode : Mode)
       ->  merge
             { Infra = [] : List SelectFiles.Type
-            , Artifacts =
-              [ SelectFiles.contains "verification-results/results.tsv"
-              , SelectFiles.contains "verification-results/logs/*.log"
-              ]
+            , Artifacts = [ SelectFiles.contains "verification-results/**/*" ]
             }
             mode
 

--- a/buildkite/src/Entrypoints/VerifyArtifacts.dhall
+++ b/buildkite/src/Entrypoints/VerifyArtifacts.dhall
@@ -14,6 +14,13 @@
 --              automode metapackage with no version pin. The unpinned install is
 --              the case that catches a dependency the channel cannot satisfy.
 --
+--              It covers devnet and mainnet in one run. The two do not share a
+--              channel -- devnet artifacts sit in alpha and mainnet ones in
+--              stable -- so package entries carry an optional @channel and image
+--              entries an optional :network. With no package list given at all,
+--              the step falls back to a default set spanning both networks, so
+--              an unconfigured schedule still tests both.
+--
 -- Everything else is passed through Buildkite environment variables, so a
 -- scheduled build can change the package list, the channel or the codenames
 -- without a change to this file. See buildkite/scripts/verify/run-verification.sh

--- a/scripts/verify/check-infra.sh
+++ b/scripts/verify/check-infra.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+# Check that the package distribution infrastructure is reachable and serving.
+#
+# This is a canary, not an artifact test. It answers one question: can a user who
+# runs "apt-get update" or "docker pull" right now get a usable answer from us?
+# It is cheap enough to run every hour and needs no credentials.
+#
+# Checks per Debian repository and codename:
+#   1. dists/<codename>/Release responds 200 and names that codename
+#   2. dists/<codename>/<component>/binary-<arch>/Packages.gz responds 200,
+#      decompresses, and holds at least one package stanza
+#
+# Checks per Docker repository:
+#   3. the registry answers and the repository holds at least one tag
+#
+# An empty index is treated as a failure. A repository that answers 200 with zero
+# packages is worse than one that is down, because apt reports no error and the
+# user simply cannot find anything.
+#
+# Usage:
+#   ./scripts/verify/check-infra.sh
+#   ./scripts/verify/check-infra.sh --repos packages.o1test.net --channels alpha,stable
+
+set -eo pipefail
+
+REPOS="packages.o1test.net"
+CHANNELS="unstable,alpha,beta,stable"
+CODENAMES="bullseye,focal,noble,jammy,bookworm"
+ARCH=amd64
+DOCKER_REPO=minaprotocol
+DOCKER_IMAGES="mina-daemon,mina-archive,mina-rosetta"
+TIMEOUT=25
+STRICT=0
+
+function usage() {
+  if [[ -n "$1" ]]; then echo "ERROR: $1"; echo; fi
+  echo "Usage: $0 [options]"
+  echo
+  echo "  -r, --repos       Comma list of apt repository hosts (default: $REPOS)"
+  echo "  -c, --channels    Comma list of components (default: $CHANNELS)"
+  echo "  -m, --codenames   Comma list of codenames (default: $CODENAMES)"
+  echo "      --arch        Architecture (default: $ARCH)"
+  echo "      --docker-repo Docker namespace (default: $DOCKER_REPO)"
+  echo "      --images      Comma list of docker repositories (default: $DOCKER_IMAGES)"
+  echo "      --timeout     Per-request timeout in seconds (default: $TIMEOUT)"
+  echo "      --strict      Treat a missing component as a failure. By default a"
+  echo "                    component that does not exist on a codename is a SKIP,"
+  echo "                    because not every repository carries every channel."
+  echo "  -h, --help        This message"
+  echo
+  echo "Exit code is 1 if any check fails."
+  exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -r|--repos) REPOS="$2"; shift;;
+  -c|--channels) CHANNELS="$2"; shift;;
+  -m|--codenames) CODENAMES="$2"; shift;;
+  --arch) ARCH="$2"; shift;;
+  --docker-repo) DOCKER_REPO="$2"; shift;;
+  --images) DOCKER_IMAGES="$2"; shift;;
+  --timeout) TIMEOUT="$2"; shift;;
+  --strict) STRICT=1;;
+  -h|--help) usage "";;
+  *) usage "Unknown parameter: $1";;
+esac; shift; done
+
+FAILURES=0
+CHECKS=0
+
+function report() {
+  local status="$1" target="$2" detail="$3"
+  printf '%-6s %-58s %s\n' "$status" "$target" "$detail"
+  CHECKS=$((CHECKS + 1))
+  if [[ "$status" == "FAIL" ]]; then FAILURES=$((FAILURES + 1)); fi
+}
+
+function http_code() {
+  curl -sSL -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" "$1" 2>/dev/null || echo "000"
+}
+
+echo "Infrastructure check  arch=$ARCH  $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "===================================================================================="
+
+IFS=',' read -ra REPO_LIST <<< "$REPOS"
+IFS=',' read -ra CHANNEL_LIST <<< "$CHANNELS"
+IFS=',' read -ra CODENAME_LIST <<< "$CODENAMES"
+IFS=',' read -ra IMAGE_LIST <<< "$DOCKER_IMAGES"
+
+for repo in "${REPO_LIST[@]}"; do
+  for codename in "${CODENAME_LIST[@]}"; do
+
+    release_url="https://${repo}/dists/${codename}/Release"
+    code=$(http_code "$release_url")
+
+    if [[ "$code" != "200" ]]; then
+      report "FAIL" "${repo} ${codename} Release" "HTTP $code"
+      continue
+    fi
+
+    # A Release file that does not name its own codename means the repository was
+    # rebuilt against the wrong suite, which breaks apt in a way that is hard to see.
+    if curl -sSL --max-time "$TIMEOUT" "$release_url" 2>/dev/null | grep -qE "^(Codename|Suite): *${codename}\b"; then
+      report "OK" "${repo} ${codename} Release" "signed index present"
+    else
+      report "FAIL" "${repo} ${codename} Release" "does not declare codename ${codename}"
+    fi
+
+    for channel in "${CHANNEL_LIST[@]}"; do
+      pkg_url="https://${repo}/dists/${codename}/${channel}/binary-${ARCH}/Packages.gz"
+      code=$(http_code "$pkg_url")
+
+      if [[ "$code" == "404" ]]; then
+        if [[ "$STRICT" == 1 ]]; then
+          report "FAIL" "${repo} ${codename}/${channel}" "component missing (HTTP 404)"
+        else
+          report "SKIP" "${repo} ${codename}/${channel}" "component not present"
+        fi
+        continue
+      fi
+
+      if [[ "$code" != "200" ]]; then
+        report "FAIL" "${repo} ${codename}/${channel}" "HTTP $code"
+        continue
+      fi
+
+      count=$(curl -sSL --max-time "$TIMEOUT" "$pkg_url" 2>/dev/null \
+        | gunzip 2>/dev/null \
+        | grep -c '^Package: ' || true)
+
+      if [[ -z "$count" || "$count" == "0" ]]; then
+        report "FAIL" "${repo} ${codename}/${channel}" "index is empty or not valid gzip"
+      else
+        report "OK" "${repo} ${codename}/${channel}" "${count} packages"
+      fi
+    done
+  done
+done
+
+echo "------------------------------------------------------------------------------------"
+
+for image in "${IMAGE_LIST[@]}"; do
+  api="https://hub.docker.com/v2/repositories/${DOCKER_REPO}/${image}/tags?page_size=1"
+  body=$(curl -sSL --max-time "$TIMEOUT" "$api" 2>/dev/null || echo "")
+
+  if [[ -z "$body" ]]; then
+    report "FAIL" "docker ${DOCKER_REPO}/${image}" "registry did not answer"
+    continue
+  fi
+
+  # "count" is the number of tags the registry reports for the repository.
+  count=$(echo "$body" | tr ',' '\n' | grep -m1 '"count"' | grep -oE '[0-9]+' || true)
+
+  if [[ -z "$count" ]]; then
+    report "FAIL" "docker ${DOCKER_REPO}/${image}" "unexpected registry answer"
+  elif [[ "$count" == "0" ]]; then
+    report "FAIL" "docker ${DOCKER_REPO}/${image}" "repository holds no tags"
+  else
+    report "OK" "docker ${DOCKER_REPO}/${image}" "${count} tags"
+  fi
+done
+
+echo "===================================================================================="
+echo "checks=${CHECKS} failures=${FAILURES}"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "Infrastructure check FAILED"
+  exit 1
+fi
+
+echo "Infrastructure check OK"
+exit 0

--- a/scripts/verify/test-release.sh
+++ b/scripts/verify/test-release.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+
+# Test published Mina Debian packages and Docker images across distribution codenames.
+#
+# For each package it starts a clean container of the matching base image, adds the
+# apt repository, installs the package at an exact version and runs a check that
+# suits that package. For each Docker image it pulls the image and runs the same
+# check inside it.
+#
+# The check is chosen by package kind, not by name alone, because the artifacts do
+# not all provide the same binaries:
+#
+#   daemon      /usr/local/bin/mina, plus config_<hash>.json matching the binary
+#   archive     mina-archive
+#   rosetta     mina-rosetta and mina-ocaml-signer (the deb ships no mina binary;
+#               the docker image does, and is then checked for it too)
+#   logproc     mina-logproc
+#   payload     a runtime-only package: /usr/lib/mina/<runtime>/mina, no mina on PATH
+#   dispatcher  /usr/local/bin/mina is the automode dispatcher, which needs
+#               MINA_HARDFORK_STATE_DIR before it will run
+#   config      configuration only, no binaries
+#
+# Applying the daemon check to a payload or rosetta package produces a failure that
+# says nothing about the package. This script avoids that class of false result.
+#
+# Usage:
+#   ./scripts/verify/test-release.sh --packages mina-devnet=3.5.0-x,mina-logproc=3.5.0-x
+#   ./scripts/verify/test-release.sh --list --channel alpha
+#   ./scripts/verify/test-release.sh --automode mina-devnet-automode=4.0.0-x
+
+set -eo pipefail
+
+REPO=packages.o1test.net
+CHANNEL=alpha
+DOCKER_REPO=minaprotocol
+DOCKER_SUFFIX="-devnet"
+CODENAMES="bullseye,focal,noble,jammy,bookworm"
+ARCH=amd64
+JOBS=4
+PACKAGES=""
+IMAGES=""
+AUTOMODE=""
+OUTDIR=""
+SIGNED=0
+LIST_ONLY=0
+
+function usage() {
+  if [[ -n "$1" ]]; then echo "ERROR: $1"; echo; fi
+  echo "Usage: $0 [options]"
+  echo
+  echo "  -p, --packages    Comma list of debian packages as name=version"
+  echo "  -i, --images      Comma list of docker images as name=version"
+  echo "  -a, --automode    Automode metapackage as name=version. Installs it with no"
+  echo "                    version pin and checks both runtimes, the genesis config"
+  echo "                    and the dispatcher. This is the operator-facing test."
+  echo "  -m, --codenames   Comma list of codenames (default: $CODENAMES)"
+  echo "  -c, --channel     Debian channel/component (default: $CHANNEL)"
+  echo "  -r, --repo        Debian repository host (default: $REPO)"
+  echo "      --docker-repo Docker registry namespace (default: $DOCKER_REPO)"
+  echo "      --suffix      Docker tag suffix after the codename (default: $DOCKER_SUFFIX)"
+  echo "      --arch        Architecture (default: $ARCH)"
+  echo "  -j, --jobs        Containers to run at once (default: $JOBS)"
+  echo "  -o, --output      Directory for logs (default: a mktemp directory)"
+  echo "  -s, --signed      Use the repository signing key instead of [trusted=yes]"
+  echo "  -l, --list        Only list what the channel holds, then exit"
+  echo "  -h, --help        This message"
+  echo
+  echo "Exit code is 1 if any case fails. Cases that cannot apply are reported as SKIP"
+  echo "and do not fail the run."
+  echo
+  echo "Examples:"
+  echo "  $0 --list --channel alpha --codenames bullseye"
+  echo "  $0 --packages mina-devnet=3.5.0-devnet-stop-slot-98e7835 \\"
+  echo "     --images mina-daemon=3.5.0-devnet-stop-slot-98e7835 \\"
+  echo "     --automode mina-devnet-automode=4.0.0-devnet-ca2ccb1"
+  exit 1
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  -p|--packages) PACKAGES="$2"; shift;;
+  -i|--images) IMAGES="$2"; shift;;
+  -a|--automode) AUTOMODE="$2"; shift;;
+  -m|--codenames) CODENAMES="$2"; shift;;
+  -c|--channel) CHANNEL="$2"; shift;;
+  -r|--repo) REPO="$2"; shift;;
+  --docker-repo) DOCKER_REPO="$2"; shift;;
+  --suffix) DOCKER_SUFFIX="$2"; shift;;
+  --arch) ARCH="$2"; shift;;
+  -j|--jobs) JOBS="$2"; shift;;
+  -o|--output) OUTDIR="$2"; shift;;
+  -s|--signed) SIGNED=1;;
+  -l|--list) LIST_ONLY=1;;
+  -h|--help) usage "";;
+  *) usage "Unknown parameter: $1";;
+esac; shift; done
+
+if ! command -v docker > /dev/null; then usage "docker is required but not installed"; fi
+
+if [[ -z "$OUTDIR" ]]; then OUTDIR=$(mktemp -d "${TMPDIR:-/tmp}/mina-test-release.XXXXXX"); fi
+mkdir -p "$OUTDIR/logs"
+RESULTS="$OUTDIR/results.tsv"
+: > "$RESULTS"
+
+# Base image for a codename. Debian and Ubuntu codenames are not interchangeable.
+function base_image() {
+  case "$1" in
+    bullseye|bookworm) echo "debian:$1" ;;
+    focal|noble|jammy) echo "ubuntu:$1" ;;
+    *) echo "" ;;
+  esac
+}
+
+# Package kind, which decides the check. Order matters: the automode and postfork
+# packages own the dispatcher, so they must be matched before the generic daemon rule.
+function package_kind() {
+  case "$1" in
+    *-automode|*-postfork-*)  echo "dispatcher" ;;
+    *-prefork-*)              echo "payload" ;;
+    *-config)                 echo "config" ;;
+    mina-archive*)            echo "archive" ;;
+    mina-rosetta*)            echo "rosetta" ;;
+    mina-logproc)             echo "logproc" ;;
+    mina-daemon)              echo "daemon" ;;
+    mina-*)                   echo "daemon" ;;
+    *)                        echo "unknown" ;;
+  esac
+}
+
+function record() {
+  # status <tab> area <tab> codename <tab> target <tab> detail
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$RESULTS"
+}
+
+# ---------------------------------------------------------------------------
+# The in-container checker. It is written once and mounted read-only into every
+# container, so the same logic runs for debians and for docker images.
+# ---------------------------------------------------------------------------
+
+CHECKER="$OUTDIR/container-check.sh"
+cat > "$CHECKER" <<'CHECKER_EOF'
+#!/usr/bin/env bash
+# Args: <kind> <context: deb|docker> [package] [strict_runtimes: yes|no]
+#
+# strict_runtimes applies to the dispatcher kind only. The automode metapackage
+# pulls in both runtimes, so it is checked with "yes" and must have both. A bare
+# postfork package ships the post-fork runtime alone and relies on the metapackage
+# to bring the pre-fork one, so it is checked with "no": a missing pre-fork runtime
+# is then reported as a warning about the installation, not a fault in the package.
+set -uo pipefail
+
+KIND="$1"
+CONTEXT="$2"
+PKG="${3:-}"
+STRICT_RUNTIMES="${4:-no}"
+rc=0
+
+function fail() { echo "CHECK-FAIL: $*"; rc=1; }
+function ok()   { echo "CHECK-OK: $*"; }
+
+function binary_runs() {
+  local bin="$1"
+  if ! command -v "$bin" > /dev/null 2>&1 && [[ ! -x "$bin" ]]; then
+    fail "$bin is not installed"
+    return 1
+  fi
+  if ! "$bin" --version > /tmp/ver.out 2>&1; then
+    fail "$bin --version exited non-zero: $(head -1 /tmp/ver.out)"
+    return 1
+  fi
+  ok "$bin --version -> $(head -1 /tmp/ver.out)"
+  return 0
+}
+
+# The daemon auto-loads /var/lib/coda/config_<hash>.json, where <hash> is the short
+# commit of the daemon that should read it. A mismatch means the package pair was
+# built against a different commit than the one installed.
+function config_matches() {
+  local commit="$1"
+  local cfg
+  cfg=$(ls /var/lib/coda/config_*.json 2>/dev/null | head -1)
+  if [[ -z "$cfg" ]]; then
+    echo "CHECK-INFO: no genesis config shipped, skipping config match"
+    return 0
+  fi
+  local hash
+  hash=$(basename "$cfg" | sed 's/config_\(.*\)\.json/\1/')
+  if [[ "${commit:0:${#hash}}" == "$hash" ]]; then
+    ok "genesis config $(basename "$cfg") matches commit ${commit:0:8}"
+  else
+    fail "genesis config $(basename "$cfg") does not match commit ${commit:0:8}"
+  fi
+}
+
+function commit_of() {
+  "$1" --version 2>&1 | grep -oE '[a-f0-9]{40}' | head -1
+}
+
+case "$KIND" in
+  daemon)
+    binary_runs mina && config_matches "$(commit_of mina)"
+    ;;
+
+  archive)
+    binary_runs mina-archive
+    ;;
+
+  rosetta)
+    binary_runs mina-rosetta
+    binary_runs mina-ocaml-signer
+    # The deb ships no mina or mina-archive. The docker image does. Check them only
+    # where they exist, so the deb is not failed for something it never shipped.
+    if [[ "$CONTEXT" == "docker" ]]; then
+      binary_runs mina
+      binary_runs mina-archive
+    else
+      for extra in mina mina-archive; do
+        if command -v "$extra" > /dev/null 2>&1; then
+          echo "CHECK-INFO: $extra present in the deb (not required)"
+        fi
+      done
+    fi
+    ;;
+
+  logproc)
+    if ! command -v mina-logproc > /dev/null 2>&1; then
+      fail "mina-logproc is not installed"
+    else
+      ok "mina-logproc is installed at $(command -v mina-logproc)"
+    fi
+    ;;
+
+  payload)
+    # A runtime-only package. It must not put mina on PATH; it must ship a runtime.
+    found=0
+    for rt in /usr/lib/mina/*/; do
+      [[ -x "${rt}mina" ]] || continue
+      found=1
+      if v=$("${rt}mina" --version 2>&1); then
+        ok "runtime $(basename "$rt") -> $(echo "$v" | head -1)"
+      else
+        fail "runtime $(basename "$rt") mina --version failed"
+      fi
+    done
+    [[ "$found" == 1 ]] || fail "no runtime found under /usr/lib/mina/"
+    if command -v mina > /dev/null 2>&1; then
+      echo "CHECK-INFO: mina is on PATH; this package usually provides none"
+    fi
+    ;;
+
+  dispatcher)
+    [[ -x /usr/local/bin/mina ]] || fail "/usr/local/bin/mina is missing"
+
+    # Inventory the runtimes first. What the dispatcher can do depends on which of
+    # them are installed, so the checks below have to know before they judge.
+    pre=""; post=""
+    for rt in /usr/lib/mina/*/; do
+      [[ -x "${rt}mina" ]] || continue
+      c=$(commit_of "${rt}mina")
+      if [[ -z "$c" ]]; then
+        fail "runtime $(basename "$rt") reports no commit"
+      else
+        ok "runtime $(basename "$rt") = ${c:0:8}"
+      fi
+      case "$(basename "$rt")" in
+        berkeley) pre="$c" ;;
+        *) post="$c" ;;
+      esac
+    done
+
+    if [[ "$STRICT_RUNTIMES" == "yes" ]]; then
+      [[ -n "$pre" ]]  || fail "no pre-fork (berkeley) runtime installed"
+      [[ -n "$post" ]] || fail "no post-fork runtime installed"
+      # Two identical runtimes mean the wrong deb pair was installed and the
+      # hardfork cannot happen, even though every other check would pass.
+      if [[ -n "$pre" && "$pre" == "$post" ]]; then
+        fail "both runtimes report the same commit ${pre:0:8}; the deb pair is wrong"
+      fi
+    else
+      [[ -n "$post" ]] || fail "no post-fork runtime installed"
+      if [[ -z "$pre" ]]; then
+        echo "CHECK-WARN: no pre-fork runtime installed, so the dispatcher cannot select one; install the automode metapackage for a working mina"
+      fi
+    fi
+
+    # The dispatcher documents --version as a pass-through to the runtime, but it
+    # stops at its environment guard first. Report the bare call, then require the
+    # supported call to work whenever the runtime it would select is present.
+    if [[ -x /usr/local/bin/mina ]]; then
+      if ! mina --version > /tmp/bare.out 2>&1; then
+        echo "CHECK-WARN: mina --version fails without MINA_HARDFORK_STATE_DIR: $(head -1 /tmp/bare.out)"
+      else
+        ok "mina --version works without MINA_HARDFORK_STATE_DIR"
+      fi
+
+      if [[ -n "$pre" ]]; then
+        export MINA_HARDFORK_STATE_DIR="${MINA_HARDFORK_STATE_DIR:-/root/.mina-config}"
+        binary_runs mina
+      fi
+    fi
+
+    # The genesis config the post-fork package ships belongs to the pre-fork
+    # runtime, because that is the one that runs first. Check it only when that
+    # runtime is actually installed, or the comparison has nothing to compare to.
+    if [[ -n "$pre" ]]; then
+      config_matches "$pre"
+    fi
+    ;;
+
+  config)
+    if ls /var/lib/coda/*.json > /dev/null 2>&1 || ls /etc/mina* > /dev/null 2>&1; then
+      ok "configuration files present"
+    else
+      fail "package $PKG shipped no configuration"
+    fi
+    ;;
+
+  *)
+    echo "CHECK-INFO: no check defined for kind '$KIND', install-only"
+    ;;
+esac
+
+exit $rc
+CHECKER_EOF
+chmod +x "$CHECKER"
+
+# ---------------------------------------------------------------------------
+# Debian setup, run inside the container before the checker.
+# ---------------------------------------------------------------------------
+
+SETUP="$OUTDIR/container-setup.sh"
+cat > "$SETUP" <<'SETUP_EOF'
+#!/usr/bin/env bash
+# Args: <package> <version> <repo> <codename> <channel> <signed>
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+
+PACKAGE="$1"; VERSION="$2"; REPO="$3"; CODENAME="$4"; CHANNEL="$5"; SIGNED="$6"
+
+apt-get update -qq
+apt-get install -y -qq ca-certificates wget gnupg > /dev/null
+
+if [[ "$SIGNED" == "1" ]]; then
+  wget -q "https://${REPO}/repo-signing-key.gpg" -O /etc/apt/trusted.gpg.d/minaprotocol.gpg
+  echo "deb https://${REPO} ${CODENAME} ${CHANNEL}" > /etc/apt/sources.list.d/mina.list
+else
+  echo "deb [trusted=yes] https://${REPO} ${CODENAME} ${CHANNEL}" > /etc/apt/sources.list.d/mina.list
+fi
+apt-get update -qq
+
+echo "INSTALL: apt-get install ${PACKAGE}=${VERSION}"
+if [[ "$VERSION" == "any" ]]; then
+  apt-get install -y "${PACKAGE}"
+else
+  apt-get install -y --allow-downgrades "${PACKAGE}=${VERSION}"
+fi
+echo "INSTALL-OK"
+SETUP_EOF
+chmod +x "$SETUP"
+
+# ---------------------------------------------------------------------------
+# List mode
+# ---------------------------------------------------------------------------
+
+if [[ "$LIST_ONLY" == 1 ]]; then
+  IFS=',' read -ra CN_LIST <<< "$CODENAMES"
+  for cn in "${CN_LIST[@]}"; do
+    echo "=== $cn / $CHANNEL / $ARCH"
+    curl -sL "https://${REPO}/dists/${cn}/${CHANNEL}/binary-${ARCH}/Packages.gz" \
+      | gunzip 2>/dev/null \
+      | awk '/^Package: /{p=$2} /^Version: /{printf "  %-32s %s\n", p, $2}' \
+      | sort -u
+  done
+  exit 0
+fi
+
+if [[ -z "$PACKAGES" && -z "$IMAGES" && -z "$AUTOMODE" ]]; then
+  usage "Nothing to test. Pass --packages, --images or --automode."
+fi
+
+# ---------------------------------------------------------------------------
+# Case runners. Each writes one line to the results file.
+# ---------------------------------------------------------------------------
+
+function run_deb_case() {
+  local cn="$1" pkg="$2" ver="$3"
+  local img kind log
+  img=$(base_image "$cn")
+  kind=$(package_kind "$pkg")
+  log="$OUTDIR/logs/deb__${cn}__${pkg}.log"
+
+  if [[ -z "$img" ]]; then
+    record "SKIP" "debian" "$cn" "$pkg" "unknown codename"
+    return 0
+  fi
+
+  if docker run --rm --platform "linux/$ARCH" \
+      -v "$SETUP:/mina/setup.sh:ro" -v "$CHECKER:/mina/check.sh:ro" \
+      "$img" \
+      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' && bash /mina/check.sh '$kind' deb '$pkg' no" \
+      > "$log" 2>&1; then
+    local warn
+    warn=$(grep -c "CHECK-WARN" "$log" || true)
+    if [[ "$warn" -gt 0 ]]; then
+      record "WARN" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
+    else
+      record "PASS" "debian" "$cn" "$pkg" "kind=$kind"
+    fi
+  else
+    local reason
+    if grep -q "unmet dependencies" "$log"; then
+      reason=$(grep -A2 "unmet dependencies" "$log" | tail -1 | sed 's/^ *//')
+      record "FAIL" "debian" "$cn" "$pkg" "install: $reason"
+    elif grep -q "CHECK-FAIL" "$log"; then
+      record "FAIL" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13-)"
+    else
+      record "FAIL" "debian" "$cn" "$pkg" "see $(basename "$log")"
+    fi
+  fi
+}
+
+function run_docker_case() {
+  local cn="$1" image="$2" ver="$3"
+  local tag kind log
+  tag="${DOCKER_REPO}/${image}:${ver}-${cn}${DOCKER_SUFFIX}"
+  case "$image" in
+    mina-daemon*)  kind="daemon" ;;
+    mina-archive*) kind="archive" ;;
+    mina-rosetta*) kind="rosetta" ;;
+    *)             kind=$(package_kind "$image") ;;
+  esac
+  log="$OUTDIR/logs/docker__${cn}__${image}.log"
+
+  if ! docker manifest inspect "$tag" > /dev/null 2>&1; then
+    record "FAIL" "docker" "$cn" "$image" "tag does not exist: $tag"
+    return 0
+  fi
+
+  if docker run --rm --platform "linux/$ARCH" --entrypoint bash \
+      -v "$CHECKER:/mina/check.sh:ro" "$tag" /mina/check.sh "$kind" docker "$image" \
+      > "$log" 2>&1; then
+    record "PASS" "docker" "$cn" "$image" "kind=$kind"
+  else
+    record "FAIL" "docker" "$cn" "$image" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
+  fi
+}
+
+# The operator-facing test: install the metapackage with no version pin. If the
+# channel holds a higher version of a strictly pinned dependency, this fails even
+# though every individual package is sound.
+function run_automode_case() {
+  local cn="$1" pkg="$2" ver="$3"
+  local img log
+  img=$(base_image "$cn")
+  log="$OUTDIR/logs/automode__${cn}.log"
+
+  if docker run --rm --platform "linux/$ARCH" \
+      -v "$SETUP:/mina/setup.sh:ro" -v "$CHECKER:/mina/check.sh:ro" \
+      "$img" \
+      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' && bash /mina/check.sh dispatcher deb '$pkg' yes" \
+      > "$log" 2>&1; then
+    local warn
+    warn=$(grep -c "CHECK-WARN" "$log" || true)
+    if [[ "$warn" -gt 0 ]]; then
+      record "WARN" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
+    else
+      record "PASS" "automode" "$cn" "$pkg" "unpinned install and both runtimes"
+    fi
+  else
+    if grep -q "unmet dependencies" "$log"; then
+      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(grep -A2 'unmet dependencies' "$log" | tail -1 | sed 's/^ *//')"
+    else
+      record "FAIL" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
+    fi
+  fi
+}
+
+export -f run_deb_case run_docker_case run_automode_case base_image package_kind record
+export OUTDIR RESULTS SETUP CHECKER REPO CHANNEL ARCH SIGNED DOCKER_REPO DOCKER_SUFFIX
+
+# ---------------------------------------------------------------------------
+# Build the work list and run it
+# ---------------------------------------------------------------------------
+
+WORK="$OUTDIR/work.txt"
+: > "$WORK"
+
+IFS=',' read -ra CN_LIST <<< "$CODENAMES"
+
+if [[ -n "$PACKAGES" ]]; then
+  IFS=',' read -ra PKG_LIST <<< "$PACKAGES"
+  for cn in "${CN_LIST[@]}"; do
+    for spec in "${PKG_LIST[@]}"; do
+      printf 'run_deb_case %s %s %s\n' "$cn" "${spec%%=*}" "${spec#*=}" >> "$WORK"
+    done
+  done
+fi
+
+if [[ -n "$IMAGES" ]]; then
+  IFS=',' read -ra IMG_LIST <<< "$IMAGES"
+  for cn in "${CN_LIST[@]}"; do
+    for spec in "${IMG_LIST[@]}"; do
+      printf 'run_docker_case %s %s %s\n' "$cn" "${spec%%=*}" "${spec#*=}" >> "$WORK"
+    done
+  done
+fi
+
+if [[ -n "$AUTOMODE" ]]; then
+  for cn in "${CN_LIST[@]}"; do
+    printf 'run_automode_case %s %s %s\n' "$cn" "${AUTOMODE%%=*}" "${AUTOMODE#*=}" >> "$WORK"
+  done
+fi
+
+TOTAL=$(wc -l < "$WORK")
+echo "Running $TOTAL cases, $JOBS at a time. Logs: $OUTDIR/logs"
+echo
+
+# shellcheck disable=SC2016
+xargs -a "$WORK" -P "$JOBS" -n 4 bash -c '"$0" "$1" "$2" "$3"' || true
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "===================================================================="
+printf '%-9s %-9s %-10s %-28s %s\n' "STATUS" "AREA" "CODENAME" "TARGET" "DETAIL"
+echo "--------------------------------------------------------------------"
+sort -k2,2 -k4,4 -k3,3 "$RESULTS" | while IFS=$'\t' read -r st area cn target detail; do
+  printf '%-9s %-9s %-10s %-28s %s\n' "$st" "$area" "$cn" "$target" "$detail"
+done
+echo "--------------------------------------------------------------------"
+
+PASS=$(grep -c '^PASS' "$RESULTS" || true)
+WARN=$(grep -c '^WARN' "$RESULTS" || true)
+FAILED=$(grep -c '^FAIL' "$RESULTS" || true)
+SKIPPED=$(grep -c '^SKIP' "$RESULTS" || true)
+
+echo "PASS $PASS   WARN $WARN   FAIL $FAILED   SKIP $SKIPPED   (of $TOTAL)"
+echo "Results: $RESULTS"
+echo "Logs:    $OUTDIR/logs"
+
+if [[ "$FAILED" -gt 0 ]]; then
+  echo
+  echo "Failures:"
+  grep '^FAIL' "$RESULTS" | while IFS=$'\t' read -r _ area cn target detail; do
+    echo "  $area $cn $target: $detail"
+  done
+  exit 1
+fi
+
+exit 0

--- a/scripts/verify/test-release.sh
+++ b/scripts/verify/test-release.sh
@@ -127,6 +127,43 @@ function package_kind() {
   esac
 }
 
+# Runtime libraries a package needs but does not declare in its control file.
+#
+# The rosetta deb is built with the shared dependencies alone, so its Depends
+# names none of jemalloc, libpq or libffi, although both binaries it ships link
+# against all three:
+#
+#   ldd mina-rosetta -> libjemalloc.so.2, libpq.so.5, libffi.so.7
+#
+# In a clean container the binary therefore stops at the first of them:
+#
+#   error while loading shared libraries: libjemalloc.so.2
+#
+# That is a known packaging defect and it is not fixed yet. Installing the
+# libraries before the package keeps this test on the question it can answer,
+# which is whether the published binary itself runs. The docker image ships them
+# already, which is why the same check passes there.
+#
+# libffi comes in under two names, as in the daemon dependencies in
+# scripts/debian/builder-helpers.sh: libffi7 on bullseye and focal, libffi8 on
+# the newer codenames. It is usually pulled in anyway by wget or gnupg, but that
+# is a side effect of another package and not something to depend on.
+#
+# Remove the rosetta entry when the deb declares these libraries itself.
+function extra_deps() {
+  local kind="$1" codename="$2" ffi
+
+  case "$codename" in
+    bullseye|focal) ffi=libffi7 ;;
+    *)              ffi=libffi8 ;;
+  esac
+
+  case "$kind" in
+    rosetta) echo "libjemalloc2 libpq5 $ffi" ;;
+    *)       echo "" ;;
+  esac
+}
+
 # A spec is "name=version" or a bare "name". A bare name means "whatever the
 # channel offers right now", which is what a recurring schedule wants: it never
 # needs editing after a release, and it tests what a user would actually get.
@@ -135,24 +172,6 @@ function spec_version() {
     *=*) echo "${1#*=}" ;;
     *)   echo "any" ;;
   esac
-}
-
-# apt prints the useful line between its header and its own generic verdict:
-#
-#   The following packages have unmet dependencies:
-#    mina-devnet-automode : Depends: mina-devnet-prefork-mesa (= X) but Y is to be installed
-#   E: Unable to correct problems, you have held broken packages.
-#
-# Report the middle line. The trailing "E:" line names no package, and reporting
-# that instead is what made a failed scheduled run impossible to diagnose once
-# the container was gone.
-function dependency_reason() {
-  local log="$1" line
-  line=$(grep -A8 "unmet dependencies" "$log" | grep -m1 "Depends:" | sed 's/^ *//')
-  if [[ -z "$line" ]]; then
-    line=$(grep -m1 "^E: " "$log" | sed 's/^ *//')
-  fi
-  echo "${line:-see the job log}"
 }
 
 function record() {
@@ -359,11 +378,16 @@ chmod +x "$CHECKER"
 SETUP="$OUTDIR/container-setup.sh"
 cat > "$SETUP" <<'SETUP_EOF'
 #!/usr/bin/env bash
-# Args: <package> <version> <repo> <codename> <channel> <signed>
+# Args: <package> <version> <repo> <codename> <channel> <signed> [extra deps]
+#
+# extra_deps is a space separated list of distribution packages to install first.
+# It carries the runtime libraries that a mina package needs but does not declare.
+# See extra_deps() in the calling script for why each one is there.
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
 
 PACKAGE="$1"; VERSION="$2"; REPO="$3"; CODENAME="$4"; CHANNEL="$5"; SIGNED="$6"
+EXTRA_DEPS="${7:-}"
 
 apt-get update -qq
 apt-get install -y -qq ca-certificates wget gnupg > /dev/null
@@ -375,6 +399,14 @@ else
   echo "deb [trusted=yes] https://${REPO} ${CODENAME} ${CHANNEL}" > /etc/apt/sources.list.d/mina.list
 fi
 apt-get update -qq
+
+# Undeclared runtime libraries, installed before the package so that the check
+# reports on the mina binary and not on a dependency the control file omits.
+if [[ -n "$EXTRA_DEPS" ]]; then
+  echo "PREREQ: apt-get install ${EXTRA_DEPS}"
+  # shellcheck disable=SC2086
+  apt-get install -y -qq $EXTRA_DEPS > /dev/null
+fi
 
 # "any" installs whatever the channel currently offers, which is exactly what a
 # user gets from "apt-get install <package>". A recurring job should use it, so
@@ -420,10 +452,16 @@ fi
 
 function run_deb_case() {
   local cn="$1" pkg="$2" ver="$3"
-  local img kind log
+  local img kind log extra note
   img=$(base_image "$cn")
   kind=$(package_kind "$pkg")
+  extra=$(extra_deps "$kind" "$cn")
   log="$OUTDIR/logs/deb__${cn}__${pkg}.log"
+
+  # Say in the report which libraries the test had to add, so a pass here is not
+  # read as "the package declares everything it needs".
+  note="kind=$kind"
+  if [[ -n "$extra" ]]; then note="$note, prereq=${extra// /+}"; fi
 
   if [[ -z "$img" ]]; then
     record "SKIP" "debian" "$cn" "$pkg" "unknown codename"
@@ -433,7 +471,7 @@ function run_deb_case() {
   if docker run --rm --platform "linux/$ARCH" \
       -v "$SETUP:/mina/setup.sh:ro" -v "$CHECKER:/mina/check.sh:ro" \
       "$img" \
-      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' && bash /mina/check.sh '$kind' deb '$pkg' no" \
+      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' '$extra' && bash /mina/check.sh '$kind' deb '$pkg' no" \
       > "$log" 2>&1; then
     local warn installed
     warn=$(grep -c "CHECK-WARN" "$log" || true)
@@ -441,12 +479,12 @@ function run_deb_case() {
     if [[ "$warn" -gt 0 ]]; then
       record "WARN" "debian" "$cn" "$pkg" "${installed:-?} :: $(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
     else
-      record "PASS" "debian" "$cn" "$pkg" "${installed:-?} (kind=$kind)"
+      record "PASS" "debian" "$cn" "$pkg" "${installed:-?} ($note)"
     fi
   else
     local reason
     if grep -q "unmet dependencies" "$log"; then
-      reason=$(dependency_reason "$log")
+      reason=$(grep -A2 "unmet dependencies" "$log" | tail -1 | sed 's/^ *//')
       record "FAIL" "debian" "$cn" "$pkg" "install: $reason"
     elif grep -q "CHECK-FAIL" "$log"; then
       record "FAIL" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13-)"
@@ -505,14 +543,14 @@ function run_automode_case() {
     fi
   else
     if grep -q "unmet dependencies" "$log"; then
-      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(dependency_reason "$log")"
+      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(grep -A2 'unmet dependencies' "$log" | tail -1 | sed 's/^ *//')"
     else
       record "FAIL" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
     fi
   fi
 }
 
-export -f run_deb_case run_docker_case run_automode_case base_image package_kind record
+export -f run_deb_case run_docker_case run_automode_case base_image package_kind extra_deps record
 export OUTDIR RESULTS SETUP CHECKER REPO CHANNEL ARCH SIGNED DOCKER_REPO DOCKER_SUFFIX
 
 # ---------------------------------------------------------------------------

--- a/scripts/verify/test-release.sh
+++ b/scripts/verify/test-release.sh
@@ -48,11 +48,16 @@ function usage() {
   if [[ -n "$1" ]]; then echo "ERROR: $1"; echo; fi
   echo "Usage: $0 [options]"
   echo
-  echo "  -p, --packages    Comma list of debian packages as name=version, or a bare"
-  echo "                    name to test whatever the channel currently offers"
-  echo "  -i, --images      Comma list of docker images as name=version"
-  echo "  -a, --automode    Automode metapackage as name=version. Installs it with no"
-  echo "                    version pin and checks both runtimes, the genesis config"
+  echo "  -p, --packages    Comma list of debian packages as name[=version][@channel]."
+  echo "                    A bare name tests whatever the channel currently offers;"
+  echo "                    @channel overrides --channel per entry, which is how one"
+  echo "                    run covers devnet (alpha) and mainnet (stable) together."
+  echo "  -i, --images      Comma list of docker images as name=version[:network]."
+  echo "                    The network is the last segment of the tag and defaults"
+  echo "                    to --suffix. A version is always required."
+  echo "  -a, --automode    Comma list of automode metapackages, same syntax as"
+  echo "                    --packages. Installs each with no version pin and checks"
+  echo "                    both runtimes, the genesis config"
   echo "                    and the dispatcher. This is the operator-facing test."
   echo "  -m, --codenames   Comma list of codenames (default: $CODENAMES)"
   echo "  -c, --channel     Debian channel/component (default: $CHANNEL)"
@@ -71,9 +76,9 @@ function usage() {
   echo
   echo "Examples:"
   echo "  $0 --list --channel alpha --codenames bullseye"
-  echo "  $0 --packages mina-devnet=3.5.0-devnet-stop-slot-98e7835 \\"
-  echo "     --images mina-daemon=3.5.0-devnet-stop-slot-98e7835 \\"
-  echo "     --automode mina-devnet-automode=4.0.0-devnet-ca2ccb1"
+  echo "  $0 --packages mina-devnet,mina-mainnet@stable \\"
+  echo "     --images mina-daemon=3.5.0-x:devnet,mina-daemon=3.4.0-y:mainnet \\"
+  echo "     --automode mina-devnet-automode,mina-mainnet-automode@stable"
   exit 1
 }
 
@@ -164,14 +169,71 @@ function extra_deps() {
   esac
 }
 
-# A spec is "name=version" or a bare "name". A bare name means "whatever the
-# channel offers right now", which is what a recurring schedule wants: it never
-# needs editing after a release, and it tests what a user would actually get.
+# A package spec is "name[=version][@channel]".
+#
+# A bare name means "whatever the channel offers right now", which is what a
+# recurring schedule wants: it never needs editing after a release, and it tests
+# what a user would actually get. The optional @channel matters because the two
+# networks do not live together -- devnet artifacts sit in alpha while mainnet
+# ones sit in stable -- so tracking both in one run needs a channel per entry.
+#
+#   mina-devnet                     -> current alpha version   (default channel)
+#   mina-mainnet@stable             -> current stable version
+#   mina-devnet=3.5.0-x             -> that exact version
+#   mina-mainnet=3.4.0-y@stable     -> that exact version from stable
+function spec_name() {
+  local s="${1%%@*}"
+  echo "${s%%=*}"
+}
+
 function spec_version() {
-  case "$1" in
-    *=*) echo "${1#*=}" ;;
+  local s="${1%%@*}"
+  case "$s" in
+    *=*) echo "${s#*=}" ;;
     *)   echo "any" ;;
   esac
+}
+
+function spec_channel() {
+  case "$1" in
+    *@*) echo "${1##*@}" ;;
+    *)   echo "$CHANNEL" ;;
+  esac
+}
+
+# An image spec is "name=version[:network]". The network is the last segment of
+# the docker tag, "<version>-<codename>-<network>", so it has to vary per entry
+# to cover devnet and mainnet in a single run. A version is always required: a
+# tag has no channel to resolve against.
+function image_version() {
+  local v="${1#*=}"
+  echo "${v%%:*}"
+}
+
+function image_network() {
+  local v="${1#*=}"
+  case "$v" in
+    *:*) echo "${v##*:}" ;;
+    *)   echo "${DOCKER_SUFFIX#-}" ;;
+  esac
+}
+
+# apt prints the useful line between its header and its own generic verdict:
+#
+#   The following packages have unmet dependencies:
+#    mina-devnet-automode : Depends: mina-devnet-prefork-mesa (= X) but Y is to be installed
+#   E: Unable to correct problems, you have held broken packages.
+#
+# Report the middle line. The trailing "E:" line names no package, and reporting
+# that instead is what made a failed scheduled run impossible to diagnose once
+# the container was gone.
+function dependency_reason() {
+  local log="$1" line
+  line=$(grep -A8 "unmet dependencies" "$log" | grep -m1 "Depends:" | sed 's/^ *//')
+  if [[ -z "$line" ]]; then
+    line=$(grep -m1 "^E: " "$log" | sed 's/^ *//')
+  fi
+  echo "${line:-see the job log}"
 }
 
 function record() {
@@ -451,12 +513,13 @@ fi
 # ---------------------------------------------------------------------------
 
 function run_deb_case() {
-  local cn="$1" pkg="$2" ver="$3"
-  local img kind log extra note
+  local cn="$1" pkg="$2" ver="$3" chan="$4"
+  local img kind log extra note target
   img=$(base_image "$cn")
   kind=$(package_kind "$pkg")
   extra=$(extra_deps "$kind" "$cn")
-  log="$OUTDIR/logs/deb__${cn}__${pkg}.log"
+  log="$OUTDIR/logs/deb__${cn}__${pkg}__${chan}.log"
+  target="${pkg}@${chan}"
 
   # Say in the report which libraries the test had to add, so a pass here is not
   # read as "the package declares everything it needs".
@@ -464,59 +527,60 @@ function run_deb_case() {
   if [[ -n "$extra" ]]; then note="$note, prereq=${extra// /+}"; fi
 
   if [[ -z "$img" ]]; then
-    record "SKIP" "debian" "$cn" "$pkg" "unknown codename"
+    record "SKIP" "debian" "$cn" "$target" "unknown codename"
     return 0
   fi
 
   if docker run --rm --platform "linux/$ARCH" \
       -v "$SETUP:/mina/setup.sh:ro" -v "$CHECKER:/mina/check.sh:ro" \
       "$img" \
-      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' '$extra' && bash /mina/check.sh '$kind' deb '$pkg' no" \
+      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$chan' '$SIGNED' '$extra' && bash /mina/check.sh '$kind' deb '$pkg' no" \
       > "$log" 2>&1; then
     local warn installed
     warn=$(grep -c "CHECK-WARN" "$log" || true)
     installed=$(grep -m1 'INSTALLED-VERSION:' "$log" | cut -d' ' -f2- || true)
     if [[ "$warn" -gt 0 ]]; then
-      record "WARN" "debian" "$cn" "$pkg" "${installed:-?} :: $(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
+      record "WARN" "debian" "$cn" "$target" "${installed:-?} :: $(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
     else
-      record "PASS" "debian" "$cn" "$pkg" "${installed:-?} ($note)"
+      record "PASS" "debian" "$cn" "$target" "${installed:-?} ($note)"
     fi
   else
     local reason
     if grep -q "unmet dependencies" "$log"; then
-      reason=$(grep -A2 "unmet dependencies" "$log" | tail -1 | sed 's/^ *//')
-      record "FAIL" "debian" "$cn" "$pkg" "install: $reason"
+      reason=$(dependency_reason "$log")
+      record "FAIL" "debian" "$cn" "$target" "install: $reason"
     elif grep -q "CHECK-FAIL" "$log"; then
-      record "FAIL" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13-)"
+      record "FAIL" "debian" "$cn" "$target" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13-)"
     else
-      record "FAIL" "debian" "$cn" "$pkg" "see $(basename "$log")"
+      record "FAIL" "debian" "$cn" "$target" "see $(basename "$log")"
     fi
   fi
 }
 
 function run_docker_case() {
-  local cn="$1" image="$2" ver="$3"
-  local tag kind log
-  tag="${DOCKER_REPO}/${image}:${ver}-${cn}${DOCKER_SUFFIX}"
+  local cn="$1" image="$2" ver="$3" network="$4"
+  local tag kind log target
+  tag="${DOCKER_REPO}/${image}:${ver}-${cn}-${network}"
+  target="${image}:${network}"
   case "$image" in
     mina-daemon*)  kind="daemon" ;;
     mina-archive*) kind="archive" ;;
     mina-rosetta*) kind="rosetta" ;;
     *)             kind=$(package_kind "$image") ;;
   esac
-  log="$OUTDIR/logs/docker__${cn}__${image}.log"
+  log="$OUTDIR/logs/docker__${cn}__${image}__${network}.log"
 
   if ! docker manifest inspect "$tag" > /dev/null 2>&1; then
-    record "FAIL" "docker" "$cn" "$image" "tag does not exist: $tag"
+    record "FAIL" "docker" "$cn" "$target" "tag does not exist: $tag"
     return 0
   fi
 
   if docker run --rm --platform "linux/$ARCH" --entrypoint bash \
       -v "$CHECKER:/mina/check.sh:ro" "$tag" /mina/check.sh "$kind" docker "$image" \
       > "$log" 2>&1; then
-    record "PASS" "docker" "$cn" "$image" "kind=$kind"
+    record "PASS" "docker" "$cn" "$target" "kind=$kind"
   else
-    record "FAIL" "docker" "$cn" "$image" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
+    record "FAIL" "docker" "$cn" "$target" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
   fi
 }
 
@@ -524,33 +588,34 @@ function run_docker_case() {
 # channel holds a higher version of a strictly pinned dependency, this fails even
 # though every individual package is sound.
 function run_automode_case() {
-  local cn="$1" pkg="$2" ver="$3"
+  local cn="$1" pkg="$2" ver="$3" chan="$4"
+  local target="${pkg}@${chan}"
   local img log
   img=$(base_image "$cn")
-  log="$OUTDIR/logs/automode__${cn}.log"
+  log="$OUTDIR/logs/automode__${cn}__${pkg}.log"
 
   if docker run --rm --platform "linux/$ARCH" \
       -v "$SETUP:/mina/setup.sh:ro" -v "$CHECKER:/mina/check.sh:ro" \
       "$img" \
-      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' && bash /mina/check.sh dispatcher deb '$pkg' yes" \
+      bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$chan' '$SIGNED' && bash /mina/check.sh dispatcher deb '$pkg' yes" \
       > "$log" 2>&1; then
     local warn
     warn=$(grep -c "CHECK-WARN" "$log" || true)
     if [[ "$warn" -gt 0 ]]; then
-      record "WARN" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
+      record "WARN" "automode" "$cn" "$target" "$(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
     else
-      record "PASS" "automode" "$cn" "$pkg" "unpinned install and both runtimes"
+      record "PASS" "automode" "$cn" "$target" "unpinned install and both runtimes"
     fi
   else
     if grep -q "unmet dependencies" "$log"; then
-      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(grep -A2 'unmet dependencies' "$log" | tail -1 | sed 's/^ *//')"
+      record "FAIL" "automode" "$cn" "$target" "unpinned install failed: $(dependency_reason "$log")"
     else
-      record "FAIL" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
+      record "FAIL" "automode" "$cn" "$target" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
     fi
   fi
 }
 
-export -f run_deb_case run_docker_case run_automode_case base_image package_kind extra_deps record
+export -f run_deb_case run_docker_case run_automode_case base_image package_kind extra_deps record dependency_reason
 export OUTDIR RESULTS SETUP CHECKER REPO CHANNEL ARCH SIGNED DOCKER_REPO DOCKER_SUFFIX
 
 # ---------------------------------------------------------------------------
@@ -566,7 +631,7 @@ if [[ -n "$PACKAGES" ]]; then
   IFS=',' read -ra PKG_LIST <<< "$PACKAGES"
   for cn in "${CN_LIST[@]}"; do
     for spec in "${PKG_LIST[@]}"; do
-      printf 'run_deb_case %s %s %s\n' "$cn" "${spec%%=*}" "$(spec_version "$spec")" >> "$WORK"
+      printf 'run_deb_case %s %s %s %s\n' "$cn" "$(spec_name "$spec")" "$(spec_version "$spec")" "$(spec_channel "$spec")" >> "$WORK"
     done
   done
 fi
@@ -578,14 +643,19 @@ if [[ -n "$IMAGES" ]]; then
       if [[ "$spec" != *=* ]]; then
         usage "Docker image '$spec' needs an explicit version; a tag has no channel to resolve against."
       fi
-      printf 'run_docker_case %s %s %s\n' "$cn" "${spec%%=*}" "${spec#*=}" >> "$WORK"
+      printf 'run_docker_case %s %s %s %s\n' "$cn" "${spec%%=*}" "$(image_version "$spec")" "$(image_network "$spec")" >> "$WORK"
     done
   done
 fi
 
+# AUTOMODE is a list like PACKAGES, so one run can cover the devnet metapackage
+# in alpha and the mainnet one in stable.
 if [[ -n "$AUTOMODE" ]]; then
+  IFS=',' read -ra AM_LIST <<< "$AUTOMODE"
   for cn in "${CN_LIST[@]}"; do
-    printf 'run_automode_case %s %s %s\n' "$cn" "${AUTOMODE%%=*}" "$(spec_version "$AUTOMODE")" >> "$WORK"
+    for spec in "${AM_LIST[@]}"; do
+      printf 'run_automode_case %s %s %s %s\n' "$cn" "$(spec_name "$spec")" "$(spec_version "$spec")" "$(spec_channel "$spec")" >> "$WORK"
+    done
   done
 fi
 
@@ -594,7 +664,7 @@ echo "Running $TOTAL cases, $JOBS at a time. Logs: $OUTDIR/logs"
 echo
 
 # shellcheck disable=SC2016
-xargs -a "$WORK" -P "$JOBS" -n 4 bash -c '"$0" "$1" "$2" "$3"' || true
+xargs -a "$WORK" -P "$JOBS" -n 5 bash -c '"$0" "$1" "$2" "$3" "$4"' || true
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/verify/test-release.sh
+++ b/scripts/verify/test-release.sh
@@ -137,6 +137,24 @@ function spec_version() {
   esac
 }
 
+# apt prints the useful line between its header and its own generic verdict:
+#
+#   The following packages have unmet dependencies:
+#    mina-devnet-automode : Depends: mina-devnet-prefork-mesa (= X) but Y is to be installed
+#   E: Unable to correct problems, you have held broken packages.
+#
+# Report the middle line. The trailing "E:" line names no package, and reporting
+# that instead is what made a failed scheduled run impossible to diagnose once
+# the container was gone.
+function dependency_reason() {
+  local log="$1" line
+  line=$(grep -A8 "unmet dependencies" "$log" | grep -m1 "Depends:" | sed 's/^ *//')
+  if [[ -z "$line" ]]; then
+    line=$(grep -m1 "^E: " "$log" | sed 's/^ *//')
+  fi
+  echo "${line:-see the job log}"
+}
+
 function record() {
   # status <tab> area <tab> codename <tab> target <tab> detail
   printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$RESULTS"
@@ -428,7 +446,7 @@ function run_deb_case() {
   else
     local reason
     if grep -q "unmet dependencies" "$log"; then
-      reason=$(grep -A2 "unmet dependencies" "$log" | tail -1 | sed 's/^ *//')
+      reason=$(dependency_reason "$log")
       record "FAIL" "debian" "$cn" "$pkg" "install: $reason"
     elif grep -q "CHECK-FAIL" "$log"; then
       record "FAIL" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13-)"
@@ -487,7 +505,7 @@ function run_automode_case() {
     fi
   else
     if grep -q "unmet dependencies" "$log"; then
-      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(grep -A2 'unmet dependencies' "$log" | tail -1 | sed 's/^ *//')"
+      record "FAIL" "automode" "$cn" "$pkg" "unpinned install failed: $(dependency_reason "$log")"
     else
       record "FAIL" "automode" "$cn" "$pkg" "$(grep -m1 'CHECK-FAIL' "$log" | cut -c13- || echo "see $(basename "$log")")"
     fi

--- a/scripts/verify/test-release.sh
+++ b/scripts/verify/test-release.sh
@@ -48,7 +48,8 @@ function usage() {
   if [[ -n "$1" ]]; then echo "ERROR: $1"; echo; fi
   echo "Usage: $0 [options]"
   echo
-  echo "  -p, --packages    Comma list of debian packages as name=version"
+  echo "  -p, --packages    Comma list of debian packages as name=version, or a bare"
+  echo "                    name to test whatever the channel currently offers"
   echo "  -i, --images      Comma list of docker images as name=version"
   echo "  -a, --automode    Automode metapackage as name=version. Installs it with no"
   echo "                    version pin and checks both runtimes, the genesis config"
@@ -123,6 +124,16 @@ function package_kind() {
     mina-daemon)              echo "daemon" ;;
     mina-*)                   echo "daemon" ;;
     *)                        echo "unknown" ;;
+  esac
+}
+
+# A spec is "name=version" or a bare "name". A bare name means "whatever the
+# channel offers right now", which is what a recurring schedule wants: it never
+# needs editing after a release, and it tests what a user would actually get.
+function spec_version() {
+  case "$1" in
+    *=*) echo "${1#*=}" ;;
+    *)   echo "any" ;;
   esac
 }
 
@@ -347,12 +358,20 @@ else
 fi
 apt-get update -qq
 
-echo "INSTALL: apt-get install ${PACKAGE}=${VERSION}"
+# "any" installs whatever the channel currently offers, which is exactly what a
+# user gets from "apt-get install <package>". A recurring job should use it, so
+# the schedule does not carry version numbers that go stale after each release.
 if [[ "$VERSION" == "any" ]]; then
+  echo "INSTALL: apt-get install ${PACKAGE} (channel candidate)"
   apt-get install -y "${PACKAGE}"
 else
+  echo "INSTALL: apt-get install ${PACKAGE}=${VERSION}"
   apt-get install -y --allow-downgrades "${PACKAGE}=${VERSION}"
 fi
+
+# Record what was really installed, so a run that pinned nothing still says
+# exactly which version it tested.
+echo "INSTALLED-VERSION: $(dpkg-query -W -f='${Version}' "$PACKAGE" 2>/dev/null || echo unknown)"
 echo "INSTALL-OK"
 SETUP_EOF
 chmod +x "$SETUP"
@@ -398,12 +417,13 @@ function run_deb_case() {
       "$img" \
       bash -c "bash /mina/setup.sh '$pkg' '$ver' '$REPO' '$cn' '$CHANNEL' '$SIGNED' && bash /mina/check.sh '$kind' deb '$pkg' no" \
       > "$log" 2>&1; then
-    local warn
+    local warn installed
     warn=$(grep -c "CHECK-WARN" "$log" || true)
+    installed=$(grep -m1 'INSTALLED-VERSION:' "$log" | cut -d' ' -f2- || true)
     if [[ "$warn" -gt 0 ]]; then
-      record "WARN" "debian" "$cn" "$pkg" "$(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
+      record "WARN" "debian" "$cn" "$pkg" "${installed:-?} :: $(grep -m1 'CHECK-WARN' "$log" | cut -c13-)"
     else
-      record "PASS" "debian" "$cn" "$pkg" "kind=$kind"
+      record "PASS" "debian" "$cn" "$pkg" "${installed:-?} (kind=$kind)"
     fi
   else
     local reason
@@ -490,7 +510,7 @@ if [[ -n "$PACKAGES" ]]; then
   IFS=',' read -ra PKG_LIST <<< "$PACKAGES"
   for cn in "${CN_LIST[@]}"; do
     for spec in "${PKG_LIST[@]}"; do
-      printf 'run_deb_case %s %s %s\n' "$cn" "${spec%%=*}" "${spec#*=}" >> "$WORK"
+      printf 'run_deb_case %s %s %s\n' "$cn" "${spec%%=*}" "$(spec_version "$spec")" >> "$WORK"
     done
   done
 fi
@@ -499,6 +519,9 @@ if [[ -n "$IMAGES" ]]; then
   IFS=',' read -ra IMG_LIST <<< "$IMAGES"
   for cn in "${CN_LIST[@]}"; do
     for spec in "${IMG_LIST[@]}"; do
+      if [[ "$spec" != *=* ]]; then
+        usage "Docker image '$spec' needs an explicit version; a tag has no channel to resolve against."
+      fi
       printf 'run_docker_case %s %s %s\n' "$cn" "${spec%%=*}" "${spec#*=}" >> "$WORK"
     done
   done
@@ -506,7 +529,7 @@ fi
 
 if [[ -n "$AUTOMODE" ]]; then
   for cn in "${CN_LIST[@]}"; do
-    printf 'run_automode_case %s %s %s\n' "$cn" "${AUTOMODE%%=*}" "${AUTOMODE#*=}" >> "$WORK"
+    printf 'run_automode_case %s %s %s\n' "$cn" "${AUTOMODE%%=*}" "$(spec_version "$AUTOMODE")" >> "$WORK"
   done
 fi
 


### PR DESCRIPTION
## What

Two tools that test artifacts we have already published, plus one Buildkite entrypoint that runs them on a schedule.

| File | Role |
|---|---|
| `scripts/verify/check-infra.sh` | Canary. Is the apt repository serving a valid, non-empty index for each codename and component, and does the registry answer? No credentials, no downloads, ~15 s. |
| `scripts/verify/test-release.sh` | Full test. Installs each package in a clean container of every codename, pulls each docker image, and installs the automode metapackage **with no version pin**. |
| `buildkite/scripts/verify/run-verification.sh` | CI glue: environment variables to flags, dispatches on `VERIFY_MODE`. |
| `buildkite/src/Entrypoints/VerifyArtifacts.dhall` | One entrypoint, `Mode = < Infra | Artifacts >`. |
| `buildkite/scripts/entrypoints/run-verify-artifacts.sh` | Renders the Dhall, same shape as `run-nightly-promoter.sh`. |

## Why

Testing the recent devnet automode release by hand surfaced problems that the existing per-package checks cannot reach, and produced a large number of failures that were not defects at all. This makes both parts repeatable.

Three design points carry the value:

- **The check is chosen by package kind, not by name.** `resolve-check-script.sh` sends everything matching `mina-*` to the daemon check, which calls `mina --version`. The prefork payload package ships no `mina` on PATH by design, and the rosetta deb never shipped `mina` or `mina-archive`. Both then fail for reasons that say nothing about the package. Kinds are `daemon`, `archive`, `rosetta`, `logproc`, `payload`, `dispatcher` and `config`.
- **The automode case installs the metapackage unpinned.** A pinned install passes straight through a channel whose contents cannot satisfy the pin. The unpinned install is the only case that reproduces what an operator sees.
- **A bare package name means "whatever the channel offers right now".** A recurring schedule cannot carry pinned versions, because they go stale the moment a release lands. `PACKAGES=mina-devnet` installs the channel candidate, exactly as `apt-get install mina-devnet` would, and the result line records which version was actually installed. Pin a version only when testing one specific release.

`WARN` is a separate state from `FAIL`, so conditions that are known and by design stay visible without failing a scheduled run.

## Both networks in one run

Devnet artifacts live in the `alpha` channel and mainnet ones in `stable`, so a single global channel cannot reach both. Rather than duplicate the pipeline per network, channel and network are per-entry:

```
PACKAGES=mina-devnet,mina-rosetta-devnet,mina-mainnet@stable,mina-rosetta-mainnet@stable
IMAGES=mina-daemon=3.5.0-x:devnet,mina-daemon=3.5.0-y:mainnet
AUTOMODE=mina-devnet-automode,mina-mainnet-automode@stable
```

`@channel` overrides the default channel per package; `:network` sets the last segment of the docker tag. With none of the three variables set, artifacts mode falls back to a default set spanning both networks, so an unconfigured schedule still tests both. Each result row names its channel or network, so the two stay readable in one table.

## Scheduling

Create two schedules in the Buildkite UI. Put `VERIFY_MODE` on the **schedules**, not in the pipeline `env:` block, or every build becomes the heavy one.

| | Hourly | Daily |
|---|---|---|
| `VERIFY_MODE` | `infra` (also the default, so it may be omitted) | `artifacts` |
| Other variables | none | none needed; `PACKAGES`, `IMAGES`, `AUTOMODE` override the default set |

A daily schedule that never needs editing is now just:

```
VERIFY_MODE=artifacts
```

That covers devnet from `alpha` and mainnet from `stable`. Docker images are not part of the default set and still need an explicit version, because a tag has no channel to resolve against.

## Testing

- `shellcheck -S warning` clean on all four scripts.
- `make all` in `buildkite/` passes 45/45; both modes render valid pipeline YAML.
- `check-infra.sh` run against the live repository: 11 checks, 0 failures.
- `test-release.sh` run against the current alpha channel on bullseye. It reproduced the two known conditions as `WARN`, passed the clean packages, and found one real defect that the existing checks never reached: `mina-rosetta` links `libjemalloc.so.2`, `libpq.so.5` and `libffi.so.7`, but the deb declares none of them, so it cannot start on a clean container. Current stable `3.4.0-bd0fe9e` has the identical incomplete `Depends`, so that is long-standing rather than a regression. That fix is not in this PR.
- Run live on the `infra-docker-and-debian-healthcheck` pipeline; several of the fixes below came from those runs.
- Full mainnet sweep, 55 cases across five codenames: 45 PASS, 5 WARN, 5 FAIL. The five failures were `mina-mainnet-automode`, which pinned a pre-fork runtime that had never been published. The report named the package and the exact version conflict, which is what made that a two-minute diagnosis. After the missing pre-fork was published the same sweep returned 5/5 installable, with both runtimes and the genesis config agreeing.

## Fixes after the first live runs

- The pipeline upload step pipes stdout into `buildkite-agent pipeline upload`, so usage text printed there was uploaded as pipeline YAML and surfaced as `FATAL Config file is empty` instead of the real error. All diagnostics now go to stderr, and a missing `dhall-to-yaml` is reported explicitly.
- `VERIFY_MODE` now defaults to `infra`, so a schedule that sets no variables still runs the canary. This also removes an inconsistency: `run-verification.sh` already defaulted to `infra` while the entrypoint demanded it.

## Note on overlap

`scripts/verify/check-daemon-auto-hardfork.sh` on develop covers the same dual-runtime idea for the `mina-daemon-auto-hardfork` **image**. Its check that the two runtimes must report different commits was good and is included here. The debian packages `*-automode`, `*-postfork-*` and `*-prefork-*` are still routed to `check-daemon.sh` by `resolve-check-script.sh`. Unifying the two paths is worth a follow-up; this PR does not change existing behaviour.

## Unrelated, but worth recording

`BUILDKITE_GIT_SUBMODULES` cannot be turned off from a pipeline `env:` block. Buildkite reports it as a protected variable and ignores it, because checkout happens before the pipeline YAML is read. The comment at `buildkite/src/Command/RunInToolchain.dhall:19` says it is ignored "when set from a step", which is narrower than what actually happens. It has to move to the agent configuration.
