### PR TITLE
ci: tag the two .deb-consuming tests Packaging so nightly stops selecting them

### DIFF
--- a/buildkite/src/Jobs/Test/DebianAutomodeTransitionTestMainnet.dhall
+++ b/buildkite/src/Jobs/Test/DebianAutomodeTransitionTestMainnet.dhall
@@ -1,3 +1,12 @@
+-- Installs and upgrades the mainnet .debs built by MinaArtifactMainnetBullseye,
+-- so it belongs to the stage that builds them.
+--
+-- Hence the Packaging tag rather than Long: the nightly's LongAndVeryLong stage
+-- used to select it while packaging did not run there, leaving it
+-- waiting_failed on a dependency that was never scheduled. The devnet variant
+-- of this test does not need the tag because it restores bare binaries from the
+-- apps cache (appDependsOn) instead of installing a .deb.
+
 let PipelineTag = ../../Pipeline/Tag.dhall
 
 let PipelineScope = ../../Pipeline/Scope.dhall
@@ -55,7 +64,7 @@ in  Pipeline.build
         , name = "DebianAutomodeTransitionTestMainnet"
         , scope = [ PipelineScope.Type.MainlineNightly ]
         , tags =
-          [ PipelineTag.Type.Long
+          [ PipelineTag.Type.Packaging
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
           ]

--- a/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
+++ b/buildkite/src/Jobs/Test/HardforkPackageConversion.dhall
@@ -1,3 +1,11 @@
+-- Converts a daemon .deb built by MinaArtifactBullseye into its hardfork
+-- variant, so it can only run in a stage that also runs the packaging jobs.
+--
+-- Hence the Packaging tag rather than Fast. Tagged Fast, the nightly's FastOnly
+-- stage selected it while packaging (moved to its own tag in 2ee630be3e) did
+-- not run there, so every night it sat waiting_failed on a dependency that was
+-- never scheduled -- and took the tear-down step down with it.
+
 let S = ../../Lib/SelectFiles.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
@@ -29,7 +37,7 @@ in  Pipeline.build
         , path = "Test"
         , name = "HardforkPackageConversion"
         , tags =
-          [ PipelineTag.Type.Fast
+          [ PipelineTag.Type.Packaging
           , PipelineTag.Type.Test
           , PipelineTag.Type.Stable
           ]


### PR DESCRIPTION
Nightly 1585 has two jobs still red, and neither can ever pass there:

```
waiting_failed  Hardfork: Package Conversion
waiting_failed  Debian automode transition test (bullseye, mainnet)
waiting_failed  :pipeline: tear down          <- dragged down by them
```

They are the **only** two jobs left that depend on a built `.deb`. Every other consumer of the app build — 22 files — already uses `appDependsOn` and restores bare binaries from the apps cache. These two use `DebianVersions.dependsOn`, which points at `MinaArtifactBullseye` / `MinaArtifactMainnetBullseye`.

Since 2ee630be3e moved packaging to its own `Packaging` tag, those artifact jobs do not run in the nightly's `FastOnly` / `LongAndVeryLong` stages. The two tests were still tagged `Fast` and `Long`, so the nightly kept selecting them and they sat waiting on a dependency that was never scheduled.

### Change

Retag both to `Packaging`, so they run in the stage that builds what they consume. No scope changes were needed: each test's scope is already a subset of its dependency's (`HardforkPackageConversion` is `Full`, matching `MinaArtifactBullseye`; the mainnet test is `MainlineNightly`, inside `MinaArtifactMainnetBullseye`'s `AllButPullRequest`).

Also adds a header comment to each file recording why the tag is what it is. It has to be a header: `dhall format` drops comments placed inside the `tags` list, which is where I put them first.

### Verification

`buildkite/scripts/pipeline/list_jobs.sh`, per stage, scope `MainlineNightly`:

| stage | of the two tests |
| --- | --- |
| `FastOnly` | 0 selected |
| `LongAndVeryLong` | 0 selected |
| `Packaging` | **2 selected** |

and the `Packaging` stage resolves to a self-consistent set — both tests plus both of the artifact jobs they depend on:

```
DebianAutomodeTransitionTestMainnet
HardforkPackageConversion
MinaArtifactBullseye
MinaArtifactBullseyeInstrumented
MinaArtifactMainnetBullseye
MinaArtifactOnlyDebianBullseye
```

`cd buildkite && make all` — 103 jobs exported, `check_deps` resolves every dependency, 45/45 monorepo tests, Dhall lint/format/dirtyWhen/duplicates/job-names clean.

### Effect on the nightly

Three fewer red jobs (the two, plus tear-down). Combined with #19191 and #19193 already merged, nightly goes from 25 failures in build 1581 to 4: `hard fork test - legacy mode`, `hard fork test - mixed mode`, `Perf: Archive`, `Perf: Snark Profiler`.
