### PR TITLE
restore ci-single-me and add a deploy makefile

### DIFF
--- a/frontend/ci-build-me/Makefile
+++ b/frontend/ci-build-me/Makefile
@@ -1,0 +1,81 @@
+# Deploy and check the Cloud Function that reads the "!ci-..." PR comments.
+#
+# The function is deployed by hand. In July 2026 a deploy was made from a
+# working copy that held changes which were never committed, so the function
+# that ran held a command (!ci-single-me) that was in no commit, and a deploy
+# from the repository would have deleted it. The `check` target finds that
+# situation, and `deploy` refuses to run with a dirty working tree.
+
+SHELL := /bin/bash
+
+PROJECT  ?= o1labs-192920
+REGION   ?= us-central1
+FUNCTION ?= githubWebhookHandler
+ENTRY    ?= githubWebhookHandler
+MEMORY   ?= 128MB
+
+SOURCE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Keep the runtime of the function that is deployed. A deploy that names
+# another runtime than the one in use is a change nobody asked for, and the
+# runtime in the README (nodejs10) is no longer offered by Google.
+RUNTIME ?= $(shell gcloud functions describe $(FUNCTION) \
+	--project $(PROJECT) --region $(REGION) \
+	--format='value(runtime)' 2>/dev/null)
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: describe
+describe: ## Show the deployed function
+	@gcloud functions describe $(FUNCTION) \
+		--project $(PROJECT) --region $(REGION) \
+		--format='table(name.basename(), status, runtime, entryPoint, updateTime)'
+
+.PHONY: check
+check: ## Compare the deployed function with this directory
+	@$(SOURCE_DIR)check-deployed-parity.sh \
+		--project $(PROJECT) --region $(REGION) --function $(FUNCTION)
+
+.PHONY: check-env
+check-env:
+	@if [ -z "$$GITHUB_SECRET" ]; then \
+		echo "Error: GITHUB_SECRET is not set. Take it from the AWS secret store (us-west-2)." >&2; exit 1; fi
+	@if [ -z "$$BUILDKITE_API_ACCESS_TOKEN" ]; then \
+		echo "Error: BUILDKITE_API_ACCESS_TOKEN is not set. Take it from the AWS secret store (us-west-2)." >&2; exit 1; fi
+	@if [ -z "$(RUNTIME)" ]; then \
+		echo "Error: cannot read the runtime of the deployed function." >&2; \
+		echo "       Check your gcloud login, or give one: make deploy RUNTIME=nodejs20" >&2; exit 1; fi
+
+.PHONY: check-clean
+check-clean:
+	@if [ -n "$$ALLOW_DIRTY" ]; then \
+		echo "⚠️  ALLOW_DIRTY is set: deploying a working tree that may hold changes that are not committed."; \
+	elif [ -n "$$(git -C $(SOURCE_DIR) status --porcelain -- $(SOURCE_DIR))" ]; then \
+		echo "Error: this directory holds changes that are not committed." >&2; \
+		git -C $(SOURCE_DIR) status --short -- $(SOURCE_DIR) >&2; \
+		echo "" >&2; \
+		echo "       Deploying now would put code in production that is in no commit," >&2; \
+		echo "       which is how the July 2026 difference was made. Commit first, or" >&2; \
+		echo "       use 'make deploy ALLOW_DIRTY=1' if you accept that." >&2; \
+		exit 1; \
+	fi
+
+.PHONY: deploy
+deploy: check-env check-clean ## Deploy this directory to Google Cloud
+	@echo "Deploying $(FUNCTION) to $(PROJECT)/$(REGION) with runtime $(RUNTIME)"
+	@echo "From commit: $$(git -C $(SOURCE_DIR) rev-parse --short HEAD)"
+	cd $(SOURCE_DIR) && gcloud functions deploy $(FUNCTION) \
+		--project $(PROJECT) \
+		--region $(REGION) \
+		--trigger-http \
+		--runtime $(RUNTIME) \
+		--memory $(MEMORY) \
+		--entry-point $(ENTRY) \
+		--source . \
+		--set-env-vars GITHUB_SECRET=$$GITHUB_SECRET,BUILDKITE_API_ACCESS_TOKEN=$$BUILDKITE_API_ACCESS_TOKEN
+	@echo ""
+	@echo "Checking that the function which is deployed is now this directory:"
+	@$(MAKE) --no-print-directory check

--- a/frontend/ci-build-me/check-deployed-parity.sh
+++ b/frontend/ci-build-me/check-deployed-parity.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+# Compare the deployed Cloud Function with the source in this repository.
+#
+# The function that reads the "!ci-..." comments is deployed by hand (see the
+# Deploy part of README.md), so the code that runs can be older than the code
+# here, and nothing shows it. This script downloads the source of the deployed
+# function and compares it with this directory.
+#
+# Usage: ./check-deployed-parity.sh [options]
+#
+#   --project ID       Google Cloud project.  Default: o1labs-192920
+#   --region REGION    Region of the function. Default: us-central1
+#   --function NAME    Name of the function.  Default: githubWebhookHandler
+#   --keep             Keep the downloaded source and write where it is.
+#   -h, --help         Write this text.
+#
+# Exit codes:
+#   0  the deployed function is the same as this directory
+#   1  the deployed function is different (the difference is written out)
+#   2  the comparison could not be made (no gcloud, no permission, ...)
+#
+# The comparison uses the same files that a deploy sends, that is every file of
+# this directory except the ones in .gcloudignore.
+
+set -euo pipefail
+
+PROJECT="o1labs-192920"
+REGION="us-central1"
+FUNCTION="githubWebhookHandler"
+KEEP=0
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+while [[ "$#" -gt 0 ]]; do case "$1" in
+    --project)  PROJECT="$2"; shift 2 ;;
+    --region)   REGION="$2"; shift 2 ;;
+    --function) FUNCTION="$2"; shift 2 ;;
+    --keep)     KEEP=1; shift ;;
+    -h|--help)  usage 0 ;;
+    *) echo "Unknown option: $1" >&2; usage 2 ;;
+esac; done
+
+# ---------------------------------------------------------------------------
+# What the script needs
+# ---------------------------------------------------------------------------
+for tool in gcloud curl unzip diff python3; do
+    command -v "$tool" > /dev/null 2>&1 || fail "'${tool}' is not installed."
+done
+
+if ! TOKEN="$(gcloud auth print-access-token 2>/dev/null)" || [[ -z "$TOKEN" ]]; then
+    fail "gcloud has no valid credentials. Run 'gcloud auth login' first."
+fi
+
+WORK_DIR="$(mktemp -d)"
+if [[ "$KEEP" -eq 0 ]]; then
+    trap 'rm -rf "$WORK_DIR"' EXIT
+fi
+
+# ---------------------------------------------------------------------------
+# Where the deployed source is
+#
+# A generation 1 function gives a download address only through the API method
+# generateDownloadUrl, which gcloud does not have a command for. A generation 2
+# function holds its source in a Cloud Storage object, which is named in the
+# description.
+# ---------------------------------------------------------------------------
+API_NAME="projects/${PROJECT}/locations/${REGION}/functions/${FUNCTION}"
+
+echo "Reading the description of ${FUNCTION} (${PROJECT}, ${REGION})"
+
+DESCRIBE_JSON="${WORK_DIR}/describe.json"
+
+# Ask for one generation and report the HTTP code, so that "no permission" and
+# "no such function" do not look the same.
+describe_with() {
+    curl -s -o "$DESCRIBE_JSON" -w '%{http_code}' \
+        -H "Authorization: Bearer ${TOKEN}" \
+        "https://cloudfunctions.googleapis.com/${1}/${API_NAME}"
+}
+
+CODE_V1="$(describe_with v1)"
+if [[ "$CODE_V1" == "200" ]]; then
+    GENERATION=1
+else
+    CODE_V2="$(describe_with v2)"
+    if [[ "$CODE_V2" == "200" ]]; then
+        GENERATION=2
+    else
+        case "$CODE_V1" in
+            401)
+                fail "the credentials of gcloud are not valid any more (HTTP 401).
+       Run:  gcloud auth login" ;;
+            403)
+                fail "this account may not read the function (HTTP 403).
+       Ask for the role roles/cloudfunctions.viewer on ${PROJECT}." ;;
+            404)
+                fail "no function '${FUNCTION}' in ${PROJECT}/${REGION} (HTTP 404).
+       Give another name with --function or another region with --region." ;;
+            *)
+                fail "cannot read the function (HTTP ${CODE_V1} for v1, ${CODE_V2} for v2).
+       $(head -c 300 "$DESCRIBE_JSON")" ;;
+        esac
+    fi
+fi
+
+UPDATE_TIME="$(python3 -c "
+import json,sys
+d=json.load(open('${DESCRIBE_JSON}'))
+print(d.get('updateTime') or d.get('updateTime','(unknown)'))
+")"
+echo "  generation : ${GENERATION}"
+echo "  updated    : ${UPDATE_TIME}"
+
+ZIP="${WORK_DIR}/deployed.zip"
+
+if [[ "$GENERATION" -eq 1 ]]; then
+    DOWNLOAD_URL="$(curl -sf -X POST \
+        -H "Authorization: Bearer ${TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d '{}' \
+        "https://cloudfunctions.googleapis.com/v1/${API_NAME}:generateDownloadUrl" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("downloadUrl",""))')"
+
+    [[ -n "$DOWNLOAD_URL" ]] || fail "the API gave no download address for the source."
+    curl -sf "$DOWNLOAD_URL" -o "$ZIP" || fail "cannot download the source archive."
+else
+    STORAGE="$(python3 -c "
+import json
+d=json.load(open('${DESCRIBE_JSON}'))
+s=((d.get('buildConfig') or {}).get('source') or {}).get('storageSource') or {}
+if s.get('bucket') and s.get('object'):
+    print('gs://%s/%s' % (s['bucket'], s['object']))
+")"
+    [[ -n "$STORAGE" ]] || fail "the description names no source object."
+    echo "  source     : ${STORAGE}"
+    gcloud storage cp "$STORAGE" "$ZIP" > /dev/null 2>&1 \
+        || fail "cannot download ${STORAGE}."
+fi
+
+# ---------------------------------------------------------------------------
+# Compare
+# ---------------------------------------------------------------------------
+DEPLOYED_DIR="${WORK_DIR}/deployed"
+mkdir -p "$DEPLOYED_DIR"
+unzip -q "$ZIP" -d "$DEPLOYED_DIR" || fail "cannot open the source archive."
+
+# A deploy sends every file except the ones in .gcloudignore. Use the same list,
+# so that a file which is never sent is not reported as a difference.
+EXCLUDES=(-x '.git' -x '.gitignore' -x '.gcloudignore' -x 'node_modules')
+if [[ -f "${SOURCE_DIR}/.gcloudignore" ]]; then
+    EXCLUDES=()
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="$(echo "$line" | tr -d '[:space:]')"
+        [[ -n "$line" ]] && EXCLUDES+=(-x "$line")
+    done < "${SOURCE_DIR}/.gcloudignore"
+fi
+# This script is itself not part of the function.
+EXCLUDES+=(-x "$(basename "${BASH_SOURCE[0]}")")
+
+DIFF_OUT="${WORK_DIR}/diff.txt"
+set +e
+diff -ru "${EXCLUDES[@]}" "$DEPLOYED_DIR" "$SOURCE_DIR" > "$DIFF_OUT" 2>&1
+DIFF_STATUS=$?
+set -e
+
+if [[ "$KEEP" -eq 1 ]]; then
+    echo "  downloaded source kept in ${DEPLOYED_DIR}"
+fi
+
+if [[ "$DIFF_STATUS" -eq 0 ]]; then
+    echo ""
+    echo "✅ The deployed function is the same as ${SOURCE_DIR}."
+    exit 0
+fi
+
+echo ""
+echo "❌ The deployed function is NOT the same as this directory."
+echo "   left  = deployed (${UPDATE_TIME})"
+echo "   right = ${SOURCE_DIR}"
+echo ""
+cat "$DIFF_OUT"
+echo ""
+echo "Deploy the current source with the command in README.md to remove the difference."
+exit 1

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -78,7 +78,10 @@ const parseParams = (comment) => {
 const buildEnvFromParams = ({ arch, profile, codename }) => {
   var filter = "DockerBuild";
 
-  if (!arch || !profile || !codename ) {
+  // Only fall back to the unfiltered DockerBuild when the caller gave nothing.
+  // A caller that gives some of the keys keeps them: "arch=amd64" alone builds
+  // the filter DockerBuildAmd64, which is a real filter.
+  if (!arch && !profile && !codename) {
     return { BUILDKITE_PIPELINE_FILTER: filter };
   }
 
@@ -213,6 +216,42 @@ const handler = async (event, req) => {
         },
         "mina-end-to-end-nightlies",
         {}
+      );
+      return [buildkite];
+    } else {
+      return [
+        "comment author is not (publically) a member of the core team",
+        "comment author is not (publically) a member of the core team",
+      ];
+    }
+  }
+
+  // Mina CI Single Test Build section
+  //
+  // Runs one generated buildkite job and the jobs it depends on. The job name
+  // is the last word of the comment, and it must be the exact name of a job in
+  // buildkite/src/gen (the match is on the whole name, not a part of it).
+  //
+  //   !ci-single-me HardForkTestMixed
+  else if (
+    req.body.action == "created" &&
+    req.body.issue.pull_request &&
+    req.body.issue.pull_request.url &&
+    req.body.comment.body.startsWith("!ci-single-me")
+  ) {
+    const orgData = await getRequest(req.body.sender.organizations_url);
+    if (orgData.data.filter((org) => org.login == "MinaProtocol").length > 0) {
+      const prData = await getRequest(req.body.issue.pull_request.url);
+
+      const jobName = req.body.comment.body.trim().split(/\s+/).pop(); // get JobName from "!ci-single-me JobName"
+
+      const buildkite = await runBuild(
+        {
+          sender: req.body.sender,
+          pull_request: prData.data,
+        },
+        "mina-single-job",
+        { JOB_NAME: jobName }
       );
       return [buildkite];
     } else {


### PR DESCRIPTION
> Stacked on #19194 (base is `dkijania/artifact-dependency-closure`), so only the
> last two commits belong to this PR. Retarget to `develop` once #19194 merges.

The Cloud Function that reads the `!ci-...` comments is deployed by hand, and
the code that runs had drifted from this repository. This PR adds a way to see
that, brings back what only production had, and makes the next deploy safe.

### The drift, found by the new check

The deployed function (generation 1, updated 2026-07-29) held a
**`!ci-single-me` handler that is in no commit**:
`git log -S "ci-single-me" -- frontend/ci-build-me/src/index.js` gives nothing.
It runs the `mina-single-job` pipeline with `JOB_NAME`, which is in use: that
pipeline has 250 builds, the recent ones `HardForkTestLegacy` and
`ConnectToDevnet`. **A deploy from `develop` would have deleted a working
command.** Someone deployed a working copy that held changes never committed.

The deployed guard in `buildEnvFromParams` was also different:

```js
if (!arch && !profile && !codename)   // deployed
if (!arch || !profile || !codename)   // this repository
```

The deployed one is the more useful: with `&&`, `arch=amd64` alone gives the
filter `DockerBuildAmd64`, which exists. With `||` any missing key throws the
others away and the filter falls back to `DockerBuild`.

### What this PR does

| Change | Why |
|---|---|
| `check-deployed-parity.sh` | Downloads the source of the deployed function and compares it with this directory. Generation 1 gives a download address only through the API method `generateDownloadUrl`, which gcloud has no command for, so the script calls it directly; a generation 2 function names a storage object instead, and both are handled. The comparison reads `.gcloudignore`, so a file that a deploy never sends is not reported. |
| `!ci-single-me` restored | It is live and used. Now it is in the repository, so a deploy keeps it. |
| `&&` guard restored | Keeps the behaviour that is in production, which is also the more useful one. |
| `Makefile` | `make check`, `make describe`, `make deploy`. |

`make deploy` **refuses a working tree that holds changes which are not
committed** — that is exactly how the July difference was made:

```
Error: this directory holds changes that are not committed.
 M src/index.js
       Deploying now would put code in production that is in no commit,
       which is how the July 2026 difference was made. Commit first, or
       use 'make deploy ALLOW_DIRTY=1' if you accept that.
```

It also reads the runtime of the deployed function instead of naming one, so a
deploy does not change the runtime by accident. That matters here: the function
runs **nodejs20**, while the README still says `nodejs10`, which Google no
longer offers. After a deploy it runs `make check` again, so the result is
proved, not assumed.

### What a deploy will now change, on purpose

After this PR the only differences left are ones this repository means to make,
and they will take effect at the next deploy. Please confirm the first two:

1. **`bkase` is removed from the `!approved-for-mainnet` approvers.** He is still
   an approver in the function that runs today.
2. **`!ci-docker-base-me` starts sending
   `BUILDKITE_PIPELINE_FILTER=BaseDockersOnly` and
   `BUILDKITE_PIPELINE_JOB_SELECTION=Full`.** The deployed one sends nothing and
   relies on the pipeline default, so its behaviour today is not the documented
   one.
3. The README gains the section about branch protection rules.

### Known, not fixed here

Neither guard is right for every input. `&&` lets `profile=devnet` alone build
the filter name `DockerBuildDevnet`, which is not one of the names in
`TagFilter.dhall`, so the build fails later with a Dhall error instead of a
clear message. Validating the composed name belongs with the artifact-selection
work, not with a PR whose purpose is to make the repository match production.
