### PR TITLE
fix(minimina): don't hang starting the archive provisioning postgres

### DIFF
--- a/src/app/minimina/src/native/archive.rs
+++ b/src/app/minimina/src/native/archive.rs
@@ -94,10 +94,17 @@ pub fn provision(
         )));
     }
 
+    // `-l` is not just about keeping the server's log: without it the postmaster
+    // inherits our stdout and stderr, and since it outlives `pg_ctl`, waiting for
+    // those pipes to close never returns. Only visible when our own stdout is a
+    // pipe rather than a terminal — i.e. every non-interactive caller.
+    let server_log = network_path.join("postgres-provision.log");
     let start = std::process::Command::new("pg_ctl")
         .args([
             "-D",
             pgdata_str,
+            "-l",
+            &server_log.display().to_string(),
             "-o",
             &format!("-p {port} -k {sockdir} -c listen_addresses=127.0.0.1"),
             "-w",
@@ -162,4 +169,40 @@ fn init_archive_db(network_path: &Path, archive_node: &ServiceConfig, port: &str
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::ServiceType;
+
+    /// `provision` has to return. Under `cargo test` our stdout is a pipe, and
+    /// that is precisely the condition it used to hang on: the postmaster
+    /// inherits our stdout and outlives `pg_ctl`, so waiting for that pipe to
+    /// close never ends. Run from a terminal, the bug is invisible.
+    ///
+    /// Needs the postgres binaries on PATH; `#[ignore]`d because CI has none.
+    /// Run manually: `cargo test provision_returns -- --ignored`.
+    #[test]
+    #[ignore]
+    fn provision_returns_when_stdout_is_not_a_terminal() {
+        let dir = tempdir::TempDir::new("pg-provision-hang").unwrap();
+        let network_id = "pg-hang-test";
+        let archive_node = ServiceConfig {
+            service_type: ServiceType::ArchiveNode,
+            service_name: "archive".to_string(),
+            // No schema files: this is about starting the server, and it keeps
+            // the test off the network.
+            archive_schema_files: None,
+            ..Default::default()
+        };
+
+        provision(dir.path(), network_id, &archive_node).unwrap();
+
+        assert!(
+            pgdata_dir(dir.path()).exists(),
+            "cluster was not initialized"
+        );
+        let _ = std::fs::remove_dir_all(postgres_socket_dir(network_id));
+    }
 }


### PR DESCRIPTION
## Summary

`minimina network create` on an archive network **never returns** in native mode when its stdout is a pipe rather than a terminal — from a script, from CI, or from anything that captures output.

`pg_ctl start` is invoked without `-l`, so the postmaster it starts inherits our stdout/stderr. The postmaster outlives `pg_ctl`, so `Command::output()` — which waits for the child's output to reach EOF — waits on a pipe the server holds open for as long as it runs.

Run from a terminal there is no pipe to wait on, which is how this survived the manual validation on #19104.

## Fix

Give `pg_ctl` a log file (`<network>/postgres-provision.log`). The server's output goes there instead of into our pipe, and the provisioning server's log ends up next to the cluster it belongs to.

## Testing

The regression test drives `provision` directly and needs no special setup to reproduce: `cargo test` captures stdout, which is exactly the condition that hangs.

- without the fix: never finishes (killed at 90s)
- with the fix: passes in 0.8s

`#[ignore]`d because it needs the postgres binaries on PATH and CI has none — run it with `cargo test provision_returns -- --ignored`. Full suite, clippy and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)