### PR TITLE
Generate the archive docker image in the hardfork pipeline

### DIFF
--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -283,7 +283,7 @@ let generateDockerForCodename =
                             , network = spec.network
                             , deb_codename = codename.DebVersion
                             , deb_install_mode =
-                                DockerImage.DebianInstallMode.DownloadOnly
+                                DockerImage.DebianInstallMode.ThroughLocalRepo
                             , deb_profile = profile
                             , deb_legacy_version = spec.deb_legacy_version
                             , deb_storage_repair_version = Some

--- a/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
+++ b/buildkite/src/Entrypoints/GenerateHardforkPackage.dhall
@@ -277,6 +277,23 @@ let generateDockerForCodename =
                                 "-${DebianVersions.lowerName
                                       codename.DebVersion}-docker-image"
                             }
+                          , DockerImage.ReleaseSpec::{
+                            , deps = dependsOnBuildHfDebian
+                            , service = Artifacts.Type.Archive
+                            , network = spec.network
+                            , deb_codename = codename.DebVersion
+                            , deb_install_mode =
+                                DockerImage.DebianInstallMode.DownloadOnly
+                            , deb_profile = profile
+                            , deb_legacy_version = spec.deb_legacy_version
+                            , deb_storage_repair_version = Some
+                                spec.deb_storage_repair_version
+                            , size = spec.size
+                            , deb_version = spec.version
+                            , step_key_suffix =
+                                "-${DebianVersions.lowerName
+                                      codename.DebVersion}-docker-image"
+                            }
                           ]
                   , None =
                     [ DockerImage.ReleaseSpec::{


### PR DESCRIPTION
Ports the two hardfork-pipeline fixes from `devnet-dryrun`, and nothing else. The dry-run config commits on that branch (`genesis_ledgers/devnet.json` — "devnet dryrun config", "stop slot") are deliberately left behind.

Both commits touch only `buildkite/src/Entrypoints/GenerateHardforkPackage.dhall`.

## 1. Always generate the archive image (`ee5cb7fd02`)

The hardfork pipeline built DaemonConfig and RosettaConfig images but no archive image, so a hardfork package set had no matching `mina-archive` docker image.

## 2. Serve a local repository for it (`ef0fbd4cb6`)

The archive step first shipped with `deb_install_mode = DownloadOnly`, copied from the Config specs next to it. That is wrong for this image, and it failed in [build 1302](https://buildkite.com/o-1-labs-2/hardfork-package-generation-new/builds/1302#019feaed-327c-4a3d-8f79-95f83ae1df52):

```
Err:1 http://172.17.0.1:8080 jammy InRelease
  Could not connect to 172.17.0.1:8080 - connect (111: Connection refused)
E: Unable to locate package mina-archive-devnet
E: Unable to locate package mina-devnet-config
```

The three images obtain their packages differently:

| service | dockerfile | install |
|---|---|---|
| DaemonConfig / RosettaConfig | `dockerfiles/stages/install-config` | `COPY …deb` then `dpkg -i`, from the build context |
| Archive | `dockerfiles/Dockerfile-mina-archive` | `apt-get install` from `${deb_repo}` |

`DownloadOnly` only stages the debians in the docker build context, which is all the Config images need. The archive image needs a repository to be served, which is what `ThroughLocalRepo` does: `start_local_repo.sh` reads the same debians and serves them with aptly under the `unstable` component, matching the step's `--deb-release unstable`.

Because the second commit only edits a line the first one adds, the net change here is a single new `ReleaseSpec` with the correct mode.

## Test plan

`make all` in `buildkite/` — Dhall compiles, 37/37 monorepo tests pass.

Verified on `devnet-dryrun`: [build 1303](https://buildkite.com/o-1-labs-2/hardfork-package-generation-new/builds/1303) is fully green with these two commits, including `Docker: Archive Devnet Jammy Devnet Amd64`, and its cache holds `mina-archive-devnet_4.0.0-rc1-devnet-dryrun-ef0fbd4_amd64.deb`.

No changelog entry: pipeline-only change.