### PR TITLE
validate the ci-docker-me filter before starting a build

### DIFF
--- a/frontend/ci-build-me/Makefile
+++ b/frontend/ci-build-me/Makefile
@@ -34,6 +34,10 @@ describe: ## Show the deployed function
 		--project $(PROJECT) --region $(REGION) \
 		--format='table(name.basename(), status, runtime, entryPoint, updateTime)'
 
+.PHONY: test
+test: ## Run the unit tests (no dependencies needed)
+	@node $(SOURCE_DIR)test/docker-filters.test.js
+
 .PHONY: check
 check: ## Compare the deployed function with this directory
 	@$(SOURCE_DIR)check-deployed-parity.sh \
@@ -64,7 +68,7 @@ check-clean:
 	fi
 
 .PHONY: deploy
-deploy: check-env check-clean ## Deploy this directory to Google Cloud
+deploy: test check-env check-clean ## Deploy this directory to Google Cloud
 	@echo "Deploying $(FUNCTION) to $(PROJECT)/$(REGION) with runtime $(RUNTIME)"
 	@echo "From commit: $$(git -C $(SOURCE_DIR) rev-parse --short HEAD)"
 	cd $(SOURCE_DIR) && gcloud functions deploy $(FUNCTION) \

--- a/frontend/ci-build-me/package.json
+++ b/frontend/ci-build-me/package.json
@@ -7,13 +7,18 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/** test/**",
     "start": "nodemon -x functions-framework --target=githubWebhookHandler",
-    "test": "jest"
+    "test": "node test/docker-filters.test.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/eddies/github-webhook-cloud-function.git"
   },
-  "keywords": ["github", "buildkite", "google cloud functions", "node"],
+  "keywords": [
+    "github",
+    "buildkite",
+    "google cloud functions",
+    "node"
+  ],
   "author": "O(1) Labs (forked from Edwin Shin)",
   "license": "ISC",
   "bugs": {
@@ -33,11 +38,16 @@
     "smee-client": "^1.1.0"
   },
   "jest": {
-    "collectCoverageFrom": ["src/**/*.js"],
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ],
     "coverageDirectory": "build/coverage",
     "testEnvironment": "node"
   },
   "nodemonConfig": {
-    "ignore": ["test/*", "docs/*"]
+    "ignore": [
+      "test/*",
+      "docs/*"
+    ]
   }
 }

--- a/frontend/ci-build-me/src/docker-filters.js
+++ b/frontend/ci-build-me/src/docker-filters.js
@@ -1,0 +1,110 @@
+// The names that buildkite/src/Pipeline/Filter.dhall (TagFilter) actually
+// declares. BUILDKITE_PIPELINE_FILTER is put straight into a dhall expression
+// as the name of a union alternative:
+//
+//   tagFilter=(./buildkite/src/Pipeline/TagFilter.dhall).Type.${tagFilter}
+//
+// so a name that is not declared does not select nothing: it stops the build at
+// the "Prepare monorepo triage" step with a dhall type error, which says
+// nothing about the comment that caused it. The combinations are not complete
+// (there is no DockerBuildArm64DevnetJammy, and no name for a profile alone),
+// so the composed name must be checked before a build is started.
+//
+// test/docker-filters.test.js reads TagFilter.dhall and fails if this list and
+// that file stop agreeing.
+const DOCKER_BUILD_FILTERS = [
+  "DockerBuild",
+  "DockerBuildAmd64",
+  "DockerBuildAmd64Devnet",
+  "DockerBuildAmd64DevnetBookworm",
+  "DockerBuildAmd64DevnetBullseye",
+  "DockerBuildAmd64DevnetFocal",
+  "DockerBuildAmd64DevnetJammy",
+  "DockerBuildAmd64DevnetNoble",
+  "DockerBuildAmd64Lightnet",
+  "DockerBuildAmd64LightnetBookworm",
+  "DockerBuildAmd64LightnetBullseye",
+  "DockerBuildAmd64Mainnet",
+  "DockerBuildAmd64MainnetBookworm",
+  "DockerBuildAmd64MainnetBullseye",
+  "DockerBuildAmd64MainnetFocal",
+  "DockerBuildAmd64MainnetJammy",
+  "DockerBuildAmd64MainnetNoble",
+  "DockerBuildArm64",
+  "DockerBuildArm64Devnet",
+  "DockerBuildArm64DevnetBookworm",
+  "DockerBuildArm64DevnetNoble",
+  "DockerBuildArm64Lightnet",
+  "DockerBuildArm64LightnetBookworm",
+  "DockerBuildArm64Mainnet",
+  "DockerBuildArm64MainnetBookworm",
+  "DockerBuildArm64MainnetNoble",
+];
+
+const DOCKER_PROFILES = ["devnet", "lightnet", "mainnet"];
+const DOCKER_ARCHES = ["amd64", "arm64"];
+const DOCKER_CODENAMES = ["jammy", "noble", "bullseye", "focal", "bookworm"];
+
+const capitalise = (value) => value.charAt(0).toUpperCase() + value.slice(1);
+
+// Turn the key=value pairs of a !ci-docker-me comment into the environment of
+// the build, or into the reason why no build can be started.
+//
+// Returns { env } when a build may start, or { error } with a text for the
+// author of the comment.
+const buildEnvFromParams = ({ arch, profile, codename }) => {
+  // No key at all: build every docker image, as before.
+  if (!arch && !profile && !codename) {
+    return { env: { BUILDKITE_PIPELINE_FILTER: "DockerBuild" } };
+  }
+
+  const wrong = [];
+  if (arch && !DOCKER_ARCHES.includes(arch)) {
+    wrong.push(`arch=${arch} (use one of: ${DOCKER_ARCHES.join(", ")})`);
+  }
+  if (profile && !DOCKER_PROFILES.includes(profile)) {
+    wrong.push(`profile=${profile} (use one of: ${DOCKER_PROFILES.join(", ")})`);
+  }
+  if (codename && !DOCKER_CODENAMES.includes(codename)) {
+    wrong.push(`codename=${codename} (use one of: ${DOCKER_CODENAMES.join(", ")})`);
+  }
+  if (wrong.length > 0) {
+    return { error: `!ci-docker-me: value not known: ${wrong.join("; ")}` };
+  }
+
+  // The name is composed in this order because that is the order the names in
+  // TagFilter.dhall are written in.
+  var filter = "DockerBuild";
+  if (arch) filter += capitalise(arch);
+  if (profile) filter += capitalise(profile);
+  if (codename) filter += capitalise(codename);
+
+  if (!DOCKER_BUILD_FILTERS.includes(filter)) {
+    return {
+      error:
+        `!ci-docker-me: this combination has no filter (${filter}).\n` +
+        `Give the architecture first, then the profile, then the codename, ` +
+        `and use a combination that buildkite/src/Pipeline/TagFilter.dhall ` +
+        `declares. These exist:\n` +
+        DOCKER_BUILD_FILTERS.filter((f) => f !== "DockerBuild").join("\n"),
+    };
+  }
+
+  return {
+    env: {
+      BUILDKITE_PIPELINE_FILTER: filter,
+      BUILDKITE_PIPELINE_FILTER_MODE: "All",
+      // The author named what to build, so the change based triage must not
+      // take it away again. !ci-docker-base-me does the same.
+      BUILDKITE_PIPELINE_JOB_SELECTION: "Full",
+    },
+  };
+};
+
+module.exports = {
+  buildEnvFromParams,
+  DOCKER_BUILD_FILTERS,
+  DOCKER_ARCHES,
+  DOCKER_PROFILES,
+  DOCKER_CODENAMES,
+};

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -75,35 +75,10 @@ const parseParams = (comment) => {
   return params;
 };
 
-const buildEnvFromParams = ({ arch, profile, codename }) => {
-  var filter = "DockerBuild";
+const {
+  buildEnvFromParams,
+} = require("./docker-filters.js");
 
-  // Only fall back to the unfiltered DockerBuild when the caller gave nothing.
-  // A caller that gives some of the keys keeps them: "arch=amd64" alone builds
-  // the filter DockerBuildAmd64, which is a real filter.
-  if (!arch && !profile && !codename) {
-    return { BUILDKITE_PIPELINE_FILTER: filter };
-  }
-
-  const profiles = ["devnet", "lightnet", "mainnet"];
-  const arches = ["amd64", "arm64"];
-  const codenames = ["jammy", "noble", "bullseye", "focal", "bookworm"];
-
-
-  if (arches.includes(arch)) {
-    filter += arch.charAt(0).toUpperCase() + arch.slice(1); // Amd64 / Arm64
-  }
-
-  if (profiles.includes(profile)) {
-    filter += profile.charAt(0).toUpperCase() + profile.slice(1); // Devnet / Lightnet / Mainnet
-  }
-
-  if (codenames.includes(codename)) {
-    filter += codename.charAt(0).toUpperCase() + codename.slice(1); // Jammy / Noble / Bullseye / Focal / Bookworm
-  }
-
-    return { BUILDKITE_PIPELINE_FILTER: filter, BUILDKITE_PIPELINE_FILTER_MODE: "All" };
-};
 // -------------------
 
 const handler = async (event, req) => {
@@ -348,7 +323,13 @@ const handler = async (event, req) => {
       const prData = await getRequest(req.body.issue.pull_request.url);
 
       const params = parseParams(req.body.comment.body);
-      const env = buildEnvFromParams(params);
+      const result = buildEnvFromParams(params);
+
+      if (result.error) {
+        return [result.error, result.error];
+      }
+
+      const env = result.env;
 
       const buildkite = await runBuild(
         {

--- a/frontend/ci-build-me/test/docker-filters.test.js
+++ b/frontend/ci-build-me/test/docker-filters.test.js
@@ -1,0 +1,148 @@
+// Tests for the !ci-docker-me parameters.
+//
+// Run with: node test/docker-filters.test.js
+//
+// BUILDKITE_PIPELINE_FILTER is put into a dhall expression as the name of a
+// union alternative, so a name that TagFilter.dhall does not declare stops the
+// build with a dhall type error that says nothing about the comment. The first
+// test reads TagFilter.dhall, so the list in index.js cannot fall behind it.
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const { buildEnvFromParams, DOCKER_BUILD_FILTERS } = require("../src/docker-filters.js");
+
+const TAG_FILTER_DHALL = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "buildkite",
+  "src",
+  "Pipeline",
+  "TagFilter.dhall"
+);
+
+let run = 0;
+let failed = 0;
+
+const test = (name, fn) => {
+  run += 1;
+  try {
+    fn();
+    console.log(`ok    ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL  ${name}`);
+    console.error(`      ${error.message.split("\n").join("\n      ")}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+
+test("the list of filters is the same as in TagFilter.dhall", () => {
+  const source = fs.readFileSync(TAG_FILTER_DHALL, "utf8");
+
+  // Take the alternatives of the union only, which are between "= <" and ">".
+  const union = source.slice(source.indexOf("= <"), source.indexOf("\n      >"));
+  const declared = new Set(
+    (union.match(/DockerBuild[A-Za-z0-9]*/g) || []).filter(
+      (name) => name.length > 0
+    )
+  );
+
+  const known = new Set(DOCKER_BUILD_FILTERS);
+
+  const missing = [...declared].filter((name) => !known.has(name)).sort();
+  const extra = [...known].filter((name) => !declared.has(name)).sort();
+
+  assert.deepStrictEqual(
+    { missing, extra },
+    { missing: [], extra: [] },
+    "docker-filters.js and TagFilter.dhall disagree.\n" +
+      `  declared in dhall but not in docker-filters.js: ${missing.join(", ") || "-"}\n` +
+      `  in docker-filters.js but not declared in dhall: ${extra.join(", ") || "-"}\n` +
+      "Update DOCKER_BUILD_FILTERS in src/docker-filters.js."
+  );
+});
+
+test("no parameter builds every docker image", () => {
+  const result = buildEnvFromParams({});
+  assert.deepStrictEqual(result.env, {
+    BUILDKITE_PIPELINE_FILTER: "DockerBuild",
+  });
+});
+
+test("a complete set of parameters gives the filter, the mode and Full", () => {
+  const result = buildEnvFromParams({
+    arch: "amd64",
+    profile: "devnet",
+    codename: "bookworm",
+  });
+  assert.deepStrictEqual(result.env, {
+    BUILDKITE_PIPELINE_FILTER: "DockerBuildAmd64DevnetBookworm",
+    BUILDKITE_PIPELINE_FILTER_MODE: "All",
+    BUILDKITE_PIPELINE_JOB_SELECTION: "Full",
+  });
+});
+
+// The change based triage must not remove what the author asked for by name.
+test("a build that names what to build is not triaged", () => {
+  const result = buildEnvFromParams({ arch: "amd64" });
+  assert.strictEqual(result.env.BUILDKITE_PIPELINE_JOB_SELECTION, "Full");
+});
+
+test("the architecture alone is enough", () => {
+  const result = buildEnvFromParams({ arch: "arm64" });
+  assert.strictEqual(result.env.BUILDKITE_PIPELINE_FILTER, "DockerBuildArm64");
+});
+
+test("the architecture and the profile are enough", () => {
+  const result = buildEnvFromParams({ arch: "amd64", profile: "lightnet" });
+  assert.strictEqual(
+    result.env.BUILDKITE_PIPELINE_FILTER,
+    "DockerBuildAmd64Lightnet"
+  );
+});
+
+// These are the ones that used to reach buildkite and die there.
+test("a combination with no filter is refused, not started", () => {
+  // TagFilter.dhall declares no name for a profile on its own.
+  const profileOnly = buildEnvFromParams({ profile: "devnet" });
+  assert.ok(profileOnly.error, "a profile on its own must be refused");
+  assert.ok(
+    profileOnly.error.includes("DockerBuildDevnet"),
+    "the message must name the filter that was composed"
+  );
+
+  // The three values are all correct, but this combination is not declared.
+  const gap = buildEnvFromParams({
+    arch: "arm64",
+    profile: "devnet",
+    codename: "jammy",
+  });
+  assert.ok(gap.error, "arm64 + devnet + jammy has no filter and must be refused");
+  assert.ok(
+    !DOCKER_BUILD_FILTERS.includes("DockerBuildArm64DevnetJammy"),
+    "if this filter is added, change this test"
+  );
+});
+
+test("a value that is not known is refused and the choices are given", () => {
+  const result = buildEnvFromParams({ arch: "x86", profile: "devnet" });
+  assert.ok(result.error, "arch=x86 must be refused");
+  assert.ok(result.error.includes("amd64"), "the message must give the choices");
+  assert.strictEqual(result.env, undefined, "no build may start");
+});
+
+test("a codename on its own is refused", () => {
+  const result = buildEnvFromParams({ codename: "bullseye" });
+  assert.ok(result.error, "a codename on its own must be refused");
+});
+
+// ---------------------------------------------------------------------------
+
+console.log("");
+console.log(`${run} tests, ${run - failed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
`!ci-docker-me` accepted requests it could not carry out, and the failure came
much later and said nothing useful. This makes it answer on the pull request
instead, and stops the change based triage from removing what was asked for.

### What went wrong

`BUILDKITE_PIPELINE_FILTER` is put into a dhall expression as the name of a
union alternative (`Prepare.dhall`):

```
tagFilter=(./buildkite/src/Pipeline/TagFilter.dhall).Type.${tagFilter}
```

So a name that `TagFilter.dhall` does not declare does not select nothing: it
stops the build at *Prepare monorepo triage* with a dhall type error that never
mentions the comment that caused it.

The old code composed the name by joining text and never checked the result, so
two kinds of request failed that way:

- **A part on its own.** `profile=devnet` composed `DockerBuildDevnet`. There is
  no such name; the names always start with the architecture.
- **A combination that is not declared.** `arch=arm64 profile=devnet
  codename=jammy` are each correct, but `DockerBuildArm64DevnetJammy` is not one
  of the 26 declared names. The set is not complete, and nothing said so.

A value that was simply wrong (`arch=x86`) was dropped without a word, which
then composed a different name and failed the same way.

Two smaller faults, from the same place:

- **The triage could remove the whole request.** `!ci-docker-me` never set
  `BUILDKITE_PIPELINE_JOB_SELECTION`, so `Triaged` stayed in force and a pull
  request that did not touch docker paths could select nothing at all, even
  though the author named exactly what to build. `!ci-docker-base-me` already
  sets `Full`; now this does too, but only when the author named something.

### What it does now

The composed name is checked against the names `TagFilter.dhall` declares. If it
is not one of them, no build starts and the author gets the reason, with the
list of what does exist. A value that is not known is refused with the choices
for that key.

The logic moved to `src/docker-filters.js`, away from `index.js`, which needs
`axios` and the rest of the Cloud Function. The tests therefore need no
`npm install` and run in well under a second.

### Tests

`npm test`, or `make test`, and `make deploy` now runs them first. 9 tests, no
dependencies.

The first test reads `TagFilter.dhall` and compares the names with the list in
`docker-filters.js`, so the two cannot drift apart: adding a filter to the dhall
without adding it here fails the test, and the other way round. Checked by
mutation — adding a name that the dhall does not declare gives:

```
FAIL  the list of filters is the same as in TagFilter.dhall
      in docker-filters.js but not declared in dhall: DockerBuildGhost
```

The rest cover: no parameter builds everything; a complete set gives the filter,
the mode and `Full`; the architecture on its own and with the profile are
enough; a part on its own is refused; a combination with no filter is refused;
and a value that is not known is refused with the choices.

### Not in this PR

The set of declared filters is still hand written and still has holes. Removing
the hole (composing the filter from tags instead of a name) is the next piece of
the artifact selection work; this PR only stops the holes from failing in a way
nobody can read. It also does not touch
`MinaArtifactOnlyDebianBullseye`, which is tagged `Docker` but builds no image,
so `!ci-docker-me` still selects one job that produces nothing.

**A deploy is needed for this to take effect** — `make deploy`, which now checks
parity afterwards.
