### PR TITLE
daemon: report node status by default to the O(1) Labs collector

### DIFF
--- a/changes/19207.md
+++ b/changes/19207.md
@@ -1,0 +1,21 @@
+Report node status by default
+
+The daemon now sends a node status report every 5 slots without any operator action. Before this change it sent a report only when the operator gave a collector address with `--node-status-url`. The reports let O(1) Labs follow how many nodes cross the hard fork stop slot and which version each of them runs.
+
+A report holds the observed block height, the commit hash, the chain id, the peer id, the peer count, a timestamp and, on a block producer, the block producer public key.
+
+Reports go to `https://devnet-status.gcp.o1test.net/submit/stats`. Give `--node-status-url` a different address to send them elsewhere.
+
+To switch reporting off, start the daemon with:
+
+```
+mina daemon --node-status-url none ...
+```
+
+The same can be done from `daemon.json`:
+
+```json
+{ "daemon": { "node-status-url": "none" } }
+```
+
+An empty address has the same effect. The daemon then starts no node status service and sends nothing.

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -57,7 +57,7 @@ type t =
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]
-  ; simplified_node_stats : bool [@default false]
+  ; simplified_node_stats : bool [@default true]
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; uptime_send_node_commit : bool [@default false]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1367,6 +1367,13 @@ let shorten_commit_id commit_id =
     (* Take the first 8 characters of the commit ID *)
     String.sub ~pos:0 ~len:min_commit_id_length commit_id
 
+(* Collector the node status service reports to when the operator does not give
+   [--node-status-url]. Reporting is on by default so that the network upgrade
+   can be followed across the stop slot; [--node-status-url none] switches it
+   off. *)
+let default_node_status_url =
+  "https://devnet-status.gcp.o1test.net/submit/stats"
+
 let start t =
   let commit_id_short = shorten_commit_id t.commit_id in
   let set_next_producer_timing timing consensus_state =
@@ -1458,8 +1465,13 @@ let start t =
         t.config.precomputed_values.genesis_constants.zkapp_cmd_limit_hardcap ) ;
   perform_compaction t.config.compile_config.compaction_interval t ;
   let () =
-    match t.config.node_status_url with
-    | Some node_status_url ->
+    match
+      Option.value ~default:default_node_status_url t.config.node_status_url
+    with
+    | "" | "none" ->
+        (* The operator opted out of node status reporting. *)
+        ()
+    | node_status_url ->
         let block_producer_public_key_base58 =
           Option.map ~f:(fun (_, pk) ->
               Public_key.Compressed.to_base58_check pk )
@@ -1488,8 +1500,6 @@ let start t =
                  t.config.precomputed_values.consensus_constants
                    .slot_duration_ms )
             ~block_producer_public_key_base58
-    | None ->
-        ()
   in
   let built_with_commit_sha =
     if t.config.uptime_send_node_commit then Some commit_id_short else None


### PR DESCRIPTION
Node status reporting is off today: the daemon starts the service only when the operator gives `--node-status-url`. We need it on by default so the network upgrade can be followed across the devnet stop slot.

## Change

`mina_lib.ml` gains a hard coded `default_node_status_url`, and the node status service now starts whether or not the operator gave a URL. `--node-status-url` still overrides the address, and the values `none` and `""` switch reporting off, so operators keep an opt-out.

No flag is added, renamed or removed. `mina_cli_entrypoint.ml` is untouched.

| `--node-status-url` | `--simplified-node-stats` | Result |
|---|---|---|
| unset | unset (default `true`) | Simple report to `https://devnet-status.gcp.o1test.net/submit/stats` |
| unset | `false` | Full report to the same collector |
| set to a URL | either | Report to the given URL |
| `none` or `""` | either | No reporting |

### Which flag switches reporting off

The URL does, not the boolean. This is worth stating because the name `--simplified-node-stats` reads as if it gated the reports.

- `--simplified-node-stats` **never** switches reporting on or off. It only picks the shape of the report that is sent either way: `true` (the default) sends the short one, `false` sends the long one. There is no value of it that means "send nothing".
- `--node-status-url` is the on/off control. `none` or `""` switches reporting off; any other address redirects it; leaving it unset uses the built-in collector.

So an operator who wants no telemetry sets `--node-status-url none`. Setting `--simplified-node-stats false` gives them *more* data sent, not less.

Three files:

- `src/lib/mina_lib/mina_lib.ml` — `default_node_status_url`; the service starts unless the address is `none` or empty
- `src/lib/mina_lib/config.ml` — `simplified_node_stats` default changed from `false` to `true`, to agree with the CLI default
- `changes/19207.md` — changelog, including how to switch reporting off

`release/mesa` is not touched and keeps reporting off by default.

## Note for the reviewer

Every daemon built from `compatible` now reports, and that includes the daemons our own tests start. `mina_automation` does not pass `--node-status-url`, so command-line and integration test runs in CI will POST to the real collector with a throwaway chain id. Say the word and I will pin `--node-status-url none` in `mina_automation`, which keeps CI silent without changing what operators get.

## Testing

No automated test ships with this PR. The behaviour was checked by hand against a local `--profile=devnet` build of this branch.

| Case | Setting | Expected | Result |
|---|---|---|---|
| A | no flag | daemon logs `url: https://devnet-status.gcp.o1test.net/submit/stats` | pass |
| B | `--node-status-url http://localhost:19876/node-status` | mock collector receives a report | pass |
| C | `--node-status-url none` | no node status service line at all | pass |

Case B payload, straight from the mock collector, with `commit_hash` matching this branch:

```json
{ "data": {
    "max_observed_block_height": 0,
    "commit_hash": "3627910ec4e442fbad1c7729fa1910be22ac062c",
    "chain_id": "5ab957649b294c55d3863aca1cfee8f5282bfdcec29adc963f5a5b7a9b6f5d9f",
    "peer_id": "...", "peer_count": 0,
    "timestamp": "...", "block_producer_public_key": null } }
```

Case A stops the daemon as soon as the service logs its address, which is well before the first report is due at 5 slots, so no test node reached the production collector.

Why case A is not automated: the address it checks is compiled in, so a test cannot point the daemon at a mock. Automating it would mean either aiming a live daemon at the real collector or adding an env override to the daemon purely for testing. Case B is already covered by the existing `node-status-report` command-line test.

The daemon is built with `dune build src/app/cli/src/mina.exe --profile=devnet`; the mock is `src/test/node_status_mock_server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
