### PR TITLE
mainnet: set the hard fork stop-slot schedule for 2026-09-03

### DIFF
--- a/changes/19211.md
+++ b/changes/19211.md
@@ -1,0 +1,33 @@
+Set the mainnet hard fork stop-slot schedule
+
+The mainnet runtime configuration now carries the stop-slot schedule for the
+Mesa upgrade:
+
+```json
+"slot_tx_end": 393800,
+"slot_chain_end": 393900,
+"hard_fork_genesis_slot_delta": 60
+```
+
+Against mainnet's genesis of `2024-06-05T00:00:00Z` and its 180 s slot, these
+place the schedule on Thursday 3 September 2026:
+
+| Event | Slot | Time (UTC) |
+| --- | --- | --- |
+| Transactions stop | 393800 | 10:00 |
+| Chain stops | 393900 | 15:00 |
+| First Mesa slot | 393960 | 18:00 |
+
+That is five hours of empty blocks, then three hours of downtime, so eight
+hours in total during which users cannot transact.
+
+The stop-slot unit test now covers mainnet as well as devnet, and is renamed
+from `devnet_stop_slot_test` to `stop_slot_test` to match. It derives every
+time from the daemon's own scheduling code rather than restating the
+arithmetic, so the configuration is checked against the logic that will act
+on it.
+
+Note that these slot numbers are specific to mainnet. Devnet's genesis is
+`2024-04-09T21:00:00Z`, so the same wall-clock schedule sits at different
+slots there; reusing devnet's numbers on mainnet would move the stop by
+almost two months.

--- a/genesis_ledgers/mainnet.json
+++ b/genesis_ledgers/mainnet.json
@@ -28,6 +28,9 @@
   },
   "daemon": {
     "network_id": "mainnet",
-    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/mainnet.txt"
+    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/mainnet.txt",
+    "slot_tx_end": 393800,
+    "slot_chain_end": 393900,
+    "hard_fork_genesis_slot_delta": 60
   }
 }

--- a/src/lib/runtime_config/test/dune
+++ b/src/lib/runtime_config/test/dune
@@ -1,5 +1,5 @@
 (test
- (name devnet_stop_slot_test)
+ (name stop_slot_test)
  (libraries
   ;; opam libraries
   alcotest
@@ -14,16 +14,22 @@
   logger
   mina_numbers
   runtime_config)
- (deps devnet.json)
+ (deps devnet.json mainnet.json)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
   (pps ppx_version)))
 
-; The test asserts against the config that actually ships, rather than a copy
-; that could drift from it.
+; The test asserts against the configs that actually ship, rather than copies
+; that could drift from them.
 (rule
  (targets devnet.json)
  (deps %{workspace_root}/genesis_ledgers/devnet.json)
+ (action
+  (copy %{deps} %{targets})))
+
+(rule
+ (targets mainnet.json)
+ (deps %{workspace_root}/genesis_ledgers/mainnet.json)
  (action
   (copy %{deps} %{targets})))

--- a/src/lib/runtime_config/test/stop_slot_test.ml
+++ b/src/lib/runtime_config/test/stop_slot_test.ml
@@ -274,9 +274,59 @@ let devnet_expected : Expected.t =
    run against the config that actually ships. *)
 let devnet_config_path = "devnet.json"
 
+(* ------------------------------------------------------------------ *)
+(* mainnet                                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* Mainnet's compiled constants are the ones devnet.ml includes, so the same
+   values apply. They are restated rather than shared with [devnet] above to
+   keep each network's expectations independently readable: if the two ever
+   diverge, only the affected network's block changes. *)
+let mainnet : Network_constants.t =
+  let compiled = Genesis_constants.Compiled.genesis_constants in
+  { constraint_constants =
+      { Genesis_constants.Compiled.constraint_constants with
+        block_window_duration_ms = 180_000
+      }
+  ; genesis_constants =
+      { compiled with
+        protocol =
+          { compiled.protocol with
+            k = 290
+          ; slots_per_epoch = 7140
+          ; slots_per_sub_window = 7
+          ; grace_period_slots = 2160
+          ; delta = 0
+          }
+      }
+  }
+
+(* Mainnet's genesis is 2024-06-05T00:00:00Z, two months later than devnet's,
+   so the same wall-clock schedule sits at different slot numbers. Reusing
+   devnet's 413540/413640 here would place the stop almost two months late. *)
+let mainnet_expected : Expected.t =
+  { slot_tx_end = 393800
+  ; slot_chain_end = 393900
+  ; hard_fork_genesis_slot_delta = 60
+  ; hard_fork_genesis_slot = 393960
+  ; tx_end_time = "2026-09-03T10:00:00.000000Z"
+  ; chain_end_time = "2026-09-03T15:00:00.000000Z"
+  ; hard_fork_genesis_time = "2026-09-03T18:00:00.000000Z"
+  ; empty_block_hours = 5
+  ; downtime_hours = 3
+  ; no_transaction_hours = 8
+  ; tx_end_epoch = 55
+  ; tx_end_slot_in_epoch = 1100
+  }
+
+let mainnet_config_path = "mainnet.json"
+
 let () =
   Alcotest.run "Hard fork stop slot schedule"
     [ ( "devnet"
       , suite ~network:devnet ~expected:devnet_expected
           ~config_path:devnet_config_path )
+    ; ( "mainnet"
+      , suite ~network:mainnet ~expected:mainnet_expected
+          ~config_path:mainnet_config_path )
     ]


### PR DESCRIPTION
Sets the mainnet stop-slot schedule and extends the stop-slot test to cover it.

```json
"slot_tx_end": 393800,
"slot_chain_end": 393900,
"hard_fork_genesis_slot_delta": 60
```

Against mainnet's genesis `2024-06-05T00:00:00Z` and its 180 s slot:

| Event | Slot | Time (UTC) |
| --- | --- | --- |
| Transactions stop | 393800 | Thu 2026-09-03 10:00 |
| Chain stops | 393900 | Thu 2026-09-03 15:00 |
| First Mesa slot | 393960 | Thu 2026-09-03 18:00 |

Five hours of empty blocks, three hours of downtime, eight hours without transactions. Epoch 55, slot 1100.

### Test

The existing devnet stop-slot test is extended with a mainnet suite and renamed `devnet_stop_slot_test` -> `stop_slot_test`, since it is no longer devnet-only. It asserts against `genesis_ledgers/mainnet.json` as it ships (copied by a dune rule) and derives every time through the daemon's own chain of calls, so nothing restates the slot arithmetic.

`dune runtest src/lib/runtime_config/test` -> **16/16 pass** (8 devnet + 8 mainnet).

### These numbers are mainnet-specific

Devnet's genesis is `2024-04-09T21:00:00Z`, mainnet's is `2024-06-05T00:00:00Z`, so the same wall clock lands on different slots:

| | devnet | mainnet |
| --- | --- | --- |
| stop-transaction | 420740 | **393800** |
| stop-network | 420840 | **393900** |
| first Mesa slot | 420900 | **393960** |

Applying devnet's `420740` to mainnet would stop it on 2026-10-29, nearly two months late.