### PR TITLE
name the lower rosetta image for the tier it is

### DIFF
--- a/buildkite/src/Constants/Docker/Package.dhall
+++ b/buildkite/src/Constants/Docker/Package.dhall
@@ -56,7 +56,7 @@ let lowerName =
             , DaemonAutoHardfork =
                 \(args : { network : Network.Type }) -> "daemon_auto_hardfork"
             , Archive = \(args : { network : Network.Type }) -> "archive"
-            , RosettaGeneric = "rosetta_apps_only"
+            , RosettaGeneric = "rosetta_profile"
             , Rosetta = \(args : { network : Network.Type }) -> "rosetta_config"
             , TxTools = "tx_tools"
             , DelegationVerifier = "delegation_verifier"


### PR DESCRIPTION
The lower rosetta image is called `rosetta_apps_only`, but it is not apps only.
This gives it the name of the tier it actually occupies. One line, and the
rendered pipelines change only in that name.

### What the image really holds

`dockerfiles/stages/rosetta/2-mina-rosetta` installs, in its two branches:

```
generic branch:  mina-generic, logproc, archive-generic, archive,
                 rosetta-generic, rosetta, PROFILE_DEB
config  branch:  mina-generic, logproc, MINA_CONFIG_DEB, archive-generic, archive,
                 rosetta-generic, rosetta, PROFILE_DEB
```

`PROFILE_DEB` is in **both**. The only difference between the two images is the
config package. So the lower one is *apps + profile*, not *apps only*.

The daemon uses three tiers, and names them:

| Tier | Artifact | Debian token | Docker service |
|---|---|---|---|
| apps only | `daemonGeneric` | `daemon_generic` | `daemon_apps_only` |
| apps + profile | `daemonProfiled` | `profile_<profile>` | `daemon_profile` |
| apps + profile + config | `daemon` | `daemon_<network>_config` | `daemon_config` |

The daemon's apps-only image really is apps only: its Dockerfile says it
"builds the CONFIGLESS daemon image" and installs no profile. So
`daemon_apps_only` and `rosetta_apps_only` carried the same name for two
different tiers, and rosetta has no tier-1 image at all.

That matters beyond tidiness: the work on named artifact sets picks steps by
these names, and a name that claims the wrong tier makes the wrong set.

### Why this is safe

`Docker.lowerName` is used only to build the buildkite **step key**
(`DockerImage.dhall`, `stepKey`). The published image name comes from
`Docker.dockerName`, which this does not touch, so no tag that anyone pulls
changes.

The step keys and the `depends_on` entries that point at them are built by the
same function, so they move together.

### Verified

All the pipelines were rendered before and after, and every line that differs is
this rename:

```
$ diff -r before/ after/ | grep '^[<>]' | grep -v 'rosetta_apps_only\|rosetta_profile'
(nothing)
```

`make all` in `buildkite/`: 45/45.

### Next, not here

- Rosetta's lower image is built once for each network (`rosetta_profile-devnet`,
  `rosetta_profile-mainnet`) and those are genuinely different images, because
  the profile follows the network. Splitting the artifact so that this tier has
  its own entry therefore needs that artifact to carry a network, and today the
  Debian side has one network-free `rosetta_generic` package, so two networked
  artifacts would ask `scripts/debian/build.sh` for the same token twice and
  trip its duplicate-output check. That needs a decision, so it is not in here.
- Whether rosetta should have a real tier-1 image at all.
