### PR TITLE
node status: default to the mainnet collector

### DIFF
--- a/changes/19217.md
+++ b/changes/19217.md
@@ -1,0 +1,15 @@
+Node status reports go to the mainnet collector
+
+The daemon reports node status every 5 slots when the operator gives no
+`--node-status-url`. That built-in address now points at the mainnet
+collector:
+
+```
+https://mainnet-status.gcp.o1test.net/submit/stats
+```
+
+It was previously the devnet collector.
+
+To report somewhere else, give the address with `--node-status-url`, or set
+`node-status-url` in `daemon.json`. To switch reporting off, use
+`--node-status-url none` or an empty address.

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1372,7 +1372,7 @@ let shorten_commit_id commit_id =
    can be followed across the stop slot; [--node-status-url none] switches it
    off. *)
 let default_node_status_url =
-  "https://devnet-status.gcp.o1test.net/submit/stats"
+  "https://mainnet-status.gcp.o1test.net/submit/stats"
 
 let start t =
   let commit_id_short = shorten_commit_id t.commit_id in


### PR DESCRIPTION
One-line change to the built-in node status collector address:

```diff
 let default_node_status_url =
-  "https://devnet-status.gcp.o1test.net/submit/stats"
+  "https://mainnet-status.gcp.o1test.net/submit/stats"
```

Operators can still override with `--node-status-url`, or `node-status-url` in `daemon.json`, and switch reporting off with `--node-status-url none`.

### Two consequences worth knowing

- **Devnet builds made from this branch will report to the mainnet collector.** The address is compiled in and one build serves several networks, so devnet nodes that do not pass `--node-status-url` will send there. The already-published devnet artifacts are unaffected — they carry the old address.
- **`mainnet-status.gcp.o1test.net` does not resolve yet.** `devnet-status` is live and confirmed receiving reports; the mainnet collector still needs deploying, otherwise reports will fail to send.

Replaces the earlier, more invasive version of this PR, which moved the address into the runtime config per network. That also avoids touching `Runtime_config.Daemon`, so this now merges forward to `release/mesa` without conflict.