### PR TITLE
Merge compatible into develop

### DIFF
--- a/changes/19179.md
+++ b/changes/19179.md
@@ -1,0 +1,11 @@
+Schedule the devnet hard fork
+
+The devnet runtime config now carries the stop-slot schedule for the upcoming hard fork. `slot_tx_end` is 413540, `slot_chain_end` is 413640 and `hard_fork_genesis_slot_delta` is 60. These slots are counted from the 2024-04-09 fork genesis, so on the wall clock they are:
+
+- 2026-08-19 10:00 UTC — the network stops accepting transactions. Blocks are still produced, but they are empty.
+- 2026-08-19 15:00 UTC — block production stops.
+- 2026-08-19 18:00 UTC — the hard fork chain starts.
+
+Node operators therefore cannot send transactions for 8 hours, of which the last 3 hours have no blocks at all. Nodes pick the schedule up from the config; a daemon must also be started with `--hardfork-handling migrate-exit` for it to generate the hard fork config automatically.
+
+A unit test asserts the schedule by running the daemon's own scheduling code against the shipped config, so the slots, the times they fall on and the length of each window are checked rather than restated.

--- a/changes/19207.md
+++ b/changes/19207.md
@@ -1,0 +1,21 @@
+Report node status by default
+
+The daemon now sends a node status report every 5 slots without any operator action. Before this change it sent a report only when the operator gave a collector address with `--node-status-url`. The reports let O(1) Labs follow how many nodes cross the hard fork stop slot and which version each of them runs.
+
+A report holds the observed block height, the commit hash, the chain id, the peer id, the peer count, a timestamp and, on a block producer, the block producer public key.
+
+Reports go to `https://devnet-status.gcp.o1test.net/submit/stats`. Give `--node-status-url` a different address to send them elsewhere.
+
+To switch reporting off, start the daemon with:
+
+```
+mina daemon --node-status-url none ...
+```
+
+The same can be done from `daemon.json`:
+
+```json
+{ "daemon": { "node-status-url": "none" } }
+```
+
+An empty address has the same effect. The daemon then starts no node status service and sends nothing.

--- a/changes/19211.md
+++ b/changes/19211.md
@@ -1,0 +1,33 @@
+Set the mainnet hard fork stop-slot schedule
+
+The mainnet runtime configuration now carries the stop-slot schedule for the
+Mesa upgrade:
+
+```json
+"slot_tx_end": 393800,
+"slot_chain_end": 393900,
+"hard_fork_genesis_slot_delta": 60
+```
+
+Against mainnet's genesis of `2024-06-05T00:00:00Z` and its 180 s slot, these
+place the schedule on Thursday 3 September 2026:
+
+| Event | Slot | Time (UTC) |
+| --- | --- | --- |
+| Transactions stop | 393800 | 10:00 |
+| Chain stops | 393900 | 15:00 |
+| First Mesa slot | 393960 | 18:00 |
+
+That is five hours of empty blocks, then three hours of downtime, so eight
+hours in total during which users cannot transact.
+
+The stop-slot unit test now covers mainnet as well as devnet, and is renamed
+from `devnet_stop_slot_test` to `stop_slot_test` to match. It derives every
+time from the daemon's own scheduling code rather than restating the
+arithmetic, so the configuration is checked against the logic that will act
+on it.
+
+Note that these slot numbers are specific to mainnet. Devnet's genesis is
+`2024-04-09T21:00:00Z`, so the same wall-clock schedule sits at different
+slots there; reusing devnet's numbers on mainnet would move the stop by
+almost two months.

--- a/changes/19217.md
+++ b/changes/19217.md
@@ -1,0 +1,15 @@
+Node status reports go to the mainnet collector
+
+The daemon reports node status every 5 slots when the operator gives no
+`--node-status-url`. That built-in address now points at the mainnet
+collector:
+
+```
+https://mainnet-status.gcp.o1test.net/submit/stats
+```
+
+It was previously the devnet collector.
+
+To report somewhere else, give the address with `--node-status-url`, or set
+`node-status-url` in `daemon.json`. To switch reporting off, use
+`--node-status-url none` or an empty address.

--- a/genesis_ledgers/devnet.json
+++ b/genesis_ledgers/devnet.json
@@ -28,6 +28,9 @@
   },
   "daemon": {
     "network_id": "devnet",
-    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/devnet.txt"
+    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/devnet.txt",
+    "slot_tx_end": 413540,
+    "slot_chain_end": 413640,
+    "hard_fork_genesis_slot_delta": 60
   }
 }

--- a/genesis_ledgers/mainnet.json
+++ b/genesis_ledgers/mainnet.json
@@ -28,6 +28,9 @@
   },
   "daemon": {
     "network_id": "mainnet",
-    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/mainnet.txt"
+    "peer_list_url": "https://bootnodes.minaprotocol.com/networks/mainnet.txt",
+    "slot_tx_end": 393800,
+    "slot_chain_end": 393900,
+    "hard_fork_genesis_slot_delta": 60
   }
 }

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -552,8 +552,8 @@ let setup_daemon logger ~itn_features ~default_snark_worker_fee =
   and simplified_node_stats =
     flag "--simplified-node-stats"
       ~aliases:[ "simplified-node-stats" ]
-      (optional_with_default true bool)
-      ~doc:"whether to report simplified node stats (default: true)"
+      (optional_with_default false bool)
+      ~doc:"whether to report simplified node stats (default: false)"
   and contact_info =
     flag "--contact-info" ~aliases:[ "contact-info" ] (optional string)
       ~doc:

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -57,7 +57,7 @@ type t =
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
   ; node_status_url : string option [@default None]
-  ; simplified_node_stats : bool [@default false]
+  ; simplified_node_stats : bool [@default true]
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; uptime_send_node_commit : bool [@default false]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1372,7 +1372,7 @@ let shorten_commit_id commit_id =
    can be followed across the stop slot; [--node-status-url none] switches it
    off. *)
 let default_node_status_url =
-  "https://devnet-status.gcp.o1test.net/submit/stats"
+  "https://mainnet-status.gcp.o1test.net/submit/stats"
 
 let start t =
   let commit_id_short = shorten_commit_id t.commit_id in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1367,6 +1367,13 @@ let shorten_commit_id commit_id =
     (* Take the first 8 characters of the commit ID *)
     String.sub ~pos:0 ~len:min_commit_id_length commit_id
 
+(* Collector the node status service reports to when the operator does not give
+   [--node-status-url]. Reporting is on by default so that the network upgrade
+   can be followed across the stop slot; [--node-status-url none] switches it
+   off. *)
+let default_node_status_url =
+  "https://devnet-status.gcp.o1test.net/submit/stats"
+
 let start t =
   let commit_id_short = shorten_commit_id t.commit_id in
   let set_next_producer_timing timing consensus_state =
@@ -1458,8 +1465,13 @@ let start t =
         t.config.precomputed_values.genesis_constants.zkapp_cmd_limit_hardcap ) ;
   perform_compaction t.config.compile_config.compaction_interval t ;
   let () =
-    match t.config.node_status_url with
-    | Some node_status_url ->
+    match
+      Option.value ~default:default_node_status_url t.config.node_status_url
+    with
+    | "" | "none" ->
+        (* The operator opted out of node status reporting. *)
+        ()
+    | node_status_url ->
         let block_producer_public_key_base58 =
           Option.map ~f:(fun (_, pk) ->
               Public_key.Compressed.to_base58_check pk )
@@ -1488,8 +1500,6 @@ let start t =
                  t.config.precomputed_values.consensus_constants
                    .slot_duration_ms )
             ~block_producer_public_key_base58
-    | None ->
-        ()
   in
   let built_with_commit_sha =
     if t.config.uptime_send_node_commit then Some commit_id_short else None

--- a/src/lib/runtime_config/test/devnet_stop_slot_test.ml
+++ b/src/lib/runtime_config/test/devnet_stop_slot_test.ml
@@ -1,0 +1,282 @@
+(** Checks a network's hard fork stop-slot schedule by driving the daemon's own
+    scheduling logic.
+
+    Nothing here reimplements slot arithmetic. Every derived value comes from
+    the same chain of calls the daemon makes when it arms the auto hard fork in
+    [src/app/cli/src/init/mina_run.ml]:
+
+    {v
+      Runtime_config.slot_tx_end / slot_chain_end
+      Runtime_config.hard_fork_genesis_slot_delta
+      Runtime_config.scheduled_hard_fork_genesis_slot
+      Genesis_ledger_helper.make_genesis_constants   (config -> constants)
+      Consensus.Constants.create
+      Consensus.Data.Consensus_time.of_global_slot / start_time / epoch / slot
+      Block_time.diff                                (window durations)
+    v}
+
+    The test supplies two things: the runtime config of the network under test,
+    and that network's compiled constants. The latter are needed because this
+    test binary is not built with the target network's profile -- under the
+    default [dev] profile a slot is 2 s rather than devnet's 180 s -- so they
+    are given explicitly rather than read from [Node_config].
+
+    Counters: [slot_tx_end] and [slot_chain_end] are
+    [Global_slot_since_hard_fork], counted from the network's last hard fork
+    genesis. A fork config's [proof.fork.global_slot_since_genesis] is a
+    different counter; the two must never be compared directly. For devnet the
+    fork base is 445860, so the hard fork genesis slot expressed in that other
+    counter is 445860 + 413700 = 859560. *)
+
+open Core_kernel
+
+(** The compiled constants of the network under test. *)
+module Network_constants = struct
+  type t =
+    { constraint_constants : Genesis_constants.Constraint_constants.t
+    ; genesis_constants : Genesis_constants.t
+    }
+end
+
+(** The schedule a runtime config declares, plus the daemon-derived quantities
+    that follow from it. *)
+module Schedule = struct
+  type t =
+    { slot_tx_end : Mina_numbers.Global_slot_since_hard_fork.t
+    ; slot_chain_end : Mina_numbers.Global_slot_since_hard_fork.t
+    ; hard_fork_genesis_slot_delta : Mina_numbers.Global_slot_span.t
+    ; hard_fork_genesis_slot : Mina_numbers.Global_slot_since_hard_fork.t
+    ; consensus_constants : Consensus.Constants.t
+    }
+
+  let require field = function
+    | Some v ->
+        v
+    | None ->
+        failwithf "runtime config: %s is not set" field ()
+
+  let of_config ~(network : Network_constants.t) (config : Runtime_config.t) =
+    (* Same merge the daemon performs: runtime config overrides the compiled
+       genesis constants, then consensus constants are derived from those. *)
+    let genesis_constants =
+      Genesis_ledger_helper.make_genesis_constants ~logger:(Logger.null ())
+        ~default:network.genesis_constants config
+      |> Or_error.ok_exn
+    in
+    let consensus_constants =
+      Consensus.Constants.create
+        ~constraint_constants:network.constraint_constants
+        ~protocol_constants:genesis_constants.protocol
+    in
+    { slot_tx_end =
+        require "daemon.slot_tx_end" (Runtime_config.slot_tx_end config)
+    ; slot_chain_end =
+        require "daemon.slot_chain_end" (Runtime_config.slot_chain_end config)
+    ; hard_fork_genesis_slot_delta =
+        require "daemon.hard_fork_genesis_slot_delta"
+          (Runtime_config.hard_fork_genesis_slot_delta config)
+    ; hard_fork_genesis_slot =
+        require "scheduled hard fork genesis slot"
+          (Runtime_config.scheduled_hard_fork_genesis_slot config)
+    ; consensus_constants
+    }
+
+  let of_file ~network path =
+    Yojson.Safe.from_file path |> Runtime_config.of_yojson
+    |> Result.map_error ~f:Error.of_string
+    |> Or_error.ok_exn |> of_config ~network
+
+  let slot_tx_end t = t.slot_tx_end
+
+  let slot_chain_end t = t.slot_chain_end
+
+  let hard_fork_genesis_slot_delta t = t.hard_fork_genesis_slot_delta
+
+  let hard_fork_genesis_slot t = t.hard_fork_genesis_slot
+
+  let consensus_time t slot =
+    Consensus.Data.Consensus_time.of_global_slot
+      ~constants:t.consensus_constants slot
+
+  (** Block time at which a slot begins -- the daemon's own computation. *)
+  let block_time_of_slot t slot =
+    Consensus.Data.Consensus_time.start_time ~constants:t.consensus_constants
+      (consensus_time t slot)
+
+  (** Formatted the same way the daemon logs it in [mina_run.ml]. *)
+  let time_of_slot t slot =
+    Block_time.to_time_exn (block_time_of_slot t slot)
+    |> Time.to_string_iso8601_basic ~zone:Time.Zone.utc
+
+  let hours_between t ~from_slot ~to_slot =
+    let span =
+      Block_time.diff
+        (block_time_of_slot t to_slot)
+        (block_time_of_slot t from_slot)
+    in
+    Int64.to_int_exn (Block_time.Span.to_ms span) / 3_600_000
+
+  (** Blocks are still produced in this window, but must be empty. *)
+  let empty_block_hours t =
+    hours_between t ~from_slot:t.slot_tx_end ~to_slot:t.slot_chain_end
+
+  (** No blocks at all in this window. *)
+  let downtime_hours t =
+    hours_between t ~from_slot:t.slot_chain_end
+      ~to_slot:t.hard_fork_genesis_slot
+
+  (** Total time users cannot transact. *)
+  let no_transaction_hours t =
+    hours_between t ~from_slot:t.slot_tx_end ~to_slot:t.hard_fork_genesis_slot
+
+  let epoch_of_slot t slot =
+    Unsigned.UInt32.to_int
+      (Consensus.Data.Consensus_time.epoch (consensus_time t slot))
+
+  let slot_in_epoch t slot =
+    Unsigned.UInt32.to_int
+      (Consensus.Data.Consensus_time.slot (consensus_time t slot))
+end
+
+(** What a network's schedule is expected to be. *)
+module Expected = struct
+  type t =
+    { slot_tx_end : int
+    ; slot_chain_end : int
+    ; hard_fork_genesis_slot_delta : int
+    ; hard_fork_genesis_slot : int
+    ; tx_end_time : string
+    ; chain_end_time : string
+    ; hard_fork_genesis_time : string
+    ; empty_block_hours : int
+    ; downtime_hours : int
+    ; no_transaction_hours : int
+    ; tx_end_epoch : int
+    ; tx_end_slot_in_epoch : int
+    }
+end
+
+let suite ~network ~(expected : Expected.t) ~config_path =
+  let open Expected in
+  let schedule () = Schedule.of_file ~network config_path in
+  let slot = Mina_numbers.Global_slot_since_hard_fork.to_int in
+  let case name f = Alcotest.test_case name `Quick f in
+  [ case "configured slots are the agreed values" (fun () ->
+        let t = schedule () in
+        Alcotest.(check int)
+          "slot_tx_end" expected.slot_tx_end
+          (slot (Schedule.slot_tx_end t)) ;
+        Alcotest.(check int)
+          "slot_chain_end" expected.slot_chain_end
+          (slot (Schedule.slot_chain_end t)) ;
+        Alcotest.(check int)
+          "hard_fork_genesis_slot_delta" expected.hard_fork_genesis_slot_delta
+          (Mina_numbers.Global_slot_span.to_int
+             (Schedule.hard_fork_genesis_slot_delta t) ) )
+  ; case "daemon derives hard fork genesis slot as chain_end + delta" (fun () ->
+        Alcotest.(check int)
+          "hard_fork_genesis_slot" expected.hard_fork_genesis_slot
+          (slot (Schedule.hard_fork_genesis_slot (schedule ()))) )
+  ; case "slots are correctly ordered" (fun () ->
+        let t = schedule () in
+        Alcotest.(check bool)
+          "slot_tx_end < slot_chain_end" true
+          (slot (Schedule.slot_tx_end t) < slot (Schedule.slot_chain_end t)) ;
+        Alcotest.(check bool)
+          "slot_chain_end <= hard fork genesis slot" true
+          ( slot (Schedule.slot_chain_end t)
+          <= slot (Schedule.hard_fork_genesis_slot t) ) )
+  ; case "daemon places transaction stop at the agreed time" (fun () ->
+        let t = schedule () in
+        Alcotest.(check string)
+          "tx end time" expected.tx_end_time
+          (Schedule.time_of_slot t (Schedule.slot_tx_end t)) )
+  ; case "daemon places chain stop at the agreed time" (fun () ->
+        let t = schedule () in
+        Alcotest.(check string)
+          "chain end time" expected.chain_end_time
+          (Schedule.time_of_slot t (Schedule.slot_chain_end t)) )
+  ; case "daemon places hard fork genesis at the agreed time" (fun () ->
+        let t = schedule () in
+        Alcotest.(check string)
+          "hard fork genesis time" expected.hard_fork_genesis_time
+          (Schedule.time_of_slot t (Schedule.hard_fork_genesis_slot t)) )
+  ; case "windows have the communicated durations" (fun () ->
+        let t = schedule () in
+        Alcotest.(check int)
+          "hours of empty blocks (tx stop -> chain stop)"
+          expected.empty_block_hours
+          (Schedule.empty_block_hours t) ;
+        Alcotest.(check int)
+          "hours of downtime (chain stop -> hard fork genesis)"
+          expected.downtime_hours
+          (Schedule.downtime_hours t) ;
+        Alcotest.(check int)
+          "hours without transactions (tx stop -> hard fork genesis)"
+          expected.no_transaction_hours
+          (Schedule.no_transaction_hours t) )
+  ; case "transaction stop lands where expected in the epoch schedule"
+      (fun () ->
+        let t = schedule () in
+        let s = Schedule.slot_tx_end t in
+        Alcotest.(check int)
+          "epoch of slot_tx_end" expected.tx_end_epoch
+          (Schedule.epoch_of_slot t s) ;
+        Alcotest.(check int)
+          "slot-in-epoch of slot_tx_end" expected.tx_end_slot_in_epoch
+          (Schedule.slot_in_epoch t s) )
+  ]
+
+(* ------------------------------------------------------------------ *)
+(* devnet                                                             *)
+(* ------------------------------------------------------------------ *)
+
+(* Devnet's compiled constants, from src/lib/node_config/profiled/mainnet.ml
+   which devnet.ml includes. They are restated here because this binary is not
+   a devnet build and node_config_profiled.mli does not expose the per-profile
+   modules. The genesis timestamp is deliberately NOT set here -- it comes from
+   the runtime config under test, via make_genesis_constants. *)
+let devnet : Network_constants.t =
+  let compiled = Genesis_constants.Compiled.genesis_constants in
+  { constraint_constants =
+      { Genesis_constants.Compiled.constraint_constants with
+        block_window_duration_ms = 180_000
+      }
+  ; genesis_constants =
+      { compiled with
+        protocol =
+          { compiled.protocol with
+            k = 290
+          ; slots_per_epoch = 7140
+          ; slots_per_sub_window = 7
+          ; grace_period_slots = 2160
+          ; delta = 0
+          }
+      }
+  }
+
+let devnet_expected : Expected.t =
+  { slot_tx_end = 413540
+  ; slot_chain_end = 413640
+  ; hard_fork_genesis_slot_delta = 60
+  ; hard_fork_genesis_slot = 413700
+  ; tx_end_time = "2026-08-19T10:00:00.000000Z"
+  ; chain_end_time = "2026-08-19T15:00:00.000000Z"
+  ; hard_fork_genesis_time = "2026-08-19T18:00:00.000000Z"
+  ; empty_block_hours = 5
+  ; downtime_hours = 3
+  ; no_transaction_hours = 8
+  ; tx_end_epoch = 57
+  ; tx_end_slot_in_epoch = 6560
+  }
+
+(* Copied next to the test executable by the rule in ./dune, so the assertions
+   run against the config that actually ships. *)
+let devnet_config_path = "devnet.json"
+
+let () =
+  Alcotest.run "Hard fork stop slot schedule"
+    [ ( "devnet"
+      , suite ~network:devnet ~expected:devnet_expected
+          ~config_path:devnet_config_path )
+    ]

--- a/src/lib/runtime_config/test/dune
+++ b/src/lib/runtime_config/test/dune
@@ -1,5 +1,5 @@
 (test
- (name devnet_stop_slot_test)
+ (name stop_slot_test)
  (libraries
   ;; opam libraries
   alcotest
@@ -14,16 +14,22 @@
   logger
   mina_numbers
   runtime_config)
- (deps devnet.json)
+ (deps devnet.json mainnet.json)
  (instrumentation
   (backend bisect_ppx))
  (preprocess
   (pps ppx_version)))
 
-; The test asserts against the config that actually ships, rather than a copy
-; that could drift from it.
+; The test asserts against the configs that actually ship, rather than copies
+; that could drift from them.
 (rule
  (targets devnet.json)
  (deps %{workspace_root}/genesis_ledgers/devnet.json)
+ (action
+  (copy %{deps} %{targets})))
+
+(rule
+ (targets mainnet.json)
+ (deps %{workspace_root}/genesis_ledgers/mainnet.json)
  (action
   (copy %{deps} %{targets})))

--- a/src/lib/runtime_config/test/dune
+++ b/src/lib/runtime_config/test/dune
@@ -1,0 +1,29 @@
+(test
+ (name devnet_stop_slot_test)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core_kernel
+  integers
+  yojson
+  ;; local libraries
+  block_time
+  consensus
+  genesis_constants
+  genesis_ledger_helper
+  logger
+  mina_numbers
+  runtime_config)
+ (deps devnet.json)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))
+
+; The test asserts against the config that actually ships, rather than a copy
+; that could drift from it.
+(rule
+ (targets devnet.json)
+ (deps %{workspace_root}/genesis_ledgers/devnet.json)
+ (action
+  (copy %{deps} %{targets})))

--- a/src/lib/runtime_config/test/stop_slot_test.ml
+++ b/src/lib/runtime_config/test/stop_slot_test.ml
@@ -274,9 +274,59 @@ let devnet_expected : Expected.t =
    run against the config that actually ships. *)
 let devnet_config_path = "devnet.json"
 
+(* ------------------------------------------------------------------ *)
+(* mainnet                                                            *)
+(* ------------------------------------------------------------------ *)
+
+(* Mainnet's compiled constants are the ones devnet.ml includes, so the same
+   values apply. They are restated rather than shared with [devnet] above to
+   keep each network's expectations independently readable: if the two ever
+   diverge, only the affected network's block changes. *)
+let mainnet : Network_constants.t =
+  let compiled = Genesis_constants.Compiled.genesis_constants in
+  { constraint_constants =
+      { Genesis_constants.Compiled.constraint_constants with
+        block_window_duration_ms = 180_000
+      }
+  ; genesis_constants =
+      { compiled with
+        protocol =
+          { compiled.protocol with
+            k = 290
+          ; slots_per_epoch = 7140
+          ; slots_per_sub_window = 7
+          ; grace_period_slots = 2160
+          ; delta = 0
+          }
+      }
+  }
+
+(* Mainnet's genesis is 2024-06-05T00:00:00Z, two months later than devnet's,
+   so the same wall-clock schedule sits at different slot numbers. Reusing
+   devnet's 413540/413640 here would place the stop almost two months late. *)
+let mainnet_expected : Expected.t =
+  { slot_tx_end = 393800
+  ; slot_chain_end = 393900
+  ; hard_fork_genesis_slot_delta = 60
+  ; hard_fork_genesis_slot = 393960
+  ; tx_end_time = "2026-09-03T10:00:00.000000Z"
+  ; chain_end_time = "2026-09-03T15:00:00.000000Z"
+  ; hard_fork_genesis_time = "2026-09-03T18:00:00.000000Z"
+  ; empty_block_hours = 5
+  ; downtime_hours = 3
+  ; no_transaction_hours = 8
+  ; tx_end_epoch = 55
+  ; tx_end_slot_in_epoch = 1100
+  }
+
+let mainnet_config_path = "mainnet.json"
+
 let () =
   Alcotest.run "Hard fork stop slot schedule"
     [ ( "devnet"
       , suite ~network:devnet ~expected:devnet_expected
           ~config_path:devnet_config_path )
+    ; ( "mainnet"
+      , suite ~network:mainnet ~expected:mainnet_expected
+          ~config_path:mainnet_config_path )
     ]


### PR DESCRIPTION
Brings `develop` up to `compatible@8110ede`. Clean merge, no conflicts. 15 commits, none of which `develop` had.

Makes `compatible` an ancestor of `develop` again, which is what the "merges cleanly into compatible" check needs.

### What it brings

| Area | Change |
| --- | --- |
| `genesis_ledgers/devnet.json` | devnet stop slots `413540 / 413640 / 60` |
| `genesis_ledgers/mainnet.json` | mainnet stop slots `393800 / 393900 / 60` (2026-09-03) |
| `src/lib/runtime_config/test/` | stop-slot test, devnet + mainnet |
| `mina_lib.ml`, `config.ml` | node status reported by default, collector `mainnet-status.gcp.o1test.net` |
| `mina_cli_entrypoint.ml` | `--simplified-node-stats` default `true` -> `false` |
| `changes/` | 19179, 19207, 19211, 19217 |

### One decision to confirm before merging

This is a **faithful** forward port — it includes the node-status default-on behaviour. When porting to `release/mesa` (#19216) that behaviour was deliberately dropped, on the grounds that reporting by default belongs to the pre-fork stop-slot window on `compatible` only.

If the same reasoning applies to `develop`, say so and I will revert the three files inside the merge exactly as in #19216:

- `mina_lib.ml` — drop `default_node_status_url`, report only when `--node-status-url` is given
- `config.ml` — `simplified_node_stats` back to `[@default false]`
- `mina_cli_entrypoint.ml` — `--simplified-node-stats` back to `true`

Changelog files are kept here, unlike #19216, since `develop` is where they belong. Say if you would rather drop them too.