### PR TITLE
add a step selector that closes over the real dependency graph

### DIFF
--- a/buildkite/scripts/pipeline/select_steps.sh
+++ b/buildkite/scripts/pipeline/select_steps.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+# Choose pipeline steps by name, and add everything they depend on.
+#
+# The pipelines are rendered to YAML first (see dump_dhall_to_pipelines.sh), so
+# every step that CI can run already has a key, and the key already holds what
+# is built, for which tier and for which network:
+#
+#   daemon_apps_only-devnet     archive-devnet
+#   daemon_profile-lightnet     rosetta_apps_only-devnet
+#   daemon_config-devnet        rosetta_config-devnet
+#
+# This script takes patterns for those keys and writes the steps that match,
+# together with the steps they depend on. It changes nothing: it only says what
+# the run set is. The caller decides what to do with it.
+#
+# The dependency walk uses the index in monorepo_lib.sh, which reads the real
+# `depends_on` of the rendered pipelines. There is no second list of
+# dependencies to keep in step with the first.
+#
+# Usage:
+#   select_steps.sh --jobs DIR --select PATTERN [--select PATTERN ...] [options]
+#
+#   --jobs DIR         Directory of rendered pipeline YAML (buildkite/src/gen)
+#   --select PATTERN   Pattern for a step key. Give it more than once to add
+#                      steps together. A pattern may hold * and ?.
+#   --format FORMAT    plan  (default) one "<file><TAB><step key>" for each step
+#                      keys  the step keys only
+#                      files the job files only, each one time
+#   --quiet            Do not write the report on stderr.
+#   -h, --help         Write this text.
+#
+# A pattern is matched against the whole key and against the key without the
+# "_<JobName>-" that the renderer puts in front, so both of these choose the
+# same step:
+#
+#   --select 'rosetta_config-devnet-docker-image'
+#   --select '_MinaArtifactBullseye-rosetta_config-devnet-docker-image'
+#
+# Exit codes:
+#   0  at least one step was chosen
+#   1  no step matched (the keys that exist are written on stderr)
+#   2  the arguments or the environment are wrong
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=buildkite/scripts/monorepo_lib.sh
+source "${SCRIPT_DIR}/../monorepo_lib.sh"
+
+JOBS_DIR=""
+FORMAT="plan"
+QUIET=0
+declare -a PATTERNS=()
+
+usage() {
+    sed -n '3,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+while [[ "$#" -gt 0 ]]; do case "$1" in
+    --jobs)   JOBS_DIR="${2:-}"; shift 2 ;;
+    --select) PATTERNS+=("${2:-}"); shift 2 ;;
+    --format) FORMAT="${2:-}"; shift 2 ;;
+    --quiet)  QUIET=1; shift ;;
+    -h|--help) usage 0 ;;
+    *) echo "Unknown option: $1" >&2; usage 2 ;;
+esac; done
+
+[[ -n "$JOBS_DIR" ]] || fail "--jobs is required."
+[[ -d "$JOBS_DIR" ]] || fail "'${JOBS_DIR}' is not a directory."
+[[ "${#PATTERNS[@]}" -gt 0 ]] || fail "give at least one --select."
+
+case "$FORMAT" in
+    plan|keys|files) ;;
+    *) fail "--format must be plan, keys or files." ;;
+esac
+
+command -v yq > /dev/null 2>&1 || fail "'yq' is not installed."
+
+report() {
+    [[ "$QUIET" -eq 1 ]] || echo "$*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Read every rendered pipeline
+# ---------------------------------------------------------------------------
+
+# step key -> job YAML file, from monorepo_lib.sh.
+build_step_index "$JOBS_DIR"
+
+if [[ "${#STEP_KEY_TO_FILE[@]}" -eq 0 ]]; then
+    fail "no step found in '${JOBS_DIR}'. Render the pipelines first with ./buildkite/scripts/dhall/dump_dhall_to_pipelines.sh"
+fi
+
+# step key -> the keys it depends on, separated by spaces.
+declare -A STEP_DEPS=()
+for key in "${!STEP_KEY_TO_FILE[@]}"; do
+    file="${STEP_KEY_TO_FILE[$key]}"
+    deps="$(yq -r "[.pipeline.steps[]? | select(.key == \"${key}\") | .depends_on[]?.step] | .[]" "$file" 2>/dev/null | tr '\n' ' ')"
+    STEP_DEPS["$key"]="$deps"
+done
+
+# The renderer puts "_<JobName>-" in front of every key. Keep the rest, so that
+# a pattern may name the step without knowing which job holds it.
+short_key() {
+    local key="$1"
+    if [[ "$key" == _*-* ]]; then
+        echo "${key#_*-}"
+    else
+        echo "$key"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Choose
+# ---------------------------------------------------------------------------
+
+declare -A CHOSEN=()
+declare -A REASON=()
+
+for pattern in "${PATTERNS[@]}"; do
+    matched=0
+    for key in "${!STEP_KEY_TO_FILE[@]}"; do
+        # shellcheck disable=SC2053  # the pattern is meant to be a glob
+        if [[ "$key" == $pattern || "$(short_key "$key")" == $pattern ]]; then
+            if [[ -z "${CHOSEN[$key]-}" ]]; then
+                CHOSEN["$key"]=1
+                REASON["$key"]="asked for (${pattern})"
+            fi
+            matched=1
+        fi
+    done
+    if [[ "$matched" -eq 0 ]]; then
+        report "⚠️  no step matches '${pattern}'"
+    fi
+done
+
+if [[ "${#CHOSEN[@]}" -eq 0 ]]; then
+    {
+        echo "ERROR: no step matched. These keys exist:"
+        for key in "${!STEP_KEY_TO_FILE[@]}"; do
+            echo "  $(short_key "$key")"
+        done | sort
+    } >&2
+    exit 1
+fi
+
+report "Chosen by name: ${#CHOSEN[@]} step(s)"
+
+# ---------------------------------------------------------------------------
+# Add what they depend on
+#
+# A step that waits for a step which is not in the run set waits for ever, so
+# every dependency has to come too, however far away it is. This walks the
+# `depends_on` of the rendered pipelines, so it holds for dependencies inside
+# one job and between jobs alike.
+# ---------------------------------------------------------------------------
+
+declare -a QUEUE=("${!CHOSEN[@]}")
+ADDED=0
+
+while [[ "${#QUEUE[@]}" -gt 0 ]]; do
+    current="${QUEUE[0]}"
+    QUEUE=("${QUEUE[@]:1}")
+
+    for dep in ${STEP_DEPS[$current]-}; do
+        [[ -z "$dep" ]] && continue
+
+        if [[ -z "${STEP_KEY_TO_FILE[$dep]-}" ]]; then
+            report "⚠️  '${current}' depends on '${dep}', which no rendered job defines"
+            continue
+        fi
+
+        if [[ -z "${CHOSEN[$dep]-}" ]]; then
+            CHOSEN["$dep"]=1
+            REASON["$dep"]="needed by ${current}"
+            QUEUE+=("$dep")
+            ADDED=$((ADDED + 1))
+        fi
+    done
+done
+
+report "Added because they are needed: ${ADDED} step(s)"
+report "Run set: ${#CHOSEN[@]} step(s)"
+
+if [[ "$QUIET" -eq 0 ]]; then
+    for key in "${!CHOSEN[@]}"; do
+        echo "  ${key}  <-  ${REASON[$key]}"
+    done | sort >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Write the run set
+# ---------------------------------------------------------------------------
+
+case "$FORMAT" in
+    plan)
+        for key in "${!CHOSEN[@]}"; do
+            printf '%s\t%s\n' "${STEP_KEY_TO_FILE[$key]}" "$key"
+        done | sort
+        ;;
+    keys)
+        for key in "${!CHOSEN[@]}"; do echo "$key"; done | sort
+        ;;
+    files)
+        for key in "${!CHOSEN[@]}"; do echo "${STEP_KEY_TO_FILE[$key]}"; done | sort -u
+        ;;
+esac

--- a/buildkite/scripts/pipeline/tests/test_select_steps.sh
+++ b/buildkite/scripts/pipeline/tests/test_select_steps.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+set -euo pipefail
+
+################################################################################
+# Tests for select_steps.sh
+#
+# Usage: bash buildkite/scripts/pipeline/tests/test_select_steps.sh
+#
+# The tests run against small rendered pipelines written in a temporary
+# directory, not against the real ones, so they do not change when a job is
+# added and they need no dhall.
+#
+# The fixture has the shape the real pipelines have: an apps job that another
+# job depends on, a debian step that every image step depends on, and an image
+# that is FROM another image.
+################################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELECT="${SCRIPT_DIR}/../select_steps.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+FAILURES=()
+CURRENT_TEST=""
+
+log_pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); }
+
+log_fail() {
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    FAILURES+=("${CURRENT_TEST}: $1")
+    echo "  FAIL: $1" >&2
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        log_pass
+    else
+        log_fail "${label}: expected '${expected}', got '${actual}'"
+    fi
+}
+
+assert_has() {
+    local label="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qFx -- "$needle"; then
+        log_pass
+    else
+        log_fail "${label}: '${needle}' is not in the result"
+    fi
+}
+
+assert_has_not() {
+    local label="$1" haystack="$2" needle="$3"
+    if echo "$haystack" | grep -qFx -- "$needle"; then
+        log_fail "${label}: '${needle}' must not be in the result"
+    else
+        log_pass
+    fi
+}
+
+run_test() {
+    CURRENT_TEST="$1"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    local before=${TESTS_FAILED}
+    echo -n "TEST: ${CURRENT_TEST} ... "
+    "$1" || true
+    if [[ ${TESTS_FAILED} -eq ${before} ]]; then echo "OK"; else echo "FAILED"; fi
+}
+
+################################################################################
+# Fixture
+################################################################################
+
+JOBS_DIR=""
+
+setup_fixture() {
+    JOBS_DIR="$(mktemp -d)"
+
+    cat > "${JOBS_DIR}/Apps.yml" <<'YAML'
+spec:
+  name: Apps
+  path: Release
+pipeline:
+  steps:
+    - key: _Apps-build-apps
+      label: build apps
+YAML
+
+    cat > "${JOBS_DIR}/Package.yml" <<'YAML'
+spec:
+  name: Package
+  path: Release
+pipeline:
+  steps:
+    - key: _Package-build-deb-pkg
+      label: debians
+      depends_on:
+        - step: _Apps-build-apps
+    - key: _Package-daemon_apps_only-devnet-docker-image
+      label: daemon apps only
+      depends_on:
+        - step: _Package-build-deb-pkg
+    - key: _Package-daemon_config-devnet-docker-image
+      label: daemon config
+      depends_on:
+        - step: _Package-build-deb-pkg
+        - step: _Package-daemon_apps_only-devnet-docker-image
+    - key: _Package-archive-devnet-docker-image
+      label: archive
+      depends_on:
+        - step: _Package-build-deb-pkg
+YAML
+}
+
+teardown_fixture() {
+    [[ -n "$JOBS_DIR" && -d "$JOBS_DIR" ]] && rm -rf "$JOBS_DIR"
+    return 0
+}
+
+select_keys() {
+    "$SELECT" --jobs "$JOBS_DIR" --format keys --quiet "$@"
+}
+
+################################################################################
+# Tests
+################################################################################
+
+# A step that is FROM another image, in a job that is built from an other job,
+# must bring both with it.
+test_closure_reaches_through_jobs() {
+    local out
+    out="$(select_keys --select 'daemon_config-devnet-docker-image')"
+
+    assert_has "the step asked for" "$out" "_Package-daemon_config-devnet-docker-image"
+    assert_has "the image it is FROM" "$out" "_Package-daemon_apps_only-devnet-docker-image"
+    assert_has "the debians it installs" "$out" "_Package-build-deb-pkg"
+    assert_has "the apps of the other job" "$out" "_Apps-build-apps"
+    assert_eq "nothing else" "4" "$(echo "$out" | wc -l)"
+}
+
+# Nothing that is not needed comes with it.
+test_only_what_is_needed() {
+    local out
+    out="$(select_keys --select 'archive-devnet-docker-image')"
+
+    assert_has "the step asked for" "$out" "_Package-archive-devnet-docker-image"
+    assert_has "the debians" "$out" "_Package-build-deb-pkg"
+    assert_has "the apps" "$out" "_Apps-build-apps"
+    assert_has_not "no daemon image" "$out" "_Package-daemon_config-devnet-docker-image"
+    assert_has_not "no apps only image" "$out" "_Package-daemon_apps_only-devnet-docker-image"
+}
+
+# This is the invariant the whole script exists for: a step that waits for a
+# step outside the run set waits for ever.
+test_no_step_waits_for_a_step_outside_the_run_set() {
+    local out
+    out="$(select_keys --select '*docker-image')"
+
+    local key deps dep
+    while IFS= read -r key; do
+        deps="$(yq -r "[.pipeline.steps[]? | select(.key == \"${key}\") | .depends_on[]?.step] | .[]" \
+            "${JOBS_DIR}"/*.yml 2>/dev/null || true)"
+        while IFS= read -r dep; do
+            [[ -z "$dep" ]] && continue
+            if echo "$out" | grep -qFx -- "$dep"; then
+                log_pass
+            else
+                log_fail "'${key}' waits for '${dep}', which is not in the run set"
+            fi
+        done <<< "$deps"
+    done <<< "$out"
+}
+
+test_a_pattern_may_hold_a_star() {
+    local out
+    out="$(select_keys --select 'daemon_*-devnet-docker-image')"
+
+    assert_has "apps only" "$out" "_Package-daemon_apps_only-devnet-docker-image"
+    assert_has "config" "$out" "_Package-daemon_config-devnet-docker-image"
+    assert_has_not "not the archive" "$out" "_Package-archive-devnet-docker-image"
+}
+
+# The name of the job holds the codename and the architecture, so the whole key
+# is how one asks for a step of one pipeline only.
+test_the_whole_key_chooses_one_job() {
+    local out
+    out="$(select_keys --select '_Package-archive-devnet-docker-image')"
+    assert_has "the step" "$out" "_Package-archive-devnet-docker-image"
+    assert_eq "the step and what it needs" "3" "$(echo "$out" | wc -l)"
+}
+
+test_more_than_one_select_adds_up() {
+    local out
+    out="$(select_keys --select 'archive-devnet-docker-image' --select 'daemon_apps_only-devnet-docker-image')"
+    assert_has "the first" "$out" "_Package-archive-devnet-docker-image"
+    assert_has "the second" "$out" "_Package-daemon_apps_only-devnet-docker-image"
+}
+
+test_formats() {
+    local files plan
+    files="$("$SELECT" --jobs "$JOBS_DIR" --format files --quiet --select 'archive-devnet-docker-image')"
+    assert_has "the job of the step" "$files" "${JOBS_DIR}/Package.yml"
+    assert_has "the job it depends on" "$files" "${JOBS_DIR}/Apps.yml"
+    assert_eq "each file one time" "2" "$(echo "$files" | wc -l)"
+
+    plan="$("$SELECT" --jobs "$JOBS_DIR" --format plan --quiet --select 'archive-devnet-docker-image')"
+    assert_eq "the plan holds a file and a key" "2" "$(echo "$plan" | head -1 | awk -F'\t' '{print NF}')"
+}
+
+test_a_pattern_that_matches_nothing_stops() {
+    local out status=0
+    out="$("$SELECT" --jobs "$JOBS_DIR" --format keys --select 'no-such-step' 2>&1)" || status=$?
+    assert_eq "exit code" "1" "$status"
+    if echo "$out" | grep -q "archive-devnet-docker-image"; then
+        log_pass
+    else
+        log_fail "the message must write the keys that do exist"
+    fi
+}
+
+test_wrong_arguments_stop() {
+    local status
+
+    status=0
+    "$SELECT" --format keys --select 'x' > /dev/null 2>&1 || status=$?
+    assert_eq "no --jobs" "2" "$status"
+
+    status=0
+    "$SELECT" --jobs "$JOBS_DIR" > /dev/null 2>&1 || status=$?
+    assert_eq "no --select" "2" "$status"
+
+    status=0
+    "$SELECT" --jobs "$JOBS_DIR" --select 'x' --format nope > /dev/null 2>&1 || status=$?
+    assert_eq "a format that is not known" "2" "$status"
+
+    status=0
+    "$SELECT" --jobs /no/such/dir --select 'x' > /dev/null 2>&1 || status=$?
+    assert_eq "a directory that is not there" "2" "$status"
+}
+
+################################################################################
+
+main() {
+    command -v yq > /dev/null 2>&1 || { echo "yq is needed" >&2; exit 2; }
+
+    setup_fixture
+
+    run_test test_closure_reaches_through_jobs
+    run_test test_only_what_is_needed
+    run_test test_no_step_waits_for_a_step_outside_the_run_set
+    run_test test_a_pattern_may_hold_a_star
+    run_test test_the_whole_key_chooses_one_job
+    run_test test_more_than_one_select_adds_up
+    run_test test_formats
+    run_test test_a_pattern_that_matches_nothing_stops
+    run_test test_wrong_arguments_stop
+
+    teardown_fixture
+
+    echo ""
+    echo "========================================"
+    echo "Results: ${TESTS_RUN} tests, ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+    echo "========================================"
+
+    if [[ ${#FAILURES[@]} -gt 0 ]]; then
+        echo ""
+        echo "Failures:"
+        for f in "${FAILURES[@]}"; do echo "  - ${f}"; done
+    fi
+
+    echo ""
+    if [[ ${TESTS_FAILED} -gt 0 ]]; then exit 1; else echo "All tests passed."; exit 0; fi
+}
+
+main "$@"


### PR DESCRIPTION
First piece of #19223 (track A, A1). Additive: two new files, nothing existing
is touched, and no rendered pipeline changes.

### What it does

`buildkite/scripts/pipeline/select_steps.sh` takes patterns for step keys and
writes the steps that match **together with everything they depend on**.

```
$ ./buildkite/scripts/pipeline/select_steps.sh \
    --jobs buildkite/src/gen --select 'rosetta_config-devnet-docker-image'

Chosen by name: 7 step(s)
Added because they are needed: 21 step(s)
Run set: 28 step(s)
  _MinaArtifactBullseye-rosetta_config-devnet-docker-image      <- asked for
  _MinaArtifactBullseye-rosetta_apps_only-devnet-docker-image   <- needed by ...
  _MinaArtifactBullseye-build-deb-pkg                           <- needed by ...
  _MinaArtifactBullseyeApps-build-apps                          <- needed by ...
  ...
```

It decides nothing else: it prints the run set, and the caller (A2) does
something with it.

### Why the step is the unit

The rendered pipelines already give every buildable thing a key, and the key
already holds what is built, for which tier and for which network:

```
daemon_apps_only-devnet     archive-devnet
daemon_profile-lightnet     rosetta_apps_only-devnet
daemon_config-devnet        rosetta_config-devnet
```

The codename and the architecture are in the **job** name, so a pattern for the
whole key chooses one pipeline (`_MinaArtifactBullseye-archive-devnet-docker-image`)
and a pattern for the short key chooses that step in every pipeline that has it.
Both forms are matched, so neither has to be learnt first.

This means the elastic part needs no change to the Dhall at all, and none of the
renames in track C are a condition for it.

### The dependency walk is not written twice

It uses `build_step_index` from `monorepo_lib.sh`, which reads the real
`depends_on` of the rendered pipelines. That file already carries the comment
"so the walk logic lives in one place", which `run-single-job-with-deps.sh`
(the `!ci-single-me` path) follows too. There is no second table of
dependencies here, so nothing can fall out of step with the pipelines.

The walk crosses jobs, which matters: `build-deb-pkg` depends on the *apps* job
of the same codename, and every image step depends on `build-deb-pkg`.

### Tests

`buildkite/scripts/pipeline/tests/test_select_steps.sh` — 9 tests, 32
assertions, no dhall and no network, about a second.

They run against a small fixture written into a temporary directory, not the
real pipelines, so adding a job does not change them. The fixture has the shape
the real ones have: an apps job that another job depends on, one debian step
that every image step depends on, and an image that is FROM another image.

The test that matters is `test_no_step_waits_for_a_step_outside_the_run_set`: it
selects a set, then reads the `depends_on` of every chosen step and fails if any
of them is missing from the run set. That is the invariant the script exists
for — a step waiting on a step that was never scheduled waits for ever.

The others cover: the closure reaches through jobs; nothing unneeded is added; a
pattern may hold a `*`; the whole key chooses one job; several `--select` add
up; the three output formats; a pattern that matches nothing exits 1 and writes
the keys that do exist; and wrong arguments exit 2.

`shellcheck -S warning` is clean.

### Next

A2 puts this behind an entrypoint that prunes the rendered YAML and uploads it,
gated by a test that the uploaded pipeline has no dangling `depends_on`.
