### PR TITLE
upload only the steps that were selected

### DIFF
--- a/buildkite/scripts/entrypoints/run-selection.sh
+++ b/buildkite/scripts/entrypoints/run-selection.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+# Build only the steps that were asked for.
+#
+# The pipelines are rendered to YAML, select_steps.sh works out which steps to
+# run (the ones named, and everything they depend on), and this script uploads
+# those steps only. A job with no chosen step is not uploaded at all.
+#
+# Usage:
+#   run-selection.sh --selection "PATTERN[,PATTERN...]" --jobs DIR [options]
+#
+#   --selection LIST   Patterns for step keys, separated by commas. This is what
+#                      the author of the comment wrote, so it is not trusted:
+#                      every pattern must match a step, or the script stops.
+#   --jobs DIR         Directory of rendered pipelines (buildkite/src/gen)
+#   --dry-run          Write what would be uploaded, upload nothing.
+#   --debug            Write the pruned pipeline of each job.
+#   -h, --help         Write this text.
+#
+# Exit codes:
+#   0  the chosen steps were uploaded (or written, with --dry-run)
+#   1  nothing matched what was asked for
+#   2  the arguments or the environment are wrong
+#
+# A step that waits for a step which is not uploaded waits for ever, so this
+# script never prunes a dependency away: select_steps.sh adds them, and the
+# check below fails the run if one is missing all the same.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELECT_STEPS="${SCRIPT_DIR}/../pipeline/select_steps.sh"
+
+SELECTION=""
+JOBS_DIR=""
+DRY_RUN=false
+DEBUG=false
+
+usage() {
+    sed -n '3,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+while [[ "$#" -gt 0 ]]; do case "$1" in
+    --selection) SELECTION="${2:-}"; shift 2 ;;
+    --jobs)      JOBS_DIR="${2:-}"; shift 2 ;;
+    --dry-run)   DRY_RUN=true; shift ;;
+    --debug)     DEBUG=true; shift ;;
+    -h|--help)   usage 0 ;;
+    *) echo "Unknown option: $1" >&2; usage 2 ;;
+esac; done
+
+[[ -n "$SELECTION" ]] || fail "--selection is required."
+[[ -n "$JOBS_DIR" ]] || fail "--jobs is required."
+[[ -d "$JOBS_DIR" ]] || fail "'${JOBS_DIR}' is not a directory."
+[[ -x "$SELECT_STEPS" ]] || fail "'${SELECT_STEPS}' is not there."
+command -v yq > /dev/null 2>&1 || fail "'yq' is not installed."
+
+# ---------------------------------------------------------------------------
+# Work out the run set
+# ---------------------------------------------------------------------------
+
+declare -a SELECT_ARGS=()
+IFS=',' read -ra RAW_PATTERNS <<< "$SELECTION"
+for pattern in "${RAW_PATTERNS[@]}"; do
+    # Take the spaces off, so that "a, b" works as well as "a,b".
+    pattern="$(echo "$pattern" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [[ -z "$pattern" ]] && continue
+    SELECT_ARGS+=(--select "$pattern")
+done
+
+[[ "${#SELECT_ARGS[@]}" -gt 0 ]] || fail "--selection holds no pattern."
+
+echo "--- Working out which steps to run"
+
+PLAN_FILE="$(mktemp)"
+trap 'rm -f "$PLAN_FILE"' EXIT
+
+set +e
+"$SELECT_STEPS" --jobs "$JOBS_DIR" --format plan "${SELECT_ARGS[@]}" > "$PLAN_FILE"
+SELECT_STATUS=$?
+set -e
+
+if [[ "$SELECT_STATUS" -ne 0 ]]; then
+    exit "$SELECT_STATUS"
+fi
+
+# job file -> the keys of its chosen steps, separated by spaces
+declare -A JOB_STEPS=()
+while IFS=$'\t' read -r file key; do
+    [[ -z "$file" || -z "$key" ]] && continue
+    JOB_STEPS["$file"]="${JOB_STEPS[$file]-} ${key}"
+done < "$PLAN_FILE"
+
+[[ "${#JOB_STEPS[@]}" -gt 0 ]] || fail "the run set is empty."
+
+# Every key of the run set, to check the dependencies against.
+ALL_KEYS=" $(cut -f2 "$PLAN_FILE" | tr '\n' ' ') "
+
+echo "--- Run set: $(cut -f2 "$PLAN_FILE" | wc -l) step(s) in ${#JOB_STEPS[@]} job(s)"
+
+# ---------------------------------------------------------------------------
+# Keep only the chosen steps of each job, and upload
+# ---------------------------------------------------------------------------
+
+UPLOADED=0
+
+for file in "${!JOB_STEPS[@]}"; do
+    job_name="$(yq -r '.spec.name' "$file")"
+
+    # Build the yq test: keep a step when its key is one of the chosen ones.
+    filter=""
+    for key in ${JOB_STEPS[$file]}; do
+        if [[ -z "$filter" ]]; then
+            filter=".key == \"${key}\""
+        else
+            filter="${filter} or .key == \"${key}\""
+        fi
+    done
+
+    pruned="$(yq -o=yaml ".pipeline | .steps |= map(select(${filter}))" "$file")"
+
+    # A step that waits for a step nobody uploads waits for ever. select_steps.sh
+    # adds every dependency, so this can only fail if the two stop agreeing.
+    missing=""
+    while IFS= read -r dep; do
+        [[ -z "$dep" || "$dep" == "null" ]] && continue
+        if [[ "$ALL_KEYS" != *" ${dep} "* ]]; then
+            missing="${missing} ${dep}"
+        fi
+    done < <(echo "$pruned" | yq -r '[.steps[]?.depends_on[]?.step] | .[]' 2>/dev/null)
+
+    if [[ -n "$missing" ]]; then
+        echo "ERROR: in job '${job_name}', these steps are waited for but not uploaded:${missing}" >&2
+        echo "       select_steps.sh and this script disagree; that is a fault, not a bad request." >&2
+        exit 2
+    fi
+
+    count="$(echo "$pruned" | yq -r '[.steps[]?] | length')"
+
+    if [[ "$DEBUG" == true ]]; then
+        echo "--- Pruned pipeline of ${job_name} (${count} step(s))"
+        echo "$pruned"
+    fi
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo " -> would upload ${job_name} with ${count} step(s):$(echo "${JOB_STEPS[$file]}" | tr ' ' '\n' | sed 's/^/ /' | tr -d '\n')"
+        continue
+    fi
+
+    echo " -> uploading ${job_name} with ${count} step(s)"
+    echo "$pruned" | buildkite-agent pipeline upload
+    UPLOADED=$((UPLOADED + 1))
+done
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "--- Dry run: nothing was uploaded."
+else
+    echo "--- Uploaded ${UPLOADED} job(s)."
+fi

--- a/buildkite/src/Entrypoints/RunSelection.dhall
+++ b/buildkite/src/Entrypoints/RunSelection.dhall
@@ -1,0 +1,75 @@
+-- Build only the steps that were asked for.
+--
+-- This is the shape RunSingleJob.dhall uses: the choice arrives as text, this
+-- file emits one step, and a script does the work. Nothing is chosen here,
+-- because Dhall cannot look at text: the Prelude of this repository has no
+-- Text.split, and Dhall has no equality for Text at all.
+--
+-- The selection is a list of patterns for step keys, separated by commas. A key
+-- holds what is built, for which tier and for which network
+-- (rosetta_config-devnet-docker-image), and the name of the job holds the
+-- codename and the architecture, so the whole key names one step of one
+-- pipeline. select_steps.sh adds every step that the chosen ones depend on.
+
+let SelectFiles = ../Lib/SelectFiles.dhall
+
+let Cmd = ../Lib/Cmds.dhall
+
+let Command = ../Command/Base.dhall
+
+let Docker = ../Command/Docker/Type.dhall
+
+let JobSpec = ../Pipeline/JobSpec.dhall
+
+let Pipeline = ../Pipeline/Dsl.dhall
+
+let Size = ../Command/Size.dhall
+
+let prefixCommands =
+      [ Cmd.run
+          "git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt"
+      , Cmd.run "./buildkite/scripts/refresh_code.sh"
+      , Cmd.run
+          "./buildkite/scripts/dhall/dump_dhall_to_pipelines.sh ./buildkite/src buildkite/src/gen"
+      ]
+
+let commands
+    : Text -> Cmd.Type
+    =     \(selection : Text)
+      ->  Cmd.run
+            (     "./buildkite/scripts/entrypoints/run-selection.sh"
+              ++  " --selection '"
+              ++  selection
+              ++  "'"
+              ++  " --jobs ./buildkite/src/gen"
+              ++  " --debug "
+            )
+
+in      \(args : { selection : Text })
+    ->  let pipelineType =
+              Pipeline.build
+                Pipeline.Config::{
+                , spec = JobSpec::{
+                  , name = "run-selection"
+                  , dirtyWhen = [ SelectFiles.everything ]
+                  }
+                , steps =
+                  [ Command.build
+                      Command.Config::{
+                      , commands = prefixCommands # [ commands args.selection ]
+                      , label = "Run selection ${args.selection}"
+                      , key = "cmds"
+                      , target = Size.Multi
+                      , docker = Some Docker::{
+                        , image =
+                            (../Constants/ContainerImages.dhall).toolchainBase
+                        , environment =
+                          [ "BUILDKITE_AGENT_ACCESS_TOKEN"
+                          , "BUILDKITE_INCREMENTAL"
+                          ]
+                        }
+                      }
+                  ]
+                }
+
+        in  pipelineType.pipeline


### PR DESCRIPTION
Second piece of #19223 (track A, A2). **Stacked on #19224** — the base of this
branch is the selector, so review that one first. Additive: two new files,
nothing existing changes, and `make all` still renders every pipeline as before.

### What it does

`RunSelection.dhall` is the same shape as `RunSingleJob.dhall`: the choice
arrives as text, the entrypoint emits **one** step, and a script does the work.
Nothing is chosen in Dhall, because Dhall cannot: the vendored Prelude has no
`Text.split`, and Dhall has no equality for Text at all.

`run-selection.sh` renders the pipelines, asks `select_steps.sh` what the run
set is, keeps only those steps in each job, and uploads. A job with no chosen
step is not uploaded.

```
$ ./buildkite/scripts/entrypoints/run-selection.sh \
    --selection '_MinaArtifactBullseye-rosetta_config-devnet-docker-image' \
    --jobs buildkite/src/gen --dry-run

--- Working out which steps to run
Chosen by name: 1 step(s)
Added because they are needed: 3 step(s)
--- Run set: 4 step(s) in 2 job(s)
 -> would upload MinaArtifactBullseye with 3 step(s):
      build-deb-pkg, rosetta_apps_only-devnet-docker-image, rosetta_config-devnet-docker-image
 -> would upload MinaArtifactBullseyeApps with 1 step(s):
      build-apps
--- Dry run: nothing was uploaded.
```

`MinaArtifactBullseye` has 9 steps; this uploads 3 of them, plus the one step of
the apps job it depends on.

### The invariant is enforced, not only tested

A step that waits for a step nobody uploads waits for ever. `select_steps.sh`
adds every dependency, so that should not happen — but this script **checks it
again** after pruning, reading the `depends_on` of what it is about to upload
and stopping the run if any of them is outside the run set:

```
ERROR: in job 'X', these steps are waited for but not uploaded: <keys>
       select_steps.sh and this script disagree; that is a fault, not a bad request.
```

A runtime check is stronger than a test here, because it holds for every
selection anyone ever writes, not only the ones a test thought of. It also says
plainly that such a failure is our fault and not a bad request, which is the
distinction an on-call person needs.

### Selection comes from a comment, so it is not trusted

The patterns are separated by commas and may hold spaces (`a, b` works).
Every pattern must match at least one step: `select_steps.sh` exits 1 and
writes the keys that do exist, so a typo answers with the list instead of a
Dhall type error deep in a Prepare step.

### Verified

- dry run against the **real** rendered pipelines of `develop`, shown above
- `RunSelection.dhall` type checks, and `make all` in `buildkite/` is 45/45 with
  every pipeline rendering as before
- `shellcheck -S warning` clean
- the 9 selector tests from #19224 still pass

### Honest gap

`run-selection.sh` has no test file of its own yet; it is covered by the dry run
above, by the runtime check, and by the selector's tests underneath it. A test
suite for the pruning itself (a fixture, a prune, then an assertion on the
uploaded YAML) belongs with A3, when the command wiring gives it a second
caller to exercise.

### Next

A3 wires `!ci-docker-me` and `!ci-debian-me` to pass a selection through, and
translates today's `arch=`/`profile=`/`codename=` into patterns.
