### PR TITLE
check comment input before it reaches dhall on the agent

### DIFF
--- a/frontend/ci-build-me/Makefile
+++ b/frontend/ci-build-me/Makefile
@@ -34,6 +34,10 @@ describe: ## Show the deployed function
 		--project $(PROJECT) --region $(REGION) \
 		--format='table(name.basename(), status, runtime, entryPoint, updateTime)'
 
+.PHONY: test
+test: ## Run the unit tests (no dependencies needed)
+	@node $(SOURCE_DIR)test/safe-input.test.js
+
 .PHONY: check
 check: ## Compare the deployed function with this directory
 	@$(SOURCE_DIR)check-deployed-parity.sh \
@@ -64,7 +68,7 @@ check-clean:
 	fi
 
 .PHONY: deploy
-deploy: check-env check-clean ## Deploy this directory to Google Cloud
+deploy: test check-env check-clean ## Deploy this directory to Google Cloud
 	@echo "Deploying $(FUNCTION) to $(PROJECT)/$(REGION) with runtime $(RUNTIME)"
 	@echo "From commit: $$(git -C $(SOURCE_DIR) rev-parse --short HEAD)"
 	cd $(SOURCE_DIR) && gcloud functions deploy $(FUNCTION) \

--- a/frontend/ci-build-me/package.json
+++ b/frontend/ci-build-me/package.json
@@ -7,13 +7,18 @@
     "coverage": "jest --coverage",
     "lint": "eslint src/** test/**",
     "start": "nodemon -x functions-framework --target=githubWebhookHandler",
-    "test": "jest"
+    "test": "node test/safe-input.test.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/eddies/github-webhook-cloud-function.git"
   },
-  "keywords": ["github", "buildkite", "google cloud functions", "node"],
+  "keywords": [
+    "github",
+    "buildkite",
+    "google cloud functions",
+    "node"
+  ],
   "author": "O(1) Labs (forked from Edwin Shin)",
   "license": "ISC",
   "bugs": {
@@ -33,11 +38,16 @@
     "smee-client": "^1.1.0"
   },
   "jest": {
-    "collectCoverageFrom": ["src/**/*.js"],
+    "collectCoverageFrom": [
+      "src/**/*.js"
+    ],
     "coverageDirectory": "build/coverage",
     "testEnvironment": "node"
   },
   "nodemonConfig": {
-    "ignore": ["test/*", "docs/*"]
+    "ignore": [
+      "test/*",
+      "docs/*"
+    ]
   }
 }

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -3,6 +3,7 @@ const HTTPError = require("./util/httpError");
 
 const { httpsRequest } = require("./util/httpsRequest");
 const axios = require("axios");
+const { checkArgument } = require("./safe-input.js");
 
 const apiKey = process.env.BUILDKITE_API_ACCESS_TOKEN;
 
@@ -245,13 +246,20 @@ const handler = async (event, req) => {
 
       const jobName = req.body.comment.body.trim().split(/\s+/).pop(); // get JobName from "!ci-single-me JobName"
 
+      // The name is put into a dhall expression on the agent, so it is checked
+      // before it goes anywhere. See src/safe-input.js.
+      const checked = checkArgument("!ci-single-me", jobName);
+      if (checked.error) {
+        return [checked.error, checked.error];
+      }
+
       const buildkite = await runBuild(
         {
           sender: req.body.sender,
           pull_request: prData.data,
         },
         "mina-single-job",
-        { JOB_NAME: jobName }
+        { JOB_NAME: checked.value }
       );
       return [buildkite];
     } else {

--- a/frontend/ci-build-me/src/safe-input.js
+++ b/frontend/ci-build-me/src/safe-input.js
@@ -1,0 +1,83 @@
+// Check the values taken from a pull request comment before they are given to
+// a build.
+//
+// Why this is needed
+// ------------------
+// The buildkite pipelines put these values straight into a dhall expression.
+// mina-single-job runs:
+//
+//   dhall-to-yaml --quoted <<< "(./buildkite/src/Entrypoints/RunSingleJob.dhall) \
+//     { name=\"${JOB_NAME}\" }" | buildkite-agent pipeline upload
+//
+// so the value ends up inside a dhall text literal. Dhall can read the
+// environment: `env:BUILDKITE_AGENT_ACCESS_TOKEN` is a legal expression. A value
+// that closes the quote can therefore run dhall of its own choosing on the
+// agent, with the token of that agent within reach.
+//
+// Only a public member of the MinaProtocol organisation can start a build, so
+// this is not open to anyone, but membership is a wide group and the check
+// costs nothing.
+//
+// What is allowed
+// ---------------
+// A job name or a step pattern needs letters, digits and a few marks. It never
+// needs a quotation mark, a backslash, a dollar or a backtick, and those are
+// exactly what is needed to leave a dhall text literal or a shell string. So
+// the rule is a list of what may appear, not a list of what may not: a mark
+// that is forgotten then fails closed.
+//
+//   letters digits _ - . / * ? , and the space
+//
+// The star and the question mark are there because a selection is a pattern
+// for step keys. The comma separates patterns.
+
+// One value may not be longer than this. A real job name or selection is far
+// shorter, and a long value in a comment is a sign of an attempt, not of use.
+const MAX_LENGTH = 500;
+
+const ALLOWED = /^[A-Za-z0-9_\-./*?, ]+$/;
+
+// Report the characters that are not allowed, so the author is told what to
+// change instead of only that it was refused.
+const disallowedCharacters = (value) => {
+  const bad = new Set();
+  for (const character of value) {
+    if (!ALLOWED.test(character)) {
+      bad.add(character === "\n" ? "\\n" : character === "\t" ? "\\t" : character);
+    }
+  }
+  return [...bad];
+};
+
+// Returns { value } when the input may be used, or { error } with a text for
+// the author of the comment.
+const checkArgument = (name, value) => {
+  if (value === undefined || value === null || value === "") {
+    return { error: `${name}: no value was given.` };
+  }
+
+  if (typeof value !== "string") {
+    return { error: `${name}: the value must be text.` };
+  }
+
+  if (value.length > MAX_LENGTH) {
+    return {
+      error: `${name}: the value is longer than ${MAX_LENGTH} characters.`,
+    };
+  }
+
+  if (!ALLOWED.test(value)) {
+    const bad = disallowedCharacters(value);
+    return {
+      error:
+        `${name}: these characters may not be used: ${bad.join(" ")}\n` +
+        "Only letters, digits and _ - . / * ? , and the space are allowed. " +
+        "The value is put into a dhall expression on the build agent, so a " +
+        "quotation mark or a backslash could run code there.",
+    };
+  }
+
+  return { value };
+};
+
+module.exports = { checkArgument, ALLOWED, MAX_LENGTH };

--- a/frontend/ci-build-me/test/safe-input.test.js
+++ b/frontend/ci-build-me/test/safe-input.test.js
@@ -1,0 +1,127 @@
+// Tests for the check on values taken from a pull request comment.
+//
+// Run with: node test/safe-input.test.js
+//
+// These values are put into a dhall expression on the build agent, and dhall
+// can read the environment, so a value that leaves its text literal can run
+// code there. The tests below are written as attempts, not as tidy examples.
+
+const assert = require("assert");
+const { checkArgument, MAX_LENGTH } = require("../src/safe-input.js");
+
+let run = 0;
+let failed = 0;
+
+const test = (name, fn) => {
+  run += 1;
+  try {
+    fn();
+    console.log(`ok    ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL  ${name}`);
+    console.error(`      ${error.message.split("\n").join("\n      ")}`);
+  }
+};
+
+const refused = (value) => {
+  const result = checkArgument("test", value);
+  assert.ok(result.error, `'${value}' must be refused`);
+  assert.strictEqual(result.value, undefined, `'${value}' must give no value`);
+  return result.error;
+};
+
+const allowed = (value) => {
+  const result = checkArgument("test", value);
+  assert.ok(!result.error, `'${value}' must be allowed, got: ${result.error}`);
+  assert.strictEqual(result.value, value);
+};
+
+// ---------------------------------------------------------------------------
+
+test("a job name is allowed", () => {
+  allowed("HardForkTestMixed");
+  allowed("TestnetIntegrationTestsLocalApps");
+  allowed("MinaArtifactBookwormArm64");
+});
+
+test("a step pattern is allowed", () => {
+  allowed("rosetta_config-devnet-docker-image");
+  allowed("_MinaArtifactBullseye-archive-devnet-docker-image");
+  allowed("daemon_*-devnet-docker-image");
+  allowed("archive-devnet-docker-image, daemon_config-devnet-docker-image");
+  allowed("buildkite/src/gen");
+});
+
+// The one that matters: leaving the dhall text literal.
+test("a value that closes the dhall text is refused", () => {
+  const error = refused('x" ++ env:BUILDKITE_AGENT_ACCESS_TOKEN ++ "');
+  assert.ok(error.includes('"'), "the message must name the quotation mark");
+  assert.ok(
+    error.includes("dhall"),
+    "the message must say why, so the reason is not guessed"
+  );
+});
+
+test("the marks needed to leave a text or a shell are refused", () => {
+  refused('name"');
+  refused("name\\");
+  refused("name$(id)");
+  refused("name`id`");
+  refused("name${X}");
+  refused("name;id");
+  refused("name|id");
+  refused("name&id");
+  refused("name>out");
+  refused("name'x'");
+  refused("name(x)");
+  refused("name{x}");
+  refused("env:SECRET");
+});
+
+test("a line end is refused", () => {
+  refused("name\nsecond line");
+  refused("name\r\nsecond line");
+  refused("name\ttab");
+});
+
+test("nothing at all is refused", () => {
+  refused("");
+  refused(undefined);
+  refused(null);
+});
+
+test("a value that is not text is refused", () => {
+  refused(42);
+  refused({});
+  refused(["a"]);
+});
+
+test("a very long value is refused", () => {
+  allowed("a".repeat(MAX_LENGTH));
+  const error = refused("a".repeat(MAX_LENGTH + 1));
+  assert.ok(error.includes(String(MAX_LENGTH)), "the message must give the limit");
+});
+
+test("the message names every character that is wrong, one time each", () => {
+  const error = refused('a"b"c\\d');
+  assert.ok(error.includes('"'), "must name the quotation mark");
+  assert.ok(error.includes("\\"), "must name the backslash");
+  // '"' appears twice in the value but must be reported once.
+  assert.strictEqual(
+    (error.match(/"/g) || []).length,
+    1,
+    "each character is named one time"
+  );
+});
+
+test("the name of the command is in the message", () => {
+  const result = checkArgument("!ci-single-me", 'bad"value');
+  assert.ok(result.error.startsWith("!ci-single-me:"));
+});
+
+// ---------------------------------------------------------------------------
+
+console.log("");
+console.log(`${run} tests, ${run - failed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
First commit of A3 in #19223, and a fix worth having on its own.

### The problem

The pipelines put a value taken from a **pull request comment** straight into a
dhall expression. `mina-single-job` is configured as:

```
dhall-to-yaml --quoted <<< "(./buildkite/src/Entrypoints/RunSingleJob.dhall) \
  { name=\"${JOB_NAME}\" }" | buildkite-agent pipeline upload
```

`JOB_NAME` comes from `!ci-single-me <name>`, and it lands inside a dhall text
literal. **Dhall can read the environment** — `env:BUILDKITE_AGENT_ACCESS_TOKEN`
is a legal expression — so a comment that closes the quotation mark can have
dhall of its own choosing evaluated on the agent, with that agent's token within
reach.

Only a public member of the MinaProtocol organisation can start a build, so this
is not open to anyone. But that is a wide group, and the check costs nothing.

This is not new and this PR does not introduce it: `!ci-single-me` already ships
this way. It is first in A3 because A3 adds a second, more expressive value
(`SELECTION`) that goes to the same place, and widening a hole before closing it
is the wrong order.

### What it does

`src/safe-input.js` checks a value before it leaves the handler. The rule is a
list of what **may** appear rather than what may not, so a mark that is
forgotten fails closed:

```
letters digits _ - . / * ? , and the space
```

That is everything a job name or a step pattern needs. It is not everything
needed to leave a dhall text literal or a shell string, which is the point. The
star, the question mark and the comma are there because a selection is a list of
patterns for step keys.

A refusal names the characters that are wrong and says why, so the author is
told what to change:

```
!ci-single-me: these characters may not be used: "
Only letters, digits and _ - . / * ? , and the space are allowed. The value is
put into a dhall expression on the build agent, so a quotation mark or a
backslash could run code there.
```

`JOB_NAME` is now checked before `runBuild`, and the checked value is what is
sent.

### Tests

`npm test`, or `make test`, which `make deploy` now requires. 10 tests, no
dependencies, well under a second. They are written as attempts rather than as
tidy examples:

- real job names and real step patterns are allowed, including
  `daemon_*-devnet-docker-image` and a comma separated list
- `x" ++ env:BUILDKITE_AGENT_ACCESS_TOKEN ++ "` is refused, and the message has
  to name the quotation mark and say that the reason is dhall
- every mark that leaves a text or a shell is refused, and `env:`
- a line end, a tab, an empty value, a value that is not text, and a value
  longer than 500 characters are refused
- each wrong character is named once, however often it appears

### Note for the deploy

This changes behaviour only for input that would previously have been passed on
unchecked, so nothing that works today stops working. It needs a deploy to take
effect: `make deploy`, which runs the tests, refuses a working tree that holds
changes which are not committed, and checks parity with the deployed function
afterwards.
