### PR TITLE
add named sets of steps

### DIFF
--- a/buildkite/scripts/pipeline/select_steps.sh
+++ b/buildkite/scripts/pipeline/select_steps.sh
@@ -24,6 +24,11 @@
 #   --jobs DIR         Directory of rendered pipeline YAML (buildkite/src/gen)
 #   --select PATTERN   Pattern for a step key. Give it more than once to add
 #                      steps together. A pattern may hold * and ?.
+#   --set NAME         A named group of patterns from
+#                      buildkite/src/Constants/Artifact/Sets.dhall, which is
+#                      only sugar: it becomes patterns and is then treated the
+#                      same. Give it more than once, and mix it with --select.
+#   --list-sets        Write the sets that exist and stop.
 #   --format FORMAT    plan  (default) one "<file><TAB><step key>" for each step
 #                      keys  the step keys only
 #                      files the job files only, each one time
@@ -51,7 +56,11 @@ source "${SCRIPT_DIR}/../monorepo_lib.sh"
 JOBS_DIR=""
 FORMAT="plan"
 QUIET=0
+LIST_SETS=0
 declare -a PATTERNS=()
+declare -a SETS=()
+
+SETS_DHALL="${SCRIPT_DIR}/../../src/Constants/Artifact/Sets.dhall"
 
 usage() {
     sed -n '3,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -66,15 +75,66 @@ fail() {
 while [[ "$#" -gt 0 ]]; do case "$1" in
     --jobs)   JOBS_DIR="${2:-}"; shift 2 ;;
     --select) PATTERNS+=("${2:-}"); shift 2 ;;
+    --set)    SETS+=("${2:-}"); shift 2 ;;
+    --list-sets) LIST_SETS=1; shift ;;
     --format) FORMAT="${2:-}"; shift 2 ;;
     --quiet)  QUIET=1; shift ;;
     -h|--help) usage 0 ;;
     *) echo "Unknown option: $1" >&2; usage 2 ;;
 esac; done
 
+# ---------------------------------------------------------------------------
+# A set is only a name for some patterns. It is read from the dhall file, so the
+# names live in one place and this script holds no copy of them.
+# ---------------------------------------------------------------------------
+
+read_sets() {
+    command -v dhall-to-json > /dev/null 2>&1 || fail "'dhall-to-json' is not installed, so --set cannot be used."
+    [[ -f "$SETS_DHALL" ]] || fail "'${SETS_DHALL}' is not there."
+    dhall-to-json <<< "(${SETS_DHALL}).sets" 2>/dev/null \
+        || fail "cannot read ${SETS_DHALL}."
+}
+
+if [[ "$LIST_SETS" -eq 1 ]]; then
+    read_sets | python3 -c '
+import json, sys
+for s in json.load(sys.stdin):
+    print("%-12s %s" % (s["name"], s["description"]))
+    print("%-12s   %s" % ("", " ".join(s["patterns"])))
+'
+    exit 0
+fi
+
+if [[ "${#SETS[@]}" -gt 0 ]]; then
+    SETS_JSON="$(read_sets)"
+    for want in "${SETS[@]}"; do
+        found="$(echo "$SETS_JSON" | python3 -c "
+import json, sys
+want = sys.argv[1]
+for s in json.load(sys.stdin):
+    if s['name'] == want:
+        print('\n'.join(s['patterns']))
+" "$want")"
+        if [[ -z "$found" ]]; then
+            {
+                echo "ERROR: there is no set called '${want}'. These exist:"
+                echo "$SETS_JSON" | python3 -c "
+import json, sys
+for s in json.load(sys.stdin):
+    print('  %-12s %s' % (s['name'], s['description']))
+"
+            } >&2
+            exit 2
+        fi
+        while IFS= read -r pattern; do
+            [[ -n "$pattern" ]] && PATTERNS+=("$pattern")
+        done <<< "$found"
+    done
+fi
+
 [[ -n "$JOBS_DIR" ]] || fail "--jobs is required."
 [[ -d "$JOBS_DIR" ]] || fail "'${JOBS_DIR}' is not a directory."
-[[ "${#PATTERNS[@]}" -gt 0 ]] || fail "give at least one --select."
+[[ "${#PATTERNS[@]}" -gt 0 ]] || fail "give at least one --select or --set."
 
 case "$FORMAT" in
     plan|keys|files) ;;

--- a/buildkite/scripts/pipeline/tests/test_select_steps.sh
+++ b/buildkite/scripts/pipeline/tests/test_select_steps.sh
@@ -219,6 +219,32 @@ test_a_pattern_that_matches_nothing_stops() {
     fi
 }
 
+# A set is only sugar: it must give exactly what its patterns give.
+test_a_set_is_the_same_as_its_patterns() {
+    local by_set by_pattern
+    by_set="$("$SELECT" --jobs "$JOBS_DIR" --format keys --quiet --set dockers)"
+    by_pattern="$(select_keys --select '*-docker-image')"
+    assert_eq "a set and its pattern agree" "$by_pattern" "$by_set"
+}
+
+test_a_set_that_is_not_known_stops() {
+    local out status=0
+    out="$("$SELECT" --jobs "$JOBS_DIR" --format keys --set no-such-set 2>&1)" || status=$?
+    assert_eq "exit code" "2" "$status"
+    if echo "$out" | grep -q "dockers"; then
+        log_pass
+    else
+        log_fail "the message must write the sets that do exist"
+    fi
+}
+
+test_the_sets_can_be_listed() {
+    local out
+    out="$("$SELECT" --list-sets)"
+    if echo "$out" | grep -q "automode"; then log_pass; else log_fail "automode is missing"; fi
+    if echo "$out" | grep -q "docker-image"; then log_pass; else log_fail "the patterns are missing"; fi
+}
+
 test_wrong_arguments_stop() {
     local status
 
@@ -254,6 +280,9 @@ main() {
     run_test test_more_than_one_select_adds_up
     run_test test_formats
     run_test test_a_pattern_that_matches_nothing_stops
+    run_test test_a_set_is_the_same_as_its_patterns
+    run_test test_a_set_that_is_not_known_stops
+    run_test test_the_sets_can_be_listed
     run_test test_wrong_arguments_stop
 
     teardown_fixture

--- a/buildkite/src/Constants/Artifact/Sets.dhall
+++ b/buildkite/src/Constants/Artifact/Sets.dhall
@@ -1,0 +1,81 @@
+-- Named groups of steps, so that a developer asks for "the automode images"
+-- instead of writing the patterns out.
+--
+-- A set is only sugar. It becomes patterns for step keys, and select_steps.sh
+-- then adds everything those steps depend on, exactly as if the patterns had
+-- been given by hand. Nothing here can select something that a pattern could
+-- not.
+--
+-- The names of the steps come from the rendered pipelines. A key holds what is
+-- built, for which tier and for which network:
+--
+--   daemon_apps_only-devnet-docker-image   the daemon with no profile, no config
+--   daemon_profile-lightnet-docker-image   the daemon with a profile
+--   daemon_config-devnet-docker-image      the daemon with a network config
+--   daemon_auto_hardfork-devnet-docker-image
+--   archive-devnet-docker-image
+--   rosetta_profile-devnet-docker-image
+--   rosetta_config-devnet-docker-image
+--   build-deb-pkg                          every debian package of a pipeline
+--
+-- The codename and the architecture are in the name of the job, not in the key,
+-- so a set covers EVERY codename.
+--
+-- A set and a pattern ADD UP, they do not narrow each other: asking for the set
+-- "automode" and the pattern "_MinaArtifactBullseye-*" gives the automode images
+-- of every codename AND every step of Bullseye. To keep to one codename, write
+-- the whole key instead of using a set:
+--
+--   --select '_MinaArtifactBullseye-daemon_auto_hardfork-*-docker-image'
+--
+-- What is NOT here, and why
+-- -------------------------
+-- There is no set for "only the prefork debians", or for any other single
+-- package. Every debian package of a pipeline is built by ONE step
+-- (build-deb-pkg), whose command holds the whole list of packages, so a set of
+-- steps cannot reach inside it. Choosing single packages needs that command to
+-- be rewritten, which is a separate piece of work (A5 of the plan).
+
+let Set = { name : Text, patterns : List Text, description : Text }
+
+let sets
+    : List Set
+    =
+      -- Whole layers
+      [ { name = "dockers"
+        , patterns = [ "*-docker-image" ]
+        , description = "every docker image"
+        }
+      , { name = "debians"
+        , patterns = [ "build-deb-pkg" ]
+        , description =
+            "every debian package (one step builds them all, so this cannot be narrowed further)"
+        }
+      , { name = "daemon"
+        , patterns = [ "daemon_*-docker-image" ]
+        , description =
+            "the daemon images: apps only, profiled, configured, auto hardfork"
+        }
+      , { name = "archive"
+        , patterns = [ "archive-*-docker-image" ]
+        , description = "the archive images"
+        }
+      , { name = "rosetta"
+        , patterns = [ "rosetta_*-docker-image" ]
+        , description = "the rosetta images: profiled and configured"
+        }
+      , { name = "automode"
+        , patterns = [ "daemon_auto_hardfork-*-docker-image" ]
+        , description = "the automode (auto hardfork) images"
+        }
+      , { name = "apps-only"
+        , patterns = [ "*_apps_only-*-docker-image" ]
+        , description = "the images with no profile and no config"
+        }
+      , { name = "configured"
+        , patterns = [ "*_config-*-docker-image" ]
+        , description = "the images that hold a network config"
+        }
+      ]
+
+in  { Type = Set, sets = sets }

--- a/buildkite/src/Constants/Artifact/Sets.dhall
+++ b/buildkite/src/Constants/Artifact/Sets.dhall
@@ -30,11 +30,21 @@
 --
 -- What is NOT here, and why
 -- -------------------------
--- There is no set for "only the prefork debians", or for any other single
--- package. Every debian package of a pipeline is built by ONE step
--- (build-deb-pkg), whose command holds the whole list of packages, so a set of
--- steps cannot reach inside it. Choosing single packages needs that command to
--- be rewritten, which is a separate piece of work (A5 of the plan).
+-- **prefork.** No step key holds the word at all. The artifacts DaemonPrefork,
+-- DaemonPostfork and CreatePreforkGenesis make a debian package but NO docker
+-- image: see expandDockerServices in Command/MinaArtifact.dhall, where all
+-- three give `none`. They exist only as tokens inside the one build-deb-pkg
+-- step, and a set of steps cannot reach inside a step. A "prefork" set would
+-- have to build every debian package of the pipeline and call it prefork,
+-- which would be a lie.
+--
+-- The same holds for any other single package: every debian package of a
+-- pipeline is built by ONE step, whose command holds the whole list. Choosing
+-- single packages needs that command to be rewritten, which is a separate
+-- piece of work (A5 of the plan). When A5 lands, `prefork` becomes a real set.
+--
+-- **lightnet beyond the daemon.** Only the daemon has a lightnet image. The
+-- archive and the rosetta images are made for devnet and mainnet only.
 
 let Set = { name : Text, patterns : List Text, description : Text }
 
@@ -75,6 +85,11 @@ let sets
       , { name = "configured"
         , patterns = [ "*_config-*-docker-image" ]
         , description = "the images that hold a network config"
+        }
+      , { name = "lightnet"
+        , patterns = [ "*_profile-lightnet-docker-image" ]
+        , description =
+            "the lightnet images. Only the daemon has one: there is no lightnet archive or rosetta image"
         }
       ]
 

--- a/buildkite/src/Constants/Artifact/Sets.dhall
+++ b/buildkite/src/Constants/Artifact/Sets.dhall
@@ -28,23 +28,13 @@
 --
 --   --select '_MinaArtifactBullseye-daemon_auto_hardfork-*-docker-image'
 --
--- What is NOT here, and why
--- -------------------------
--- **prefork.** No step key holds the word at all. The artifacts DaemonPrefork,
--- DaemonPostfork and CreatePreforkGenesis make a debian package but NO docker
--- image: see expandDockerServices in Command/MinaArtifact.dhall, where all
--- three give `none`. They exist only as tokens inside the one build-deb-pkg
--- step, and a set of steps cannot reach inside a step. A "prefork" set would
--- have to build every debian package of the pipeline and call it prefork,
--- which would be a lie.
+-- Not sets:
 --
--- The same holds for any other single package: every debian package of a
--- pipeline is built by ONE step, whose command holds the whole list. Choosing
--- single packages needs that command to be rewritten, which is a separate
--- piece of work (A5 of the plan). When A5 lands, `prefork` becomes a real set.
---
--- **lightnet beyond the daemon.** Only the daemon has a lightnet image. The
--- archive and the rosetta images are made for devnet and mainnet only.
+-- * prefork, and any single package. DaemonPrefork, DaemonPostfork and
+--   CreatePreforkGenesis make a debian but no docker image, and one step builds
+--   every debian, so a set of steps cannot reach them. They become sets with A5.
+-- * a profile such as lightnet. Only the daemon has one, and one pattern needs
+--   no name: --select '*_profile-lightnet-docker-image'
 
 let Set = { name : Text, patterns : List Text, description : Text }
 
@@ -85,11 +75,6 @@ let sets
       , { name = "configured"
         , patterns = [ "*_config-*-docker-image" ]
         , description = "the images that hold a network config"
-        }
-      , { name = "lightnet"
-        , patterns = [ "*_profile-lightnet-docker-image" ]
-        , description =
-            "the lightnet images. Only the daemon has one: there is no lightnet archive or rosetta image"
         }
       ]
 


### PR DESCRIPTION
A4 of #19223. Builds on the selector from #19224, which is merged, so this is
additive: one new dhall file, one new option, three new tests.

### What it does

A developer asks for a named group instead of writing patterns:

```
$ select_steps.sh --jobs buildkite/src/gen --set automode
Chosen by name: 10 step(s)
Added because they are needed: 26 step(s)
Run set: 36 step(s)
```

```
$ select_steps.sh --list-sets
dockers      every docker image
debians      every debian package (one step builds them all, so this cannot be narrowed further)
daemon       the daemon images: apps only, profiled, configured, auto hardfork
archive      the archive images
rosetta      the rosetta images: profiled and configured
automode     the automode (auto hardfork) images
apps-only    the images with no profile and no config
configured   the images that hold a network config
```

### A set is only sugar

It becomes patterns, and the selector then treats it exactly as if the patterns
had been written by hand. Nothing a set can reach is out of reach of a pattern.
A test holds that: `--set dockers` and `--select '*-docker-image'` must give the
same run set, character for character.

The names live in `Constants/Artifact/Sets.dhall` and the script reads them with
`dhall-to-json`, so there is one definition and the shell holds no copy.

### Two things the sets say plainly, because they are easy to get wrong

**A set covers every codename.** The codename and the architecture are in the
name of the *job*, not in the step key.

**A set and a pattern add up; they do not narrow each other.** I wrote the
opposite in a comment first, then ran it: `--set automode --select
'_MinaArtifactBullseye-*'` gives the automode images of every codename *and*
every step of Bullseye. To keep to one codename, write the whole key:

```
--select '_MinaArtifactBullseye-daemon_auto_hardfork-*-docker-image'
```

which gives 5 steps: that image, the image it is FROM, the apps-only image under
that, the debians, and the apps build.

### What is deliberately absent

**`prefork`, and any single package.** `DaemonPrefork`, `DaemonPostfork` and
`CreatePreforkGenesis` make a debian package but no docker image (all three give
`none` in `expandDockerServices`), and one step builds every debian, so a set of
steps cannot reach them. Pointing `prefork` at `build-deb-pkg` was the other
option and was rejected: it builds every package while calling itself prefork,
the same kind of name that lies about its contents as the `rosetta_apps_only`
removed in #19215. Both become real sets with **A5**.

**A profile, such as `lightnet`.** I added one, then took it out. The sets group
by family, by tier or by variant; a profile is a fourth axis, and if lightnet
were a set then devnet and mainnet would have to be too. It would also hold a
single pattern and promise more than it holds, since only the daemon has a
lightnet image. One profiled image needs no name:
`--select '*_profile-lightnet-docker-image'`.

### Verified

- `--set automode` against the real rendered pipelines of `develop`: 10 steps
  named, 26 pulled in, 36 in the run set
- an unknown set exits 2 and writes the sets that do exist
- 12 tests, 37 assertions in `tests/test_select_steps.sh` (was 9 and 32)
- `shellcheck -S warning` clean; `make all` in `buildkite/` 45/45
