### PR TITLE
build only the debian packages that were asked for

### DIFF
--- a/buildkite/scripts/entrypoints/run-selection.sh
+++ b/buildkite/scripts/entrypoints/run-selection.sh
@@ -12,6 +12,10 @@
 #   --selection LIST   Patterns for step keys, separated by commas. This is what
 #                      the author of the comment wrote, so it is not trusted:
 #                      every pattern must match a step, or the script stops.
+#   --deb LIST         Patterns for debian package tokens, separated by commas
+#                      (prefork_*, logproc, ...). The debian step of a job is
+#                      then told to build only the packages that match.
+#                      See "Narrowing the debian step" below.
 #   --jobs DIR         Directory of rendered pipelines (buildkite/src/gen)
 #   --dry-run          Write what would be uploaded, upload nothing.
 #   --debug            Write the pruned pipeline of each job.
@@ -25,13 +29,28 @@
 # A step that waits for a step which is not uploaded waits for ever, so this
 # script never prunes a dependency away: select_steps.sh adds them, and the
 # check below fails the run if one is missing all the same.
+#
+# Narrowing the debian step
+# -------------------------
+# One step builds every debian package of a job:
+#
+#   build-from-cache.sh <variant> <token> <token> ...
+#
+# With --deb, that list is cut down to the tokens that match. It is only cut
+# down when NO docker image of that job is being built, because the images
+# install those .deb files from the build context (install-mina-debs.sh), so an
+# image whose packages were not built fails inside docker with a message about
+# a missing file. When an image survives, the whole list is kept and the reason
+# is written out.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SELECT_STEPS="${SCRIPT_DIR}/../pipeline/select_steps.sh"
+NARROW_DEBS="${SCRIPT_DIR}/../pipeline/narrow_debian_tokens.py"
 
 SELECTION=""
+DEB_SELECTION=""
 JOBS_DIR=""
 DRY_RUN=false
 DEBUG=false
@@ -48,6 +67,7 @@ fail() {
 
 while [[ "$#" -gt 0 ]]; do case "$1" in
     --selection) SELECTION="${2:-}"; shift 2 ;;
+    --deb)       DEB_SELECTION="${2:-}"; shift 2 ;;
     --jobs)      JOBS_DIR="${2:-}"; shift 2 ;;
     --dry-run)   DRY_RUN=true; shift ;;
     --debug)     DEBUG=true; shift ;;
@@ -55,7 +75,12 @@ while [[ "$#" -gt 0 ]]; do case "$1" in
     *) echo "Unknown option: $1" >&2; usage 2 ;;
 esac; done
 
-[[ -n "$SELECTION" ]] || fail "--selection is required."
+if [[ -z "$SELECTION" && -n "$DEB_SELECTION" ]]; then
+    # Asking for packages means asking for the step that builds them.
+    SELECTION="build-deb-pkg"
+fi
+
+[[ -n "$SELECTION" ]] || fail "--selection or --deb is required."
 [[ -n "$JOBS_DIR" ]] || fail "--jobs is required."
 [[ -d "$JOBS_DIR" ]] || fail "'${JOBS_DIR}' is not a directory."
 [[ -x "$SELECT_STEPS" ]] || fail "'${SELECT_STEPS}' is not there."
@@ -139,6 +164,28 @@ for file in "${!JOB_STEPS[@]}"; do
         echo "ERROR: in job '${job_name}', these steps are waited for but not uploaded:${missing}" >&2
         echo "       select_steps.sh and this script disagree; that is a fault, not a bad request." >&2
         exit 2
+    fi
+
+    # Narrow the debian step, but only when this job builds no image: the
+    # images install those .deb files from the build context, so an image whose
+    # packages were not built fails inside docker.
+    if [[ -n "$DEB_SELECTION" && "${JOB_STEPS[$file]}" == *build-deb-pkg* ]]; then
+        if [[ "${JOB_STEPS[$file]}" == *docker-image* ]]; then
+            echo " !  ${job_name}: keeping every debian package, because this job also builds images that install them" >&2
+        else
+            declare -a deb_patterns=()
+            IFS=',' read -ra raw_debs <<< "$DEB_SELECTION"
+            for d in "${raw_debs[@]}"; do
+                d="$(echo "$d" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+                [[ -n "$d" ]] && deb_patterns+=("$d")
+            done
+
+            if ! narrowed="$(echo "$pruned" | "$NARROW_DEBS" "${deb_patterns[@]}")"; then
+                echo "ERROR: in job '${job_name}', no debian package matches ${DEB_SELECTION}" >&2
+                exit 1
+            fi
+            pruned="$narrowed"
+        fi
     fi
 
     count="$(echo "$pruned" | yq -r '[.steps[]?] | length')"

--- a/buildkite/scripts/pipeline/narrow_debian_tokens.py
+++ b/buildkite/scripts/pipeline/narrow_debian_tokens.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+"""Keep only the wanted debian packages in a pipeline that is about to be uploaded.
+
+One step of a job builds every debian package of that job:
+
+    build-from-cache.sh <variant> <token> <token> ...
+
+This reads a pipeline on stdin, cuts that list down to the tokens that match the
+patterns given, and writes the pipeline out again.
+
+    narrow_debian_tokens.py 'prefork_*' logproc < pipeline.yml > narrowed.yml
+
+The token list is written more than once in the same step: once in the `echo
+"-- Running: ..."` line that the log shows, and once in the command that really
+runs. Both are changed, so the log does not say something other than what ran.
+
+Nothing else in the pipeline is touched. When no token matches, the run stops:
+building nothing is never what was meant, and a silent empty list would make
+build.sh fall back to building EVERY default package.
+"""
+
+import fnmatch
+import re
+import sys
+
+# build-from-cache.sh <variant> <token> <token> ...
+# A token is lower case letters, digits and underscores. The list ends at the
+# first word that is not one, which is how the two forms of the line (the echo
+# and the real command) both end.
+CALL = re.compile(
+    r"(build-from-cache\.sh\s+)([A-Za-z0-9_]+)((?:\s+[a-z0-9_]+)+)"
+)
+
+
+def narrow_line(line, patterns, report):
+    def replace(match):
+        head, variant, tokens = match.group(1), match.group(2), match.group(3)
+        wanted = [
+            token
+            for token in tokens.split()
+            if any(fnmatch.fnmatchcase(token, p) for p in patterns)
+        ]
+        report["seen"].update(tokens.split())
+        report["kept"].update(wanted)
+        if not wanted:
+            # Leave the line alone; the caller stops the run.
+            return match.group(0)
+        return head + variant + " " + " ".join(wanted)
+
+    return CALL.sub(replace, line)
+
+
+def main():
+    patterns = sys.argv[1:]
+    if not patterns:
+        sys.stderr.write("usage: narrow_debian_tokens.py PATTERN [PATTERN ...]\n")
+        return 2
+
+    report = {"seen": set(), "kept": set()}
+    text = sys.stdin.read()
+    out = "\n".join(narrow_line(line, patterns, report) for line in text.split("\n"))
+
+    if not report["seen"]:
+        sys.stderr.write(
+            "narrow_debian_tokens.py: no build-from-cache.sh call was found, "
+            "so nothing was narrowed.\n"
+        )
+        return 1
+
+    if not report["kept"]:
+        sys.stderr.write(
+            "narrow_debian_tokens.py: no debian package matches %s.\n"
+            "  These are built by this job:\n%s\n"
+            % (
+                " ".join(patterns),
+                "\n".join("    " + t for t in sorted(report["seen"])),
+            )
+        )
+        return 1
+
+    dropped = sorted(report["seen"] - report["kept"])
+    sys.stderr.write(
+        "narrow_debian_tokens.py: keeping %d of %d packages (%s)\n"
+        % (
+            len(report["kept"]),
+            len(report["seen"]),
+            " ".join(sorted(report["kept"])),
+        )
+    )
+    if dropped:
+        sys.stderr.write("  not built: %s\n" % " ".join(dropped))
+
+    sys.stdout.write(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/buildkite/scripts/pipeline/tests/test_narrow_debian_tokens.sh
+++ b/buildkite/scripts/pipeline/tests/test_narrow_debian_tokens.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# Tests for narrow_debian_tokens.py
+#
+# Usage: bash buildkite/scripts/pipeline/tests/test_narrow_debian_tokens.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NARROW="${SCRIPT_DIR}/../narrow_debian_tokens.py"
+
+RUN=0; PASSED=0; FAILED=0; FAILURES=()
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    RUN=$((RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        PASSED=$((PASSED + 1))
+    else
+        FAILED=$((FAILED + 1))
+        FAILURES+=("${label}: expected '${expected}', got '${actual}'")
+        echo "  FAIL ${label}: expected '${expected}', got '${actual}'" >&2
+    fi
+}
+
+# A step whose token list is written twice, as the real pipelines write it: once
+# in the line the log shows, and once in the command that runs.
+fixture() {
+    cat <<'YAML'
+steps:
+  - key: _Job-build-deb-pkg
+    command:
+      - echo "-- Running: ( ./buildkite/scripts/debian/build-from-cache.sh bullseye logproc archive_devnet daemon_devnet_prefork prefork_devnet_genesis_ledger ) --"
+      - docker run --rm image bash -c "./buildkite/scripts/debian/build-from-cache.sh bullseye logproc archive_devnet daemon_devnet_prefork prefork_devnet_genesis_ledger"
+      - ./buildkite/scripts/debian/write_to_cache.sh bullseye
+YAML
+}
+
+echo "TEST: a pattern keeps only what matches"
+out="$(fixture | "$NARROW" 'prefork_*' 'daemon_*_prefork' 2>/dev/null)"
+check "kept tokens" "2" "$(echo "$out" | grep -o 'build-from-cache.sh bullseye[a-z0-9_ ]*' | head -1 | grep -o '[a-z0-9_]*prefork[a-z0-9_]*' | wc -l)"
+check "logproc is gone" "0" "$(echo "$out" | grep -c 'bullseye logproc' || true)"
+
+echo "TEST: BOTH places are rewritten, so the log matches what runs"
+count="$(echo "$out" | grep -c 'build-from-cache.sh bullseye daemon_devnet_prefork prefork_devnet_genesis_ledger')"
+check "two occurrences" "2" "$count"
+
+echo "TEST: the rest of the pipeline is untouched"
+check "write_to_cache stays" "1" "$(echo "$out" | grep -c 'write_to_cache.sh bullseye')"
+check "the key stays" "1" "$(echo "$out" | grep -c '_Job-build-deb-pkg')"
+
+echo "TEST: a pattern that matches nothing stops, it does not build everything"
+status=0
+fixture | "$NARROW" 'no_such_package' > /dev/null 2>&1 || status=$?
+check "exit code" "1" "$status"
+msg="$(fixture | "$NARROW" 'no_such_package' 2>&1 >/dev/null || true)"
+check "the message lists what exists" "1" "$(echo "$msg" | grep -c 'archive_devnet')"
+
+echo "TEST: a pipeline with no debian call stops"
+status=0
+echo "steps: []" | "$NARROW" 'logproc' > /dev/null 2>&1 || status=$?
+check "exit code" "1" "$status"
+
+echo "TEST: no pattern at all is refused"
+status=0
+fixture | "$NARROW" > /dev/null 2>&1 || status=$?
+check "exit code" "2" "$status"
+
+echo ""
+echo "Results: ${RUN} checks, ${PASSED} passed, ${FAILED} failed"
+if [[ ${FAILED} -gt 0 ]]; then
+    printf '  - %s\n' "${FAILURES[@]}"
+    exit 1
+fi
+echo "All tests passed."


### PR DESCRIPTION
A5 of #19223, the last axis. Until now a selection could name any docker image
but not a single debian package, because one step builds them all. This makes
that step buildable in part.

```
$ run-selection.sh --deb 'prefork_*,daemon_*_prefork' \
    --jobs buildkite/src/gen --dry-run

narrow_debian_tokens.py: keeping 2 of 19 packages
  (daemon_devnet_prefork prefork_devnet_genesis_ledger)
  not built: archive_devnet archive_generic daemon_devnet_automode
             daemon_devnet_config daemon_devnet_postfork daemon_generic
             daemon_storage_toolbox functional_test_suite logproc profile_devnet
             profile_devnet_generic profile_lightnet profile_mainnet_generic
             rosetta_devnet rosetta_generic test_executive tx_tools
```

### It needs no dhall change either

The token list is already in the rendered command:

```
build-from-cache.sh bullseye daemon_devnet_config daemon_generic profile_lightnet ...
```

so narrowing is the same post-render work as everything else in track A. The
artifact-to-token mapping in the dhall is not read, and nothing is written
twice.

### The safety rule is the point of the PR

The images install those `.deb` files **from the build context**
(`install-mina-debs.sh`), so an image whose packages were not built fails inside
docker. The list is therefore cut down **only when the job builds no image**.
When an image survives, the whole list is kept and the reason is said out loud:

```
!  MinaArtifactBullseye: keeping every debian package, because this job also
   builds images that install them
```

That is a real case, not a theoretical one: `--deb logproc` together with an
archive image gives exactly this, and the archive image would otherwise fail on
a missing file.

### Two smaller decisions

**Both places are rewritten.** The token list appears twice in the step: in the
`echo "-- Running: ..."` line that the log shows, and in the command that really
runs. Rewriting only the second would make the log say something other than what
happened. A test holds both.

**A pattern that matches nothing stops the run.** It does not quietly build
nothing, because `build.sh` with an empty list falls back to building **every**
default package — the opposite of what was asked. The message lists the packages
the job does build.

### Tests

- `tests/test_narrow_debian_tokens.sh`: 9 checks. Only what matches is kept; both
  places are rewritten; the rest of the pipeline is untouched; a pattern that
  matches nothing exits 1 and lists what exists; a pipeline with no debian call
  exits 1; no pattern at all exits 2.
- the 12 selector tests still pass
- checked against the real rendered pipelines of `develop`, both the narrowing
  and the refusal to narrow, as shown above

### What this unlocks

`prefork` can now be a set, and so can any single package. That needs the `Set`
record in `Constants/Artifact/Sets.dhall` to carry debian patterns as well as
step patterns, which is a small follow-up rather than part of this PR.

When it lands, the two sets are:

* **prefork** = `prefork_*_genesis_ledger`, `daemon_*_prefork`. These are built
  FOR the next hardfork.
* **automode** = the auto hardfork images it already holds, plus
  `daemon_*_postfork`.

postfork belongs with automode, not with prefork: the two are never wanted in
the same build.
