### PR TITLE
make the artifact builders scheduling-agnostic

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -317,58 +317,69 @@ let profileTents
           \(spec : PackagingSpec.Type)
       ->  Text/concatSep " " (Artifact.profileTents spec.artifacts)
 
-let build_artifacts
-    : PackagingSpec.Type -> Command.Type
+let debianTokens
+    : PackagingSpec.Type -> Text
+    =     \(spec : PackagingSpec.Type)
+      ->  Text/concatSep
+            " "
+            (List/map Artifact.Type Text Artifact.toDebianToken spec.artifacts)
+
+let CacheHops =
+      { apps =
+              \(codename : Text)
+          ->  \(variant : Text)
+          ->  Cmd.run
+                "./buildkite/scripts/apps/write_to_cache.sh ${codename} ${variant}"
+      , appsBuildManifest =
+              \(codename : Text)
+          ->  \(treeVariant : Text)
+          ->  Cmd.run
+                "./buildkite/scripts/apps/write_build_manifest_to_cache.sh ${codename} ${treeVariant}"
+      , debian =
+              \(codename : Text)
+          ->  Cmd.run "./buildkite/scripts/debian/write_to_cache.sh ${codename}"
+      }
+
+let artifactCommands
+    : PackagingSpec.Type -> List Cmd.Type
     =     \(spec : PackagingSpec.Type)
       ->  let nets = Artifact.networks spec.artifacts
 
-          let debianTokens =
-                Text/concatSep
-                  " "
-                  ( List/map
-                      Artifact.Type
-                      Text
-                      Artifact.toDebianToken
-                      spec.artifacts
-                  )
+          in  Toolchain.select
+                Toolchain.Spec::{
+                , mode = spec.toolchainSelectMode
+                , debVersion = spec.debVersion
+                , arch = spec.arch
+                , submodules = True
+                }
+                (   [ "AWS_ACCESS_KEY_ID"
+                    , "AWS_SECRET_ACCESS_KEY"
+                    , "MINA_BRANCH=\$BUILDKITE_BRANCH"
+                    , "MINA_COMMIT_SHA1=\$BUILDKITE_COMMIT"
+                    , "MINA_DEB_CODENAME=${DebianVersions.lowerName
+                                             spec.debVersion}"
+                    , "ARCHITECTURE=${Arch.lowerName spec.arch}"
+                    , Network.foldMinaBuildMainnetEnv nets
+                    , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
+                    , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
+                    ]
+                  # BuildFlags.buildEnvs spec.buildFlags
+                  # spec.extraBuildEnvs
+                  # DebianVersions.overrideEnvs
+                )
+                "${spec.buildScript} ${debianTokens spec} ${profileTents spec}"
 
-          let appsCacheWrite =
-                Cmd.run
-                  "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                  spec.debVersion} ${appsVariant
-                                                                                       spec}"
+let build_artifacts
+    : PackagingSpec.Type -> Command.Type
+    =     \(spec : PackagingSpec.Type)
+      ->  let codename = DebianVersions.lowerName spec.debVersion
 
           in  Command.build
                 Command.Config::{
                 , commands =
-                      Toolchain.select
-                        Toolchain.Spec::{
-                        , mode = spec.toolchainSelectMode
-                        , debVersion = spec.debVersion
-                        , arch = spec.arch
-                        , submodules = True
-                        }
-                        (   [ "AWS_ACCESS_KEY_ID"
-                            , "AWS_SECRET_ACCESS_KEY"
-                            , "MINA_BRANCH=\$BUILDKITE_BRANCH"
-                            , "MINA_COMMIT_SHA1=\$BUILDKITE_COMMIT"
-                            , "MINA_DEB_CODENAME=${DebianVersions.lowerName
-                                                     spec.debVersion}"
-                            , "ARCHITECTURE=${Arch.lowerName spec.arch}"
-                            , Network.foldMinaBuildMainnetEnv nets
-                            , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
-                            , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
-                            ]
-                          # BuildFlags.buildEnvs spec.buildFlags
-                          # spec.extraBuildEnvs
-                          # DebianVersions.overrideEnvs
-                        )
-                        "${spec.buildScript} ${debianTokens} ${profileTents
-                                                                 spec}"
-                    # [ Cmd.run
-                          "./buildkite/scripts/debian/write_to_cache.sh ${DebianVersions.lowerName
-                                                                            spec.debVersion}"
-                      , appsCacheWrite
+                      artifactCommands spec
+                    # [ CacheHops.debian codename
+                      , CacheHops.apps codename (appsVariant spec)
                       ]
                 , label = "Debian: Build ${labelSuffix spec}"
                 , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
@@ -417,32 +428,32 @@ let appsJobName
       -- single network-less app job.
       \(spec : PackagingSpec.Type) -> "${genericBuildName spec}Apps"
 
+let appsCommands
+    : AppsSpec.Type -> List Cmd.Type
+    =     \(spec : AppsSpec.Type)
+      ->  Toolchain.select
+            Toolchain.Spec::{
+            , mode = spec.toolchainSelectMode
+            , debVersion = spec.debVersion
+            , arch = spec.arch
+            , submodules = True
+            }
+            (appsBuildEnvs spec)
+            "./buildkite/scripts/build-artifact.sh"
+
 let build_apps
     : AppsSpec.Type -> Command.Type
     =     \(spec : AppsSpec.Type)
-      ->  let appsCacheWrite =
-                Cmd.run
-                  "./buildkite/scripts/apps/write_to_cache.sh ${DebianVersions.lowerName
-                                                                  spec.debVersion} ${appsSpecVariant
-                                                                                       spec}"
+      ->  let codename = DebianVersions.lowerName spec.debVersion
 
           in  Command.build
                 Command.Config::{
                 , commands =
-                      Toolchain.select
-                        Toolchain.Spec::{
-                        , mode = spec.toolchainSelectMode
-                        , debVersion = spec.debVersion
-                        , arch = spec.arch
-                        , submodules = True
-                        }
-                        (appsBuildEnvs spec)
-                        "./buildkite/scripts/build-artifact.sh"
-                    # [ appsCacheWrite
-                      , Cmd.run
-                          "./buildkite/scripts/apps/write_build_manifest_to_cache.sh ${DebianVersions.lowerName
-                                                                                         spec.debVersion} ${appsSpecTreeVariant
-                                                                                                              spec}"
+                      appsCommands spec
+                    # [ CacheHops.apps codename (appsSpecVariant spec)
+                      , CacheHops.appsBuildManifest
+                          codename
+                          (appsSpecTreeVariant spec)
                       ]
                 , label = "Build apps: ${appsLabelSuffix spec}"
                 , key = "build-apps"
@@ -455,13 +466,6 @@ let build_apps
                     }
                   ]
                 }
-
-let debianTokens
-    : PackagingSpec.Type -> Text
-    =     \(spec : PackagingSpec.Type)
-      ->  Text/concatSep
-            " "
-            (List/map Artifact.Type Text Artifact.toDebianToken spec.artifacts)
 
 let buildDebianFromApps
     : PackagingSpec.Type -> Text -> List Cmd.Type
@@ -488,9 +492,7 @@ let build_debian
                   buildDebianFromApps
                     spec
                     "${debianTokens spec} ${profileTents spec}"
-                # [ Cmd.run
-                      "./buildkite/scripts/debian/write_to_cache.sh ${DebianVersions.lowerName
-                                                                        spec.debVersion}"
+                # [ CacheHops.debian (DebianVersions.lowerName spec.debVersion)
                   ]
             , label = "Debian: Build ${labelSuffix spec}"
             , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
@@ -854,4 +856,8 @@ in  { onlyDebianPipeline = onlyDebianPipeline
     , buildDebian = build_debian
     , buildDebianFromApps = buildDebianFromApps
     , debianTokens = debianTokens
+    , CacheHops = CacheHops
+    , appsCommands = appsCommands
+    , artifactCommands = artifactCommands
+    , dockerCommands = docker_commands
     }


### PR DESCRIPTION
Part of #19223 (track B, step B1). Pure refactor. The gate is an empty render
diff: all 103 rendered pipelines are byte-identical before and after.

## What moves

A builder in `Command/MinaArtifact.dhall` used to do two different things: build
something, and then push the result into the CI cache. The cache hop is there
only because **every buildkite step is its own agent**, so what one step makes
reaches the next one only through the cache. That is a property of the
SCHEDULE, not of the build.

This separates the two:

| new | what it emits |
|---|---|
| `appsCommands` | compile only (`build-artifact.sh`) |
| `artifactCommands` | compile and package in one workspace (`build-release.sh <tokens>`) |
| `buildDebianFromApps` | package binaries an app job compiled (unchanged, already had this shape) |
| `dockerCommands` | the docker steps (was private as `docker_commands`) |
| `CacheHops` | the three writes: `apps`, `appsBuildManifest`, `debian` |

`buildArtifacts`, `buildApps` and `buildDebian` stay exactly as they were from
outside: each is now the matching builder plus the hops it needs, in the same
order as before.

## Why

B2 wants one step that runs apps, then debians, then dockers on **one** agent.
For `MinaArtifactBullseye` today the apps job writes the `_build` tree to the
cache, the packaging job reads it and writes the `.deb` set, and then each of
the 8 docker steps reads that deb set down again. A single agent removes all of
it — but only if the builders can be called without dragging a cache write in
with them. That is what this PR makes possible; it adds no assembler yet.

## One hop that does NOT move

`debian/build-from-cache.sh` restores the build tree and packages it in the same
script (`restore_build_tree.sh` is line 32 of it), so the read is not a command
that can be lifted out — it is the entry script itself. An assembler that
already holds the tree calls `artifactCommands` instead, which is the same
compile-and-package path `MinaArtifactOnlyDebianBullseye` uses today. Splitting
that script is B2's business, and it would change the rendered YAML, so it does
not belong in a refactor gated on an empty diff.

## Gates

- `dump_dhall_to_pipelines.sh` before and after: `diff -r` is empty, 103 jobs
- `make all` in `buildkite/` (syntax, lint, format, deps, dirty-when, dups,
  names, monorepo tests) passes

No changelog entry: buildkite-only change.
