### PR TITLE
build one artifact set on one agent

### DIFF
--- a/buildkite/scripts/debian/stage_local_debs.sh
+++ b/buildkite/scripts/debian/stage_local_debs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Stage .deb files this agent built itself into the docker build context.
+#
+# scripts/docker/build.sh picks up every *.deb sitting in the docker build
+# context and stages it under _debs/, which the Dockerfiles COPY into the image
+# for install-mina-debs.sh -- no apt repo involved. So an image can be built out
+# of packages that never went to the CI cache, as long as the debian build ran
+# on this agent first.
+#
+# This is the local-disk counterpart of read_all_from_cache.sh, which fills the
+# same directory from the CI cache when the debs were built by another job on
+# another agent.
+#
+# Usage: stage_local_debs.sh [<source-dir>]   (default source: _build)
+
+set -eo pipefail
+
+SOURCE_DIR="${1:-_build}"
+DEB_STAGE="dockerfiles"
+
+echo "--- Staging locally built debian packages into ${DEB_STAGE}"
+
+shopt -s nullglob
+built_debs=("${SOURCE_DIR}"/*.deb)
+shopt -u nullglob
+
+if [[ "${#built_debs[@]}" -eq 0 ]]; then
+  echo "No .deb files found in ${SOURCE_DIR}/. The debian build must run first." >&2
+  exit 1
+fi
+
+echo "Staging ${#built_debs[@]} locally built .deb file(s):"
+printf '  %s\n' "${built_debs[@]}"
+cp "${built_debs[@]}" "${DEB_STAGE}/"

--- a/buildkite/scripts/docker/build-from-local-debs.sh
+++ b/buildkite/scripts/docker/build-from-local-debs.sh
@@ -78,24 +78,11 @@ if [[ -z "$DOCKER_REGISTRY_ARG" ]]; then
   exit 1
 fi
 
-# scripts/docker/build.sh picks up every *.deb sitting in the docker build
-# context and stages it under _debs/, which the Dockerfiles COPY into the image
-# for install-mina-debs.sh -- no apt repo involved.
+# The docker build context. Must match the directory stage_local_debs.sh copies
+# into, because the legacy packages below land next to the freshly built ones.
 DEB_STAGE="dockerfiles"
 
-echo "--- Staging locally built debian packages into ${DEB_STAGE}"
-shopt -s nullglob
-built_debs=(_build/*.deb)
-shopt -u nullglob
-
-if [[ "${#built_debs[@]}" -eq 0 ]]; then
-  echo "No .deb files found in _build/. The debian build step must run first." >&2
-  exit 1
-fi
-
-echo "Staging ${#built_debs[@]} locally built .deb file(s):"
-printf '  %s\n' "${built_debs[@]}"
-cp "${built_debs[@]}" "${DEB_STAGE}/"
+./buildkite/scripts/debian/stage_local_debs.sh
 
 # Only images that install a package from before the fork need this: it is a
 # released artifact pinned at --legacy-version, not something this build can

--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -32,7 +32,13 @@ let Arch = ../Constants/Arch.dhall
 
 let DebianInstallMode
     : Type
-    = < NoInstall | DownloadOnly >
+    =
+      -- Where the .deb files the image installs come from. NoInstall is for the
+      -- images that install none (base, toolchain). DownloadOnly pulls the
+      -- packaging job's debs out of the CI cache, which is what a step needs
+      -- when the debs were built on another agent. FromLocalBuild takes them
+      -- off this agent's disk, for a step that built them itself.
+      < NoInstall | DownloadOnly | FromLocalBuild >
 
 let ciDockerCacheMountedRoot = "/var/storagebox/docker-cache"
 
@@ -120,7 +126,10 @@ let stepLabel =
                                                                                                         spec.build_flags} ${Arch.capitalName
                                                                                                                               spec.arch}"
 
-let generateStep =
+let releaseCommand =
+    -- What building one image actually runs, with no buildkite step around it.
+    -- A step of its own is one way to schedule this; running several of them in
+    -- a row on one agent is another.
           \(spec : ReleaseSpec.Type)
       ->  let exportMinaDebCmd =
                 "export MINA_DEB_CODENAME=${DebianVersions.lowerName
@@ -136,6 +145,8 @@ let generateStep =
                       " && ROOT=${spec.deb_root_folder} LOCAL_DEB_FOLDER=\"dockerfiles\" ./buildkite/scripts/debian/read_all_from_cache.sh "
                   , NoInstall =
                       " && echo Skipping local debian package download "
+                  , FromLocalBuild =
+                      " && ./buildkite/scripts/debian/stage_local_debs.sh "
                   }
                   spec.deb_install_mode
 
@@ -284,28 +295,28 @@ let generateStep =
                 ++  imageNameArg
                 ++  maybeSaveToCacheArg
 
-          let commands =
-                [ Cmd.run
-                    (     exportMinaDebCmd
-                      ++  " && "
-                      ++  exportBranchNameCmd
-                      ++  " && "
-                      ++  pruneDockerImages
-                      ++  maybeFetchLocalDebs
-                      ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
-                      ++  " && "
-                      ++  maybeLoadBaseImage
-                      ++  buildDockerCmd
-                      ++  maybeVerify
-                    )
-                ]
+          in  Cmd.run
+                (     exportMinaDebCmd
+                  ++  " && "
+                  ++  exportBranchNameCmd
+                  ++  " && "
+                  ++  pruneDockerImages
+                  ++  maybeFetchLocalDebs
+                  ++  " && source ./buildkite/scripts/export-git-env-vars.sh "
+                  ++  " && "
+                  ++  maybeLoadBaseImage
+                  ++  buildDockerCmd
+                  ++  maybeVerify
+                )
 
-          let target =
+let generateStep =
+          \(spec : ReleaseSpec.Type)
+      ->  let target =
                 merge { Arm64 = Size.XLarge, Amd64 = Size.XLarge } spec.arch
 
           in  Command.build
                 Command.Config::{
-                , commands = commands
+                , commands = [ releaseCommand spec ]
                 , label = "${stepLabel spec}"
                 , key = "${stepKey spec}"
                 , target = target
@@ -315,6 +326,7 @@ let generateStep =
                 }
 
 in  { generateStep = generateStep
+    , releaseCommand = releaseCommand
     , DebianInstallMode = DebianInstallMode
     , ReleaseSpec = ReleaseSpec
     , stepKey = stepKey

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -8,6 +8,12 @@ let List/map = Prelude.List.map
 
 let List/concatMap = Prelude.List.concatMap
 
+let List/filter = Prelude.List.filter
+
+let Natural/equal = Prelude.Natural.equal
+
+let Natural/enumerate = Prelude.Natural.enumerate
+
 let Optional/default = Prelude.Optional.default
 
 let Text/concatSep = Prelude.Text.concatSep
@@ -27,6 +33,8 @@ let JobSpec = ../Pipeline/JobSpec.dhall
 let Size = ./Size.dhall
 
 let DockerImage = ./DockerImage.dhall
+
+let DockerLogin = ./DockerLogin/Type.dhall
 
 let DebianVersions = ../Constants/DebianVersions.dhall
 
@@ -758,8 +766,8 @@ let docker_step
                 }
                 entry.service
 
-let docker_commands
-    : PackagingSpec.Type -> List Command.Type
+let docker_release_specs
+    : PackagingSpec.Type -> List DockerImage.ReleaseSpec.Type
     =     \(spec : PackagingSpec.Type)
       ->  let services =
                 List/concatMap
@@ -768,20 +776,64 @@ let docker_commands
                   expandDockerServices
                   spec.artifacts
 
-          let flattened_docker_steps =
-                List/concatMap
-                  DockerService
-                  DockerImage.ReleaseSpec.Type
-                  (\(e : DockerService) -> docker_step e spec)
-                  services
-
-          in  List/map
+          in  List/concatMap
+                DockerService
                 DockerImage.ReleaseSpec.Type
-                Command.Type
-                (     \(s : DockerImage.ReleaseSpec.Type)
-                  ->  DockerImage.generateStep s
-                )
-                flattened_docker_steps
+                (\(e : DockerService) -> docker_step e spec)
+                services
+
+let docker_commands
+    : PackagingSpec.Type -> List Command.Type
+    =     \(spec : PackagingSpec.Type)
+      ->  List/map
+            DockerImage.ReleaseSpec.Type
+            Command.Type
+            (\(s : DockerImage.ReleaseSpec.Type) -> DockerImage.generateStep s)
+            (docker_release_specs spec)
+
+let assembledDockerCommands
+    : PackagingSpec.Type -> List Cmd.Type
+    =
+      -- The same image builds as docker_commands, but as plain commands for one
+      -- agent instead of one step each.
+      --
+      -- Two things change when the fan-out goes away. The debs are on local
+      -- disk already, so no step reads them back out of the cache. And the
+      -- order that depends_on carried has to be produced here, because commands
+      -- in one step run in the order they are listed: every image is built
+      -- after the images it is FROM, which is what Docker.buildTier says.
+          \(spec : PackagingSpec.Type)
+      ->  let Spec = DockerImage.ReleaseSpec.Type
+
+          let localSpecs =
+                List/map
+                  Spec
+                  Spec
+                  (     \(s : Spec)
+                    ->      s
+                        //  { deb_install_mode =
+                                DockerImage.DebianInstallMode.FromLocalBuild
+                            }
+                  )
+                  (docker_release_specs spec)
+
+          let ofTier =
+                    \(tier : Natural)
+                ->  List/filter
+                      Spec
+                      (     \(s : Spec)
+                        ->  Natural/equal (Docker.buildTier s.service) tier
+                      )
+                      localSpecs
+
+          let ordered =
+                List/concatMap
+                  Natural
+                  Spec
+                  ofTier
+                  (Natural/enumerate (Docker.maxBuildTier + 1))
+
+          in  List/map Spec Cmd.Type DockerImage.releaseCommand ordered
 
 let pipelineBuilder
     : PackagingSpec.Type -> List Command.Type -> Pipeline.Config.Type
@@ -799,6 +851,43 @@ let pipelineBuilder
             }
           , steps = steps
           }
+
+let assembleCommands
+    : PackagingSpec.Type -> List Cmd.Type
+    =
+      -- Compile, package and build every image, in that order, on one agent.
+      -- Nothing goes through the CI cache, because nothing has to: what one
+      -- part leaves on disk is what the next part reads. The fan-out instead
+      -- writes the build tree once, reads it back once, writes the deb set
+      -- once, and reads it back once per image.
+          \(spec : PackagingSpec.Type)
+      ->  artifactCommands spec # assembledDockerCommands spec
+
+let assemble
+    : PackagingSpec.Type -> Command.Type
+    =     \(spec : PackagingSpec.Type)
+      ->  Command.build
+            Command.Config::{
+            , commands = assembleCommands spec
+            , label = "Assemble: ${labelSuffix spec}"
+            , key = "assemble"
+            , target = Size.XLarge
+            , docker_login = Some DockerLogin::{=}
+            , if_ = spec.if_
+            }
+
+let assembledPipeline
+    : PackagingSpec.Type -> Pipeline.Config.Type
+    =
+      -- One job, one step, one agent. Opt-in: the fan-out stays the default for
+      -- nightly and for release, where the parallelism and the per-image retry
+      -- are worth the cache traffic.
+      --
+      -- The spec has to be self-contained, because there is no depends_on to
+      -- pull a missing image in from another job: an artifact list holding
+      -- Daemon or DaemonProfiled must hold DaemonGeneric too, and one holding
+      -- Rosetta gets RosettaGeneric on its own (see expandDockerServices).
+      \(spec : PackagingSpec.Type) -> pipelineBuilder spec [ assemble spec ]
 
 let onlyDebianPipeline
     -- The one job that still compiles AND packages in a single step
@@ -848,6 +937,9 @@ let packagePipeline
 in  { onlyDebianPipeline = onlyDebianPipeline
     , appsPipeline = appsPipeline
     , packagePipeline = packagePipeline
+    , assembledPipeline = assembledPipeline
+    , assemble = assemble
+    , assembleCommands = assembleCommands
     , PackagingSpec = PackagingSpec
     , AppsSpec = AppsSpec
     , labelSuffix = labelSuffix

--- a/buildkite/src/Constants/Docker/Package.dhall
+++ b/buildkite/src/Constants/Docker/Package.dhall
@@ -103,6 +103,37 @@ let isGeneric =
             }
             package
 
+let buildTier =
+    -- How deep an image sits in the FROM chain, and so the order the images
+    -- have to be built in when one agent builds several of them in a row.
+    --
+    -- Tier 0 is built out of .deb files alone. Tier 1 is FROM a tier-0 image
+    -- (the *-configured and *-profiled daemons come FROM the generic daemon,
+    -- and the configured rosetta comes FROM the generic rosetta). Tier 2 is
+    -- FROM a tier-1 image.
+    --
+    -- When the images are separate buildkite steps the same order is expressed
+    -- as depends_on, which Command/MinaArtifact.dhall builds in docker_step;
+    -- the two must agree.
+          \(package : Package)
+      ->  merge
+            { DaemonGeneric = 0
+            , DaemonProfiled = \(args : { profile : Profile.Type }) -> 1
+            , Daemon = \(args : { network : Network.Type }) -> 1
+            , DaemonLegacyHardfork = \(args : { network : Network.Type }) -> 1
+            , DaemonAutoHardfork = \(args : { network : Network.Type }) -> 2
+            , Archive = \(args : { network : Network.Type }) -> 0
+            , RosettaGeneric = 0
+            , Rosetta = \(args : { network : Network.Type }) -> 1
+            , TxTools = 0
+            , DelegationVerifier = 0
+            , Toolchain = 0
+            , Base = 0
+            }
+            package
+
+let maxBuildTier = 2
+
 let isNetworked =
           \(package : Package)
       ->  merge
@@ -378,6 +409,8 @@ in  { Type = Package
     , isGeneric = isGeneric
     , isNetworked = isNetworked
     , isProfiled = isProfiled
+    , buildTier = buildTier
+    , maxBuildTier = maxBuildTier
     , dockerName = dockerName
     , dockerNames = dockerNames
     , dockerTag = dockerTag

--- a/buildkite/src/Jobs/Release/MinaArtifactAssembledBullseye.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactAssembledBullseye.dhall
@@ -1,0 +1,58 @@
+-- The single-agent shape of MinaArtifactBullseye: the same artifacts, built by
+-- one step on one agent instead of an app job, a packaging job and a step per
+-- image.
+--
+-- It is opt-in and is selected by nothing: `scope = []` keeps it out of pull
+-- request CI, out of the nightlies and out of the release pipeline, which all
+-- keep the fan-out. Run it by name with `!ci-single-me
+-- MinaArtifactAssembledBullseye`.
+--
+-- The artifact list is MinaArtifactBullseye's, less TestExecutive and
+-- FunctionalTestSuite, which produce no image and no package that any image
+-- installs.
+
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.assembledPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , prefix = "MinaArtifactAssembled"
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , scope = [] : List PipelineScope.Type
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )


### PR DESCRIPTION
Part of #19223 (track B, step B2). **Stacked on #19232** — review that one first;
this PR shows only its own commit once #19232 merges.

## What this adds

An opt-in single-agent shape for an artifact build. One step compiles, packages
and builds every image, in that order, on one agent's local disk.

`MinaArtifactBullseye` today moves the same bytes through the CI cache four
ways: the apps job writes the `_build` tree, the packaging job reads it back and
writes the `.deb` set, and then **each of the 8 docker steps reads that deb set
down again**, because every step is its own agent. The assembled shape does none
of that — what one part leaves on disk is what the next part reads.

## Nothing changes for anyone today

All 103 existing pipelines render byte-identical. The new job
`MinaArtifactAssembledBullseye` has `scope = []`, so it is selected by nothing:
not pull request CI, not the nightlies, not release, not even with
`BUILDKITE_PIPELINE_FILTER=Packaging`, which matches its tags exactly (checked
with `list_jobs.sh` in all five scopes). Run it by name:

```
!ci-single-me MinaArtifactAssembledBullseye
```

## The pieces

- **`Docker.buildTier`** (`Constants/Docker/Package.dhall`) — how deep an image
  sits in the FROM chain. Commands in one step run in the order they are listed,
  so the order that `depends_on` carries in the fan-out has to be produced
  explicitly here. Tier 0 is built from `.deb` files alone; tier 1 is FROM a
  tier-0 image (the configured and profiled daemons, the configured rosetta);
  tier 2 is FROM a tier-1 image (the auto-hardfork daemon).
- **`DebianInstallMode.FromLocalBuild`** (`Command/DockerImage.dhall`) — a third
  answer to "where do the .deb files come from". `NoInstall` is for images that
  install none; `DownloadOnly` reads the packaging job's debs out of the CI
  cache; `FromLocalBuild` takes them off this agent's disk.
- **`buildkite/scripts/debian/stage_local_debs.sh`** — copies `_build/*.deb`
  into the docker build context. Lifted out of `build-from-local-debs.sh`, which
  already did exactly this and now calls the script instead, so the two paths
  cannot drift.
- **`DockerImage.releaseCommand`** — what building one image runs, with no
  buildkite step around it. `generateStep` is now that command plus the step.
- **`MinaArtifact.assembledPipeline`** — one job, one step, `Size.XLarge` (the
  dedicated `generic` queue, not the shared `generic_multi` one).

## Order the assembled step builds in

Checked against the rendered YAML. It is the same 8 images the fan-out builds,
and every image comes after the images it is FROM:

```
mina-daemon (generic)  ->  mina-daemon-configured  ->  mina-daemon-auto-hardfork
mina-archive               mina-daemon-profiled (lightnet, devnet)
mina-rosetta (generic) ->  mina-rosetta-configured
```

## Known limits, held on purpose

- **The spec has to be self-contained.** There is no `depends_on` to pull a
  missing image in from another job, so an artifact list holding `Daemon` or
  `DaemonProfiled` must hold `DaemonGeneric` too. Documented on
  `assembledPipeline`. This is why the mainnet job cannot simply be assembled as
  it stands: its daemon-configured image depends on the **devnet** job's generic
  daemon.
- **No retry on the step.** A retry would redo the compile, so the per-image
  retry granularity of the fan-out is genuinely lost. That is one half of the
  trade the epic records; it is why this is opt-in and why B3 picks the shape.
- **Disk.** Every image build still runs the same forced prune
  (`DISK_PRUNE_THRESHOLD=0 disk-cleanup.sh`) it runs in the fan-out, now eight
  times in one step rather than once per agent.

## Gates

- render diff of all 103 existing jobs: **empty**
- `make all` in `buildkite/` (syntax, lint, format, deps, dirty-when, dups,
  names, 45 monorepo tests)
- `list_jobs.sh` in all five scopes: the new job is never selected; the 9
  fan-out artifact jobs still are
- `shellcheck` clean on both shell scripts

No changelog entry: buildkite-only change.
