### PR TITLE
Verify a release commit is tagged, as its own job

### DIFF
--- a/buildkite/src/Jobs/Release/ReleaseCommit.dhall
+++ b/buildkite/src/Jobs/Release/ReleaseCommit.dhall
@@ -1,0 +1,53 @@
+-- Refuse to release a commit that is not tagged.
+--
+-- A release version is read from the repository, never asserted. The check
+-- is a job of its own, and scoped to Release, for three reasons:
+--
+--  * It fails in seconds. Discovering an untagged commit inside a packaging
+--    job means discovering it forty minutes in, after the apps build.
+--  * The policy is declared here rather than carried in an environment
+--    variable that every job would have to be given. A pipeline either runs
+--    this job or it does not.
+--  * scripts/export-git-env-vars.sh stays a script about git facts and the
+--    version derived from them. Enforcement lives with the pipeline that
+--    wants it.
+--
+-- dirtyWhen is deliberately `everything`: this is not a reaction to a change
+-- in some file, it is a precondition of the pipeline it belongs to. Scope
+-- keeps it out of every other pipeline.
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Size = ../../Command/Size.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen = [ S.everything ]
+        , path = "Release"
+        , name = "ReleaseCommit"
+        , scope = [ PipelineScope.Type.Release ]
+        , tags = [ PipelineTag.Type.Fast, PipelineTag.Type.Release ]
+        }
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands = [ Cmd.run "./scripts/verify/release-commit.sh" ]
+            , label = "Release: verify the commit is tagged"
+            , key = "verify-release-commit"
+            , target = Size.Small
+            }
+        ]
+      }

--- a/scripts/verify/release-commit.sh
+++ b/scripts/verify/release-commit.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# Refuse to release a commit that is not tagged.
+#
+# The version a build stamps comes from find_most_recent_numeric_tag in
+# scripts/export-git-env-vars.sh, which walks BACKWARDS until it finds a
+# numeric tag. Every commit therefore gets a version, derived from the release
+# it follows. That is correct for pull-request and nightly builds.
+#
+# For a release build it is a trap. Building an untagged commit does not fail:
+# it quietly reuses the PREVIOUS release's tag and produces, say,
+# 4.0.0-<a-different-hash> — a package that claims a release it is not. With
+# SKIP_GITBRANCH=1 there is not even a branch segment left to tell the two
+# apart.
+#
+# So a pipeline that publishes runs this first, as its own step, and stops
+# there instead of discovering the problem forty minutes later inside
+# packaging — or not discovering it at all.
+#
+# This is a check, not a source of values. It sets nothing and exports
+# nothing; export-git-env-vars.sh stays a script about git facts and the
+# version derived from them.
+
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+# Sourced for GITTAG / GITHASH / GITHASH_CONFIG, so the tag logic and the
+# `git fetch --tags` it performs live in exactly one place. Nothing here
+# recomputes them.
+# shellcheck disable=SC1090,SC1091
+source "${SCRIPTPATH}/../export-git-env-vars.sh"
+
+if [[ -n "${OVERRIDE_TAG:-}" ]]; then
+    echo -e "${RED}❌ ERROR: OVERRIDE_TAG is set (${OVERRIDE_TAG}).${CLEAR}" >&2
+    echo "" >&2
+    echo "    A release version is read from the repository, never asserted." >&2
+    echo "    OVERRIDE_TAG makes the package version independent of what is" >&2
+    echo "    actually tagged, which is the exact confusion this check exists" >&2
+    echo "    to prevent. Tag the commit instead." >&2
+    exit 1
+fi
+
+# `git tag --points-at HEAD` must run AFTER export-git-env-vars.sh, not
+# before: find_most_recent_numeric_tag is what performs `git fetch --tags`,
+# and on a fresh CI clone a read before it sees no tags at all and would
+# reject a properly tagged commit.
+HEAD_TAGS=$(git tag --points-at HEAD)
+
+if [[ -z "${HEAD_TAGS}" ]]; then
+    echo -e "${RED}❌ ERROR: HEAD (${GITHASH_CONFIG}) carries no git tag.${CLEAR}" >&2
+    echo "" >&2
+    echo "    This pipeline publishes, so the version must come from a tag on" >&2
+    echo "    the commit being built. Without one the version falls back to the" >&2
+    echo "    most recent tag reachable from HEAD (${GITTAG}), producing" >&2
+    echo "    ${GITTAG}-${GITHASH}: a package that claims a release it is not." >&2
+    echo "" >&2
+    echo "    Tag the commit you mean to release, then build that commit." >&2
+    echo "    Use an ANNOTATED tag: find_most_recent_numeric_tag calls" >&2
+    echo "    git describe without --tags, so a lightweight tag is invisible to" >&2
+    echo "    the version derivation even though git tag --points-at sees it." >&2
+    echo "" >&2
+    echo "        git tag -a <version> -m <version> ${GITHASH_CONFIG}" >&2
+    echo "        git push origin <version>" >&2
+    exit 1
+fi
+
+# An annotated tag is a tag object; a lightweight tag points straight at the
+# commit. Only the first is visible to the version derivation, so a HEAD
+# carrying only lightweight tags would pass the check above and still be
+# versioned from an older release.
+ANNOTATED=""
+while IFS= read -r tag; do
+    [[ -z "$tag" ]] && continue
+    if [[ "$(git cat-file -t "$tag" 2>/dev/null)" == "tag" ]]; then
+        ANNOTATED="${ANNOTATED:+${ANNOTATED} }${tag}"
+    fi
+done <<< "${HEAD_TAGS}"
+
+if [[ -z "${ANNOTATED}" ]]; then
+    echo -e "${RED}❌ ERROR: HEAD is tagged, but only with lightweight tags.${CLEAR}" >&2
+    echo "" >&2
+    echo "    Tags on HEAD: ${HEAD_TAGS//$'\n'/ }" >&2
+    echo "    find_most_recent_numeric_tag calls git describe without --tags," >&2
+    echo "    so none of these are visible to the version derivation and the" >&2
+    echo "    build would still be versioned ${GITTAG}-${GITHASH}." >&2
+    echo "" >&2
+    echo "        git tag -a <version> -m <version> ${GITHASH_CONFIG}" >&2
+    exit 1
+fi
+
+# The version derivation must actually have chosen a tag from HEAD. If GITTAG
+# is some older tag, the two checks above passed and the build would still be
+# mislabelled — for example when HEAD's only annotated tag is non-numeric and
+# find_most_recent_numeric_tag walked past it.
+if [[ " ${ANNOTATED} " != *" ${GITTAG} "* ]]; then
+    echo -e "${RED}❌ ERROR: the version would not come from HEAD's tag.${CLEAR}" >&2
+    echo "" >&2
+    echo "    Annotated tags on HEAD: ${ANNOTATED}" >&2
+    echo "    Tag the version derivation chose: ${GITTAG}" >&2
+    echo "" >&2
+    echo "    find_most_recent_numeric_tag only accepts a tag that starts with" >&2
+    echo "    a digit, and walks backwards past any that does not. The build" >&2
+    echo "    would be versioned ${GITTAG}-${GITHASH}." >&2
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Release commit check passed${CLEAR}"
+echo "    Commit:  ${GITHASH_CONFIG}"
+echo "    Tag:     ${GITTAG}"
+echo "    Version: ${MINA_DEB_VERSION}"


### PR DESCRIPTION
Groundwork for publishing straight from a build instead of promoting afterwards. Two files added, **nothing modified**.

### The problem

`find_most_recent_numeric_tag` in `scripts/export-git-env-vars.sh` walks **backwards** until it finds a numeric tag. Every commit therefore gets a version, derived from the release it follows. That is correct for pull-request and nightly builds.

For a release build it is a trap. Building an untagged commit does not fail — it quietly reuses the **previous** release's tag and produces `4.0.0-<a-different-hash>`: a package that claims a release it is not. With `SKIP_GITBRANCH=1` there is not even a branch segment left to tell the two apart.

### Why a job and not an environment variable

I first wrote this as `REQUIRE_GIT_TAG=1` read inside `export-git-env-vars.sh`. That was wrong on three counts:

- **It fails late.** Inside a packaging job means forty minutes in, after the apps build. As its own job it fails in seconds.
- **The policy belongs in the pipeline.** A pipeline either runs this job or it does not — no flag to thread through `overrideEnvs` and trust that every job received it.
- **`export-git-env-vars.sh` already does too much.** It reaches beyond its name by deriving `MINA_DEB_VERSION` / `MINA_DOCKER_TAG` (versioning policy, not git facts) and by passing `MINA_DEB_CODENAME` through without computing it. Enforcement did not belong there too.

So it is `scripts/verify/release-commit.sh` plus `Jobs/Release/ReleaseCommit.dhall`, scoped to `Release` so no other pipeline sees it.

### What it rejects

Standing alone let it check more than the flag version could. Four ways a release can be mislabelled:

| Case | Why it is rejected |
| --- | --- |
| HEAD carries no tag | Version silently falls back to the previous release's tag |
| HEAD carries only **lightweight** tags | `git describe` is called without `--tags`, so they are invisible to the version derivation even though `git tag --points-at` reports them |
| HEAD's annotated tags exist, but none is the one the derivation chose | Happens when they are non-numeric and it walked past them |
| `OVERRIDE_TAG` is set at all | Makes the version independent of what is tagged — the exact confusion this check exists to prevent |

It **sources** `export-git-env-vars.sh` rather than repeating any of it, so the tag logic and the `git fetch --tags` it performs stay in one place. The tag is read *after* that source, not before: the fetch is what makes tags visible, and a read before it sees none on a fresh CI clone and would reject a properly tagged commit.

### Verification

All five cases (four rejections plus the passing one) exercised against a throwaway repository. `make all` passes in `buildkite/` — 18 tests, 48 assertions. `shellcheck` clean. The job renders.

```
✅ Release commit check passed
    Commit:  ca3282b0
    Tag:     4.1.0
    Version: 4.1.0-ca3282b
```

### Found, not fixed

`find_most_recent_numeric_tag` can **recurse forever**: when no numeric tag is reachable, `git describe --always` returns a bare hash, which is not numeric, so it recurses on `<hash>~`, then on `~`, endlessly — the process hangs rather than fails. Hit while building the test fixtures. A proper fix needs a decision about what should happen when there is no numeric tag, so it is left alone here and deserves its own issue.