### PR TITLE
Derive transaction pool vk refcounts from pool membership

### DIFF
--- a/changes/19243.md
+++ b/changes/19243.md
@@ -1,0 +1,18 @@
+Fix verification-key refcount leaks in the transaction pool on the commit path
+
+Building on the frontier-recreation fix in #19162, the remaining paths that
+leaked verification-key refcounts are now closed. A node that produced or
+received blocks containing zkApp commands retained table entries and their
+on-disk verification-key cache handles until it restarted, which grew both
+memory and the number of on-disk reads done while verifying incoming
+transactions. The largest of these fired on every block carrying a
+verification-key-setting zkApp command; the others fired on chain reorgs.
+
+Refcounts are now derived from what the pool actually holds, rather than
+adjusted by hand at each site that changes it. A new
+`Coda_Transaction_pool_vk_refcount_leaks_detected` counter reports if the table
+is ever found holding keys while the pool is empty, which is what a leak of this
+kind looks like on a running node.
+
+Also fixes a log line that reported dropping locally generated commands when
+the transition frontier was recreated but listed none of them.

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -143,6 +143,8 @@ module Transaction_pool : sig
 
   val vk_refcount_table_size : Gauge.t
 
+  val vk_refcount_leaks_detected : Counter.t
+
   val zkapp_transactions_added_to_pool : Counter.t
 
   val zkapp_transaction_size : Counter.t

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -126,6 +126,8 @@ module Transaction_pool = struct
 
   let vk_refcount_table_size : Gauge.t = ()
 
+  let vk_refcount_leaks_detected : Counter.t = ()
+
   let zkapp_transactions_added_to_pool : Counter.t = ()
 
   let zkapp_transaction_size : Counter.t = ()

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -474,6 +474,13 @@ module Transaction_pool = struct
     let help = "Size of verification key refcount table" in
     Gauge.v "vk_refcount_table_size" ~help ~namespace ~subsystem
 
+  let vk_refcount_leaks_detected : Counter.t =
+    let help =
+      "Number of times the verification key refcount table was found holding \
+       keys while the transaction pool was empty"
+    in
+    Counter.v "vk_refcount_leaks_detected" ~help ~namespace ~subsystem
+
   let zkapp_transactions_added_to_pool : Counter.t =
     let help =
       "Number of zkapp transactions added to the pool since the node start"

--- a/src/lib/network_pool/f_sequence.ml
+++ b/src/lib/network_pool/f_sequence.ml
@@ -596,19 +596,15 @@ let iter = C.iter
 
 let find = C.find
 
+(* Stops at the match. [C.fold_until] escapes the underlying fold with an
+   exception, so this costs the index it returns rather than the length of the
+   sequence -- the previous version kept folding after finding, and every
+   caller in [indexed_pool] is looking for a nonce at or near the head of a
+   sender's queue. *)
 let findi t ~f =
-  match
-    C.fold t ~init:(`Not_found 0) ~f:(fun acc x ->
-        match acc with
-        | `Not_found i ->
-            if f x then `Found i else `Not_found (i + 1)
-        | `Found i ->
-            `Found i )
-  with
-  | `Not_found _ ->
-      None
-  | `Found i ->
-      Some i
+  C.fold_until t ~init:0
+    ~f:(fun i x -> if f x then Stop (Some i) else Continue (i + 1))
+    ~finish:(fun _ -> None)
 
 let to_seq : 'e t -> 'e Sequence.t = fun t -> Sequence.unfold ~init:t ~f:uncons
 
@@ -780,6 +776,18 @@ let%test_unit "list isomorphism - snoc" =
       assert_measure (Fn.const 1) xs_fseq ;
       [%test_eq: int list] xs (to_list xs_fseq) ;
       [%test_eq: int] (List.length xs) (length xs_fseq) )
+
+let%test_unit "findi matches the list implementation" =
+  Quickcheck.test
+    Quickcheck.Generator.(
+      tuple2 (big_list (Int.gen_incl 0 20)) (Int.gen_incl 0 20))
+    ~f:(fun (xs, target) ->
+      let xs_fseq = List.fold_left xs ~init:empty ~f:snoc in
+      (* Pins that the *first* match is returned, which is what the callers in
+         indexed_pool rely on and what short-circuiting must not change. *)
+      [%test_eq: int option]
+        (List.findi xs ~f:(fun _ x -> x = target) |> Option.map ~f:fst)
+        (findi xs_fseq ~f:(fun x -> x = target)) )
 
 let%test_unit "alternating cons/snoc" =
   Quickcheck.test

--- a/src/lib/network_pool/f_sequence.ml
+++ b/src/lib/network_pool/f_sequence.ml
@@ -1,762 +1,79 @@
+(** A sequence type backed by [Core.Fdeque].
+
+    The pool needs deque operations on a sender's queued transactions, plus the
+    ability to drop everything after a given index when a transaction is
+    replaced or revalidated away. [Fdeque] provides the ends; [split_at] is
+    built from it and costs the index it is given, which is small in practice
+    because every caller splits where a nonce scan just matched.
+
+    Note the caveat [Fdeque] documents: its amortized bounds assume the deque
+    is threaded sequentially through calls. Sender queues are used that way --
+    each version derives from the previous one -- but a caller that repeatedly
+    dequeued from the same retained version would see the worst case. *)
 open Core
 
-(** A digit is a container of 1-4 elements. *)
-module Digit = struct
-  (* We use GADTs to track whether it's valid to remove/add an element to a
-     digit, which gets us type safe (un)cons and (un)snoc. *)
+type 'e t = 'e Fdeque.t
 
-  [@@@warning "-37"]
+(* Structural, over the elements in order: two deques holding the same sequence
+   must compare equal whatever their internal split. *)
+let compare cmp_e x y = List.compare cmp_e (Fdeque.to_list x) (Fdeque.to_list y)
 
-  type addable = Type_addable
+let equal eq_e x y = List.equal eq_e (Fdeque.to_list x) (Fdeque.to_list y)
 
-  type not_addable = Type_not_addable
+let sexp_of_t sexp_e t = List.sexp_of_t sexp_e (Fdeque.to_list t)
 
-  type removable = Type_removable
+let is_empty = Fdeque.is_empty
 
-  type not_removable = Type_not_removable
+let length = Fdeque.length
 
-  [@@@warning "+37"]
+let head_exn = Fdeque.peek_front_exn
 
-  type (_, _, 'e) t =
-    | One : 'e -> (addable, not_removable, 'e) t
-    | Two : 'e * 'e -> (addable, removable, 'e) t
-    | Three : 'e * 'e * 'e -> (addable, removable, 'e) t
-    | Four : 'e * 'e * 'e * 'e -> (not_addable, removable, 'e) t
+let last_exn = Fdeque.peek_back_exn
 
-  (* Can't derive compare on GADTs, instead we provide an explicit instance. *)
-  let compare (type add_x rem_x add_y rem_y) cmp_e (x : (add_x, rem_x, 'e) t)
-      (y : (add_y, rem_y, 'e) t) =
-    let fallthrough ~f = function 0 -> f () | n -> n in
-    match (x, y) with
-    | One x, One y ->
-        cmp_e x y
-    | One _, _ ->
-        -1
-    | _, One _ ->
-        1
-    | Two (x1, x2), Two (y1, y2) ->
-        fallthrough (cmp_e x1 y1) ~f:(fun () -> cmp_e x2 y2)
-    | Two _, _ ->
-        -1
-    | _, Two _ ->
-        1
-    | Three (x1, x2, x3), Three (y1, y2, y3) ->
-        fallthrough (cmp_e x1 y1) ~f:(fun () ->
-            fallthrough (cmp_e x2 y2) ~f:(fun () -> cmp_e x3 y3) )
-    | Three _, _ ->
-        -1
-    | _, Three _ ->
-        1
-    | Four (x1, x2, x3, x4), Four (y1, y2, y3, y4) ->
-        fallthrough (cmp_e x1 y1) ~f:(fun () ->
-            fallthrough (cmp_e x2 y2) ~f:(fun () ->
-                fallthrough (cmp_e x3 y3) ~f:(fun () -> cmp_e x4 y4) ) )
-    | Four _, _ ->
-        .
-    | _, Four _ ->
-        .
+let uncons = Fdeque.dequeue_front
 
-  (* "Eliminators" dispatching on addability/removability. You could achieve
-      the same effect more directly using or-patterns, but the code that
-      makes the typechecker understand existentials under or-patterns isn't
-      in our compiler version. (ocaml/ocaml#2110)
-  *)
-  let addable_elim : type a r.
-         ((addable, r, 'e) t -> 'o) (** Function handling addable case *)
-      -> ((not_addable, removable, 'e) t -> 'o)
-         (** Function handling non-addable case *)
-      -> (a, r, 'e) t
-      -> 'o =
-   fun f g t ->
-    match t with One _ -> f t | Two _ -> f t | Three _ -> f t | Four _ -> g t
+let unsnoc t =
+  Fdeque.dequeue_back t |> Option.map ~f:(fun (last, rest) -> (rest, last))
 
-  let removable_elim : type a r.
-         ((a, removable, 'e) t -> 'o) (** Function handling removable case*)
-      -> ((addable, not_removable, 'e) t -> 'o)
-         (** Function handling non-removable case *)
-      -> (a, r, 'e) t
-      -> 'o =
-   fun f g t ->
-    match t with One _ -> g t | Two _ -> f t | Three _ -> f t | Four _ -> f t
+let foldl f init t = Fdeque.fold t ~init ~f
 
-  (** Existential type for when addability is determined at runtime. *)
-  type ('r, 'e) t_any_a = Mk_any_a : ('a, 'r, 'e) t -> ('r, 'e) t_any_a
+let foldr f init t = List.fold_right (Fdeque.to_list t) ~init ~f
 
-  (** Same for removability. *)
-  type ('a, 'e) t_any_r = Mk_any_r : ('a, 'r, 'e) t -> ('a, 'e) t_any_r
-
-  (** Both. *)
-  type 'e t_any_ar = Mk_any_ar : ('a, 'r, 'e) t -> 'e t_any_ar
-
-  (** "Broaden" a t_any_a into a t_any_ar, i.e. forget that we know the
-      removability status. *)
-  let broaden_any_a : ('r, 'e) t_any_a -> 'e t_any_ar =
-   fun (Mk_any_a t) -> Mk_any_ar t
-
-  (** Same deal for t_any_r *)
-  let broaden_any_r : ('a, 'e) t_any_r -> 'e t_any_ar =
-   fun (Mk_any_r t) -> Mk_any_ar t
-
-  let cons : type r. 'e -> (addable, r, 'e) t -> (removable, 'e) t_any_a =
-   fun v d ->
-    match d with
-    | One a ->
-        Mk_any_a (Two (v, a))
-    | Two (a, b) ->
-        Mk_any_a (Three (v, a, b))
-    | Three (a, b, c) ->
-        Mk_any_a (Four (v, a, b, c))
-
-  let snoc : type r. (addable, r, 'e) t -> 'e -> (removable, 'e) t_any_a =
-   fun d v ->
-    match d with
-    | One a ->
-        Mk_any_a (Two (a, v))
-    | Two (a, b) ->
-        Mk_any_a (Three (a, b, v))
-    | Three (a, b, c) ->
-        Mk_any_a (Four (a, b, c, v))
-
-  let uncons : type a. (a, removable, 'e) t -> 'e * (addable, 'e) t_any_r =
-    function
-    | Two (a, b) ->
-        (a, Mk_any_r (One b))
-    | Three (a, b, c) ->
-        (a, Mk_any_r (Two (b, c)))
-    | Four (a, b, c, d) ->
-        (a, Mk_any_r (Three (b, c, d)))
-
-  let unsnoc : type a. (a, removable, 'e) t -> (addable, 'e) t_any_r * 'e =
-    function
-    | Two (a, b) ->
-        (Mk_any_r (One a), b)
-    | Three (a, b, c) ->
-        (Mk_any_r (Two (a, b)), c)
-    | Four (a, b, c, d) ->
-        (Mk_any_r (Three (a, b, c)), d)
-
-  let foldr : type a r. ('e -> 'acc -> 'acc) -> 'acc -> (a, r, 'e) t -> 'acc =
-   fun f z d ->
-    match d with
-    | One a ->
-        f a z
-    | Two (a, b) ->
-        f a (f b z)
-    | Three (a, b, c) ->
-        f a (f b (f c z))
-    | Four (a, b, c, d) ->
-        f a (f b (f c (f d z)))
-
-  let foldl : type a r. ('acc -> 'e -> 'acc) -> 'acc -> (a, r, 'e) t -> 'acc =
-   fun f z d ->
-    match d with
-    | One a ->
-        f z a
-    | Two (a, b) ->
-        f (f z a) b
-    | Three (a, b, c) ->
-        f (f (f z a) b) c
-    | Four (a, b, c, d) ->
-        f (f (f (f z a) b) c) d
-
-  let to_list : type a r. (a, r, 'e) t -> 'e list =
-   fun t -> foldr List.cons [] t
-
-  let gen_any_ar : int t_any_ar Quickcheck.Generator.t =
-    let open Quickcheck.Generator.Let_syntax in
-    let gen_measure = Int.gen_incl 1 20 in
-    let%bind a, b, c, d =
-      Quickcheck.Generator.tuple4 gen_measure gen_measure gen_measure
-        gen_measure
-    in
-    Quickcheck.Generator.of_list
-      [ Mk_any_ar (One a)
-      ; Mk_any_ar (Two (a, b))
-      ; Mk_any_ar (Three (a, b, c))
-      ; Mk_any_ar (Four (a, b, c, d))
-      ]
-
-  (** Given a measurement function, compute the total measure of a digit.
-      See below for an explanation of what measure is.
-  *)
-  let measure : ('e -> int) -> (_, _, 'e) t -> int =
-   fun measure' -> foldl (fun m e -> m + measure' e) 0
-
-  (** Split a digit by measure. Again see below. *)
-  let split : type a r.
-         ('e -> int)
-      -> int
-      -> int
-      -> (a, r, 'e) t
-      -> 'e t_any_ar option * 'e * 'e t_any_ar option =
-   fun measure' target acc t ->
-    (* Addable inputs go to addable outputs, but non-addable inputs may go to
-       either. We use a separate function for addables to represent this and
-       minimizing the amount of Obj.magicking we need to do. *)
-    let rec split_addable : type r.
-           int
-        -> (addable, r, 'e) t
-        -> (addable, 'e) t_any_r option * 'e * (addable, 'e) t_any_r option =
-     fun acc t ->
-      removable_elim
-        (fun t' ->
-          let head, Mk_any_r tail = uncons t' in
-          if acc + measure' head >= target then
-            (None, head, Some (Mk_any_r tail))
-          else
-            match split_addable (acc + measure' head) tail with
-            | Some (Mk_any_r lhs), m, rhs ->
-                let (Mk_any_a cons_res) = cons head lhs in
-                (* t' is addable, so the tail of t' is twice-addable. We just
-                   passed that tail to split_addable, which always returns
-                   digits with <= the number of elements of the input. So
-                   cons_res is addable but it's not possible to convince the
-                   typechecker of that, as far as I can tell.
-                *)
-                let cons_res' : (addable, removable, 'e) t =
-                  Obj.magic cons_res
-                in
-                (Some (Mk_any_r cons_res'), m, rhs)
-            | None, m, rhs ->
-                (Some (Mk_any_r (One head)), m, rhs) )
-        (fun (One a) ->
-          if acc + measure' a >= target then (None, a, None)
-          else failwith "Digit.split index out of bounds" )
-        t
-    in
-    addable_elim
-      (fun t' ->
-        let lhs, m, rhs = split_addable acc t' in
-        (Option.map ~f:broaden_any_r lhs, m, Option.map ~f:broaden_any_r rhs) )
-      (fun t' ->
-        let head, Mk_any_r tail = uncons t' in
-        if acc + measure' head >= target then (None, head, Some (Mk_any_ar tail))
-        else
-          let lhs, m, rhs = split_addable (acc + measure' head) tail in
-          match lhs with
-          | None ->
-              (Some (Mk_any_ar (One head)), m, Option.map ~f:broaden_any_r rhs)
-          | Some (Mk_any_r lhs') ->
-              ( Some (broaden_any_a (cons head lhs'))
-              , m
-              , Option.map ~f:broaden_any_r rhs ) )
-      t
-
-  let opt_to_list : 'a t_any_ar option -> 'a list = function
-    | None ->
-        []
-    | Some (Mk_any_ar dig) ->
-        to_list dig
-
-  let%test_unit "Digit.split preserves contents and order" =
-    Quickcheck.test
-      (let open Quickcheck.Generator.Let_syntax in
-       let%bind (Mk_any_ar dig as dig') = gen_any_ar in
-       let%bind idx = Int.gen_incl 1 (List.length @@ to_list dig) in
-       return (dig', idx) )
-      ~f:(fun (Mk_any_ar dig, target) ->
-        let lhs_opt, m, rhs_opt = split Fn.id target 0 dig in
-        let lhs', rhs' = (opt_to_list lhs_opt, opt_to_list rhs_opt) in
-        [%test_eq: int list] (lhs' @ [ m ] @ rhs') (to_list dig) )
-
-  let%test_unit "Digit.split matches list implementation" =
-    Quickcheck.test
-      ~sexp_of:(fun (Mk_any_ar dig, idx) ->
-        Tuple2.sexp_of_t
-          (List.sexp_of_t Int.sexp_of_t)
-          Int.sexp_of_t
-          (to_list dig, idx) )
-      (let open Quickcheck.Generator.Let_syntax in
-       let%bind (Mk_any_ar dig) = gen_any_ar in
-       let%bind idx = Int.gen_incl 1 (List.length @@ to_list dig) in
-       return (Mk_any_ar dig, idx) )
-      ~f:(fun (Mk_any_ar dig, idx) ->
-        let as_list = to_list dig in
-        let lhs_list = List.take as_list (idx - 1) in
-        let m_list = List.nth_exn as_list (idx - 1) in
-        let rhs_list = List.drop as_list idx in
-        [%test_eq: int list] (lhs_list @ (m_list :: rhs_list)) as_list ;
-        let lhs_fseq, m_fseq, rhs_fseq = split (Fn.const 1) idx 0 dig in
-        let lhs_fseq', rhs_fseq' =
-          (opt_to_list lhs_fseq, opt_to_list rhs_fseq)
-        in
-        [%test_eq: int list] (lhs_fseq' @ (m_fseq :: rhs_fseq')) (to_list dig) ;
-        [%test_eq: int list] lhs_list lhs_fseq' ;
-        [%test_eq: int] m_list m_fseq ;
-        [%test_eq: int list] rhs_list rhs_fseq' ;
-        [%test_eq: int] (List.length lhs_fseq') (idx - 1) ;
-        [%test_eq: int] (List.length rhs_fseq') (List.length as_list - idx) )
-
-  (* See comment below about measures for why index 0 is an edge case. *)
-  let%test_unit "Digit.split with index 0 is trivial" =
-    Quickcheck.test
-      (Quickcheck.Generator.tuple2 gen_any_ar (Int.gen_incl 0 200))
-      ~f:(fun (Mk_any_ar dig, acc) ->
-        let as_list = to_list dig in
-        let lhs, m, rhs = split Fn.id acc acc dig in
-        assert (Option.is_none lhs) ;
-        [%test_eq: int] m (List.hd_exn as_list) ;
-        match rhs with
-        | None ->
-            [%test_eq: int list] [] (List.tl_exn as_list)
-        | Some (Mk_any_ar rhs') ->
-            [%test_eq: int list] (to_list rhs') (List.tl_exn as_list) )
-
-  let%test _ =
-    match split Fn.id 1 0 (One 1) with None, 1, None -> true | _ -> false
-
-  let%test _ =
-    match split Fn.id 5 0 (Three (0, 2, 4)) with
-    | Some (Mk_any_ar (Two (0, 2))), 4, None ->
-        true
-    | _ ->
-        false
-
-  let%test _ =
-    match split Fn.id 10 0 (Four (2, 3, 5, 1)) with
-    | Some (Mk_any_ar (Two (2, 3))), 5, Some (Mk_any_ar (One 1)) ->
-        true
-    | _ ->
-        false
-
-  let%test _ =
-    match split Fn.id 7 0 (Four (2, 4, 3, 2)) with
-    | Some (Mk_any_ar (Two (2, 4))), 3, Some (Mk_any_ar (One 2)) ->
-        true
-    | _ ->
-        false
-end
-
-(** Nodes containing 2-3 elements, with a cached measurement. *)
-module Node = struct
-  (** This implementation doesn't actually use 2-nodes, but they're here for
-      future use. The paper uses them in the append operation, which isn't
-      implemented here.
-  *)
-  type 'e t = Two of int * 'e * 'e | Three of int * 'e * 'e * 'e
-  [@@deriving equal, compare]
-
-  (** Extract the cached measurement *)
-  let measure : 'e t -> int =
-   fun t -> match t with Two (m, _, _) -> m | Three (m, _, _, _) -> m
-
-  let to_digit : 'e t -> (Digit.addable, Digit.removable, 'e) Digit.t = function
-    | Two (_m, a, b) ->
-        Digit.Two (a, b)
-    | Three (_m, a, b, c) ->
-        Digit.Three (a, b, c)
-
-  (* smart constructors to maintain correct measures *)
-  let _mk_2 : ('e -> int) -> 'e -> 'e -> 'e t =
-   fun f a b -> Two (f a + f b, a, b)
-
-  let mk_3 : ('e -> int) -> 'e -> 'e -> 'e -> 'e t =
-   fun f a b c -> Three (f a + f b + f c, a, b, c)
-
-  let split_to_digits :
-         ('e -> int)
-      -> int
-      -> int
-      -> 'e t
-      -> 'e Digit.t_any_ar option * 'e * 'e Digit.t_any_ar option =
-   fun measure' target acc t -> to_digit t |> Digit.split measure' target acc
-end
-
-(** Finally, the actual finger tree type! *)
-type 'e t =
-  | Empty : 'e t  (** Empty tree *)
-  | Single : 'e -> 'e t  (** Single element tree *)
-  | Deep :
-      ( int
-      * ('aL, 'rL, 'e) Digit.t
-      * 'e Node.t t Lazy.t
-      * ('aR, 'rR, 'e) Digit.t )
-      -> 'e t
-      (** The recursive case. We have a cached measurement, prefix and suffix
-          fingers, and a subtree. Note the subtree has a different type than its
-          parent. The top level has 'es, the next level has 'e Node.ts, the next
-          has 'e Node.t Node.ts and so on. As you go deeper, the breadth
-          increases exponentially. *)
-
-(* Can't derive compare for GADTs.. *)
-let rec compare : type e. (e -> e -> int) -> e t -> e t -> int =
- fun cmp_e x y ->
-  match (x, y) with
-  | Empty, Empty ->
-      0
-  | Empty, _ ->
-      -1
-  | _, Empty ->
-      1
-  | Single x, Single y ->
-      cmp_e x y
-  | Single _, _ ->
-      -1
-  | _, Single _ ->
-      1
-  | Deep (i, pre_x, mid_x, suff_x), Deep (j, pre_y, mid_y, suff_y) ->
-      let cmp = Int.compare i j in
-      if cmp <> 0 then cmp
-      else
-        let cmp = Digit.compare cmp_e pre_x pre_y in
-        if cmp <> 0 then cmp
-        else
-          let cmp = Lazy.compare (compare (Node.compare cmp_e)) mid_x mid_y in
-          if cmp <> 0 then cmp else Digit.compare cmp_e suff_x suff_y
-  | Deep _, _ ->
-      .
-  | _, Deep _ ->
-      .
-
-(* About measurements: in the paper they define finger trees more generally than
-   this implementation. Given a monoid m, a measurement function for elements
-   e -> m, and "monotonic" predicates on m, if you cache the measure of subtrees
-   you can index into and split finger trees at the transition point of the
-   predicates in log time. The output of any of the split functions is a triple
-   of the longest subsequence starting from the beginning where the predicate is
-   false, the element that flips it to true, and the subsequence after that up
-   to the end. In this implementation the monoid is natural numbers under
-   summation, the measurement is 'Fn.const 1' and the predicates are
-   (fun x -> x >= idx). So the measure of a tree is how many elements are in it
-   and the transition point is where there are >= idx elements. Index 0 is a
-   special case, since forall x : ℕ. x >= 0. In that case the first subsequence
-   is empty, the transition point is the first element, and the second
-   subsequence is the rest of the input sequence.
-
-   You'll see many functions take a parameter measure' to compute measures of
-   elements with. This is always either Node.measure or 'Fn.const 1' depending
-   on if we're at the top level or not.
-
-   Other measurement functions and monoids get you priority queues, search trees
-   and interval trees.
-*)
-let measure : ('e -> int) -> 'e t -> int =
- fun measure' t ->
-  match t with Empty -> 0 | Single a -> measure' a | Deep (m, _, _, _) -> m
-
-(** Smart constructor for deep nodes that tracks measure. *)
-let deep :
-       ('e -> int)
-    -> (_, _, 'e) Digit.t
-    -> 'e Node.t t
-    -> (_, _, 'e) Digit.t
-    -> 'e t =
- fun measure' prefix middle suffix ->
-  Deep
-    ( Digit.measure measure' prefix
-      + measure Node.measure middle
-      + Digit.measure measure' suffix
-    , prefix
-    , lazy middle
-    , suffix )
-
-let empty : 'e t = Empty
-
-(** Add a new element to the left end of the tree. *)
-let rec cons' : 'e. ('e -> int) -> 'e -> 'e t -> 'e t =
- fun measure' v t ->
-  match t with
-  | Empty ->
-      Single v
-  | Single v' ->
-      deep measure' (Digit.One v) Empty (Digit.One v')
-  | Deep (_, prefix, middle, suffix) ->
-      (* If there is space in the left finger, the finger is the only thing that
-         needs to change. If not we need to make a recursive call. A recursive
-         call frees up two finger slots and is needed every third cons
-         operation, so the amortized cost is constant for a two layer tree.
-         Because each level triples the number of elements in the fingers, we
-         free up 2 * 3^level slots per recursive call and need to do so every
-         2 * 3^level conses. So cons is amortized O(1) for arbitrary depth
-         trees.
-      *)
-      Digit.addable_elim
-        (fun prefix' ->
-          let (Mk_any_a prefix'') = Digit.cons v prefix' in
-          deep measure' prefix'' (Lazy.force middle) suffix )
-        (fun (Four (a, b, c, d)) ->
-          deep measure'
-            (Digit.Two (v, a))
-            (cons' Node.measure (Node.mk_3 measure' b c d) @@ Lazy.force middle)
-            suffix )
-        prefix
-
-let cons : 'e -> 'e t -> 'e t = fun x xs -> cons' (Fn.const 1) x xs
-
-(** Add a new element to the right end of the tree. This is a mirror of cons' *)
-let rec snoc' : 'e. ('e -> int) -> 'e t -> 'e -> 'e t =
- fun measure' t v ->
-  match t with
-  | Empty ->
-      Single v
-  | Single v' ->
-      deep measure' (Digit.One v') Empty (Digit.One v)
-  | Deep (_, prefix, middle, suffix) ->
-      Digit.addable_elim
-        (fun digit ->
-          let (Mk_any_a digit') = Digit.snoc digit v in
-          deep measure' prefix (Lazy.force middle) digit' )
-        (fun (Four (a, b, c, d)) ->
-          deep measure' prefix
-            (snoc' Node.measure (Lazy.force middle) @@ Node.mk_3 measure' a b c)
-            (Digit.Two (d, v)) )
-        suffix
-
-let snoc : 'e t -> 'e -> 'e t = fun xs x -> snoc' (Fn.const 1) xs x
-
-(** Create a finger tree from a digit *)
-let tree_of_digit : ('e -> int) -> ('a, 'r, 'e) Digit.t -> 'e t =
- fun measure' dig -> Digit.foldr (cons' measure') Empty dig
-
-(** If the input is non-empty, get the first element and the rest of the
-    sequence. If it is empty, return None. *)
-let rec uncons' : 'e. ('e -> int) -> 'e t -> ('e * 'e t) option =
- fun measure' t ->
-  match t with
-  | Empty ->
-      None
-  | Single e ->
-      Some (e, empty)
-  | Deep (_m, prefix, middle, suffix) ->
-      Digit.removable_elim
-        (fun prefix' ->
-          let head, Mk_any_r prefix_rest = Digit.uncons prefix' in
-          Some (head, deep measure' prefix_rest (force middle) suffix) )
-        (fun (One e) ->
-          match uncons' Node.measure (force middle) with
-          | None ->
-              Some (e, tree_of_digit measure' suffix)
-          | Some (node, rest) ->
-              Some (e, deep measure' (Node.to_digit node) rest suffix) )
-        prefix
-
-(** Uncons for the top level trees. *)
-let uncons : 'e t -> ('e * 'e t) option = fun t -> uncons' (Fn.const 1) t
-
-(** Mirror of uncons' for the last element. *)
-let rec unsnoc' : 'e. ('e -> int) -> 'e t -> ('e t * 'e) option =
- fun measure' t ->
-  match t with
-  | Empty ->
-      None
-  | Single e ->
-      Some (empty, e)
-  | Deep (_m, prefix, middle, suffix) ->
-      Digit.removable_elim
-        (fun suffix' ->
-          let Mk_any_r liat, deah = Digit.unsnoc suffix' in
-          Some (deep measure' prefix (force middle) liat, deah) )
-        (fun (One e) ->
-          match unsnoc' Node.measure (force middle) with
-          | None ->
-              Some (tree_of_digit measure' prefix, e)
-          | Some (rest, node) ->
-              Some (deep measure' prefix rest (Node.to_digit node), e) )
-        suffix
-
-(** Mirror of uncons. *)
-let unsnoc : 'e t -> ('e t * 'e) option = fun t -> unsnoc' (Fn.const 1) t
-
-let head_exn : 'e t -> 'e = fun t -> Option.value_exn (uncons t) |> Tuple2.get1
-
-let last_exn : 'e t -> 'e = fun t -> unsnoc t |> Option.value_exn |> Tuple2.get2
-
-let rec foldl : ('a -> 'e -> 'a) -> 'a -> 'e t -> 'a =
- fun f acc t ->
-  match uncons t with
-  | None ->
-      acc
-  | Some (head, tail) ->
-      foldl f (f acc head) tail
-
-let rec foldr : ('e -> 'a -> 'a) -> 'a -> 'e t -> 'a =
- fun f acc t ->
-  match uncons t with
-  | None ->
-      acc
-  | Some (head, tail) ->
-      f head (foldr f acc tail)
-
-module C = Container.Make (struct
-  type nonrec 'a t = 'a t
-
-  let fold : 'a t -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum =
-   fun t ~init ~f -> foldl f init t
-
-  let iter = `Define_using_fold
-
-  let length = `Custom (fun t -> measure (Fn.const 1) t)
-end)
-
-let is_empty = C.is_empty
-
-let length = C.length
-
-let iter = C.iter
-
-let find = C.find
-
-(* Stops at the match. [C.fold_until] escapes the underlying fold with an
-   exception, so this costs the index it returns rather than the length of the
-   sequence -- the previous version kept folding after finding, and every
-   caller in [indexed_pool] is looking for a nonce at or near the head of a
-   sender's queue. *)
 let findi t ~f =
-  C.fold_until t ~init:0
+  Fdeque.fold_until t ~init:0
     ~f:(fun i x -> if f x then Stop (Some i) else Continue (i + 1))
     ~finish:(fun _ -> None)
 
-let to_seq : 'e t -> 'e Sequence.t = fun t -> Sequence.unfold ~init:t ~f:uncons
+let iter t ~f = Fdeque.iter t ~f
 
-let sexp_of_t : ('e -> Sexp.t) -> 'e t -> Sexp.t =
- fun sexp_inner -> Fn.compose (Sequence.sexp_of_t sexp_inner) to_seq
+let to_list = Fdeque.to_list
 
-let rec equal : ('e -> 'e -> bool) -> 'e t -> 'e t -> bool =
- fun eq_inner xs ys ->
-  match (uncons xs, uncons ys) with
-  | Some (x, xs_tail), Some (y, ys_tail) ->
-      eq_inner x y && equal eq_inner xs_tail ys_tail
-  | _ ->
-      false
+let to_seq t = Sequence.of_list (Fdeque.to_list t)
 
-let to_list : 'e t -> 'e list = fun fseq -> Sequence.to_list (to_seq fseq)
+let empty = Fdeque.empty
 
-let of_list : 'e list -> 'e t = List.fold_left ~init:empty ~f:snoc
+let singleton = Fdeque.singleton
 
-(* Split a tree into the elements before a given index, the element at that
-   index and the elements after it. The index must exist in the tree. *)
-let rec split : 'e. ('e -> int) -> 'e t -> int -> int -> 'e t * 'e * 'e t =
- fun measure' t target acc ->
-  match t with
-  | Empty ->
-      failwith "FSequence.split index out of bounds (1)"
-  | Single x ->
-      if acc + measure' x >= target then (Empty, x, Empty)
-      else failwith "FSequence.split index out of bounds (2)"
-  | Deep (_m, prefix, middle, suffix) ->
-      let acc_p = acc + Digit.measure measure' prefix in
-      if acc_p >= target then
-        (* split point is in left finger *)
-        let dl, m, dr = Digit.split measure' target acc prefix in
-        ( (* left part of digit split *)
-          ( match dl with
-          | None ->
-              Empty
-          | Some (Mk_any_ar dig) ->
-              tree_of_digit measure' dig )
-        , (* middle of digit split *) m
-        , (* right part of digit split + subtree + suffix *)
-          match dr with
-          | None -> (
-              match uncons' Node.measure @@ force middle with
-              | None ->
-                  tree_of_digit measure' suffix
-              | Some (head, tail) ->
-                  deep measure' (Node.to_digit head) tail suffix )
-          | Some (Mk_any_ar dig) ->
-              deep measure' dig (force middle) suffix )
-      else
-        let acc_m = acc_p + measure Node.measure (force middle) in
-        if acc_m >= target then
-          (* split point is in subtree *)
-          let lhs, m, rhs = split Node.measure (force middle) target acc_p in
-          (* The subtree is made of nodes, so the midpoint we got from the
-             recursive call is a node, so split that. *)
-          let m_lhs, m_m, m_rhs =
-            Node.split_to_digits measure' target
-              (measure Node.measure lhs + acc_p)
-              m
-          in
-          ( (* prefix + lhs of the split of the subtree + lhs of the split of
-               them midpoint of the subtree *)
-            ( match m_lhs with
-            | None -> (
-                match unsnoc' Node.measure lhs with
-                | None ->
-                    tree_of_digit measure' prefix
-                | Some (liat, deah) ->
-                    deep measure' prefix liat (Node.to_digit deah) )
-            | Some (Mk_any_ar dig) ->
-                deep measure' prefix lhs dig )
-          , (* midpoint of the split of the subtree *)
-            m_m
-          , (* rhs of the split of the midpoint of the subtree + rhs of the
-               split of the subtree + suffix *)
-            match m_rhs with
-            | None -> (
-                match uncons' Node.measure rhs with
-                | None ->
-                    tree_of_digit measure' suffix
-                | Some (head, tail) ->
-                    deep measure' (Node.to_digit head) tail suffix )
-            | Some (Mk_any_ar dig) ->
-                deep measure' dig rhs suffix )
-        else
-          let acc_s = acc_m + Digit.measure measure' suffix in
-          if acc_s >= target then
-            (* split point is in right finger *)
-            let dl, m, dr = Digit.split measure' target acc_m suffix in
-            ( (* prefix + subtree + left part of digit split *)
-              ( match dl with
-              | None -> (
-                  match unsnoc' Node.measure (force middle) with
-                  | None ->
-                      tree_of_digit measure' prefix
-                  | Some (liat, deah) ->
-                      deep measure' prefix liat (Node.to_digit deah) )
-              | Some (Mk_any_ar dig) ->
-                  deep measure' prefix (force middle) dig )
-            , (* midpoint of digit split *)
-              m
-            , (* right part of digit split *)
-              match dr with
-              | None ->
-                  Empty
-              | Some (Mk_any_ar dig) ->
-                  tree_of_digit measure' dig )
-          else failwith "FSequence.split index out of bounds (3)"
+let cons e t = Fdeque.enqueue_front t e
 
-(* Split a tree into the elements before some index and the elements >= that
-   index. split_at works when the index is out of range and returns a pair while
-   split throws an exception if the index is out of range and returns a triple.
-   The contract is that split_at xs i = take i xs, drop i xs.
-*)
-let split_at : 'e t -> int -> 'e t * 'e t =
- fun t idx ->
-  match t with
-  | Empty ->
-      (empty, empty)
-  | _ ->
-      if idx = 0 then (empty, t)
-      else if measure (Fn.const 1) t >= idx then
-        match split (Fn.const 1) t idx 0 with lhs, m, rhs -> (snoc lhs m, rhs)
-      else (t, empty)
+let snoc t e = Fdeque.enqueue_back t e
 
-let singleton : 'e -> 'e t = fun v -> Single v
+let of_list = Fdeque.of_list
 
-(* Assert that the cached measures match the actual ones. *)
-let rec assert_measure : type e. (e -> int) -> e t -> unit =
- fun measure' -> function
-  | Empty ->
-      ()
-  | Single _ ->
-      ()
-  | Deep (cached_measure, prefix, middle, suffix) ->
-      let measure_node_with_assert node =
-        let expected = Node.measure node in
-        let contents = node |> Node.to_digit |> Digit.to_list in
-        [%test_eq: int] expected (List.sum (module Int) ~f:measure' contents) ;
-        expected
-      in
-      let middle' = Lazy.force middle in
-      assert_measure measure_node_with_assert middle' ;
-      [%test_eq: int] cached_measure
-        ( Digit.measure measure' prefix
-        + measure Node.measure middle'
-        + Digit.measure measure' suffix )
+let split_at t i =
+  let rec go i taken rest =
+    if i <= 0 then (Fdeque.of_list (List.rev taken), rest)
+    else
+      match Fdeque.dequeue_front rest with
+      | None ->
+          (Fdeque.of_list (List.rev taken), rest)
+      | Some (x, rest) ->
+          go (i - 1) (x :: taken) rest
+  in
+  go i [] t
 
-(* Quickcheck.Generator.list generates pretty small lists, which are not big
-   enough to exercise multiple levels of the tree. So we use this instead. *)
+let find t ~f = Fdeque.find t ~f
+
 let big_list : 'a Quickcheck.Generator.t -> 'a list Quickcheck.Generator.t =
  fun gen ->
   let open Quickcheck.Generator.Let_syntax in
@@ -766,21 +83,19 @@ let big_list : 'a Quickcheck.Generator.t -> 'a list Quickcheck.Generator.t =
 let%test_unit "list isomorphism - cons" =
   Quickcheck.test (big_list Int.quickcheck_generator) ~f:(fun xs ->
       let xs_fseq = List.fold_right xs ~f:cons ~init:empty in
-      assert_measure (Fn.const 1) xs_fseq ;
       [%test_eq: int list] xs (to_list xs_fseq) ;
       [%test_eq: int] (List.length xs) (length xs_fseq) )
 
 let%test_unit "list isomorphism - snoc" =
   Quickcheck.test (big_list Int.quickcheck_generator) ~f:(fun xs ->
       let xs_fseq = List.fold_left xs ~init:empty ~f:snoc in
-      assert_measure (Fn.const 1) xs_fseq ;
       [%test_eq: int list] xs (to_list xs_fseq) ;
       [%test_eq: int] (List.length xs) (length xs_fseq) )
 
 let%test_unit "findi matches the list implementation" =
   Quickcheck.test
     Quickcheck.Generator.(
-      tuple2 (big_list (Int.gen_incl 0 20)) (Int.gen_incl 0 20))
+      tuple2 (big_list (Int.gen_incl 0 20)) (Int.gen_incl 0 20) )
     ~f:(fun (xs, target) ->
       let xs_fseq = List.fold_left xs ~init:empty ~f:snoc in
       (* Pins that the *first* match is returned, which is what the callers in
@@ -797,7 +112,6 @@ let%test_unit "alternating cons/snoc" =
       let rec go list fseq cmds_acc =
         match cmds_acc with
         | [] ->
-            assert_measure (Fn.const 1) fseq ;
             [%test_eq: int list] list (to_list fseq) ;
             [%test_eq: int] (List.length list) (length fseq)
         | `A x :: rest ->
@@ -835,8 +149,6 @@ let%test_unit "split properties" =
       let split_l_fseq', split_r_fseq' =
         (to_list split_l_fseq, to_list split_r_fseq)
       in
-      assert_measure (Fn.const 1) split_l_fseq ;
-      assert_measure (Fn.const 1) split_r_fseq ;
       [%test_eq: int] (List.length split_l_list + List.length split_r_list) len ;
       [%test_eq: int list] split_l_list split_l_fseq' ;
       [%test_eq: int list] split_r_list split_r_fseq' ;
@@ -895,22 +207,17 @@ let%test_module "random sequence generation, with splits" =
       in
       Quickcheck.test gen ~trials:100_000 ~shrinker
         ~sexp_of:(List.sexp_of_t sexp_of_action) ~f:(fun acts ->
-          let rec go fseq =
-            let assert_m fseq' =
-              assert_measure (Fn.const 1) fseq' ;
-              fseq'
-            in
-            function
+          let rec go fseq = function
             | [] ->
                 ()
             | `Cons x :: acts_rest ->
-                go (assert_m @@ cons x fseq) acts_rest
+                go (cons x fseq) acts_rest
             | `Snoc x :: acts_rest ->
-                go (assert_m @@ snoc fseq x) acts_rest
+                go (snoc fseq x) acts_rest
             | `Split_take_left idx :: acts_rest ->
-                go (assert_m @@ Tuple2.get1 @@ split_at fseq idx) acts_rest
+                go (Tuple2.get1 @@ split_at fseq idx) acts_rest
             | `Split_take_right idx :: acts_rest ->
-                go (assert_m @@ Tuple2.get2 @@ split_at fseq idx) acts_rest
+                go (Tuple2.get2 @@ split_at fseq idx) acts_rest
           in
           go empty acts )
   end )

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -154,9 +154,10 @@ module For_tests = struct
     assert (Set.equal all_by_sender all_txns) ;
     assert (Set.equal all_by_fee all_txns) ;
     assert (Set.equal all_by_sender' applicable_by_fee) ;
-    (* In each sender's queue nonces should be strictly increasing and the
-       reserved currency should be equal to the sum of amounts and fees of
-       all the commands in the queue. *)
+    (* In each sender's queue nonces should be dense -- each the successor of
+       the one before it, per the invariant block at the top of this file --
+       and the reserved currency should be equal to the sum of amounts and fees
+       of all the commands in the queue. *)
     Map.iteri pool.all_by_sender
       ~f:(fun ~key ~data:(queue, reserved_currency) ->
         [%test_pred:
@@ -176,10 +177,12 @@ module For_tests = struct
                 |> User_command.applicable_at_nonce
               in
               [%test_pred: Account_nonce.t]
-                (* Last nonce is None only at the very beginning. *)
+                (* Last nonce is None only at the very beginning. A gap here
+                   would mean the pool holds a command that cannot apply until
+                   some command it never received shows up. *)
                 (fun n ->
-                  Option.value_map last_nonce ~default:true
-                    ~f:Account_nonce.(( > ) n) )
+                  Option.value_map last_nonce ~default:true ~f:(fun last ->
+                      Account_nonce.(equal n (succ last)) ) )
                 nonce ;
               let consumed =
                 currency_consumed_unchecked

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -560,7 +560,7 @@ let run : type a e.
 let remove_with_dependents_exn :
        Transaction_hash.User_command_with_valid_signature.t
     -> Sender_local_state.t ref
-    -> ( Transaction_hash.User_command_with_valid_signature.t Sequence.t
+    -> ( Transaction_hash.User_command_with_valid_signature.t list
        , Update.single
        , _ )
        Writer_result.t =
@@ -621,7 +621,7 @@ let remove_with_dependents_exn :
             assert (Currency.Amount.(equal reserved_currency' zero)) ;
             None ) )
     } ;
-  F_sequence.to_seq drop_queue
+  F_sequence.to_list drop_queue
 
 let run' t cmd x =
   run t
@@ -645,11 +645,13 @@ let drop_until_sufficient_balance :
     -> Currency.Amount.t
     -> Transaction_hash.User_command_with_valid_signature.t F_sequence.t
        * Currency.Amount.t
-       * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
+       * Transaction_hash.User_command_with_valid_signature.t list =
  fun (queue, currency_reserved) current_balance ->
+  (* [dropped_so_far] is built up in reverse and flipped once on the way out,
+     so that each drop costs O(1) rather than O(dropped so far). *)
   let rec go queue' currency_reserved' dropped_so_far =
     if Currency.Amount.(currency_reserved' <= current_balance) then
-      (queue', currency_reserved', dropped_so_far)
+      (queue', currency_reserved', List.rev dropped_so_far)
     else
       let daeh, liat =
         Option.value_exn
@@ -661,9 +663,9 @@ let drop_until_sufficient_balance :
       let consumed = Option.value_exn (currency_consumed liat) in
       go daeh
         (Option.value_exn Currency.Amount.(currency_reserved' - consumed))
-        (Sequence.append dropped_so_far @@ Sequence.singleton liat)
+        (liat :: dropped_so_far)
   in
-  go queue currency_reserved Sequence.empty
+  go queue currency_reserved []
 
 (* Iterate over commands in the pool, removing them if they require too much
    currency or have too low of a nonce. An argument is provided to instruct
@@ -674,7 +676,7 @@ let revalidate :
     -> logger:Logger.t
     -> [ `Entire_pool | `Subset of Account_id.Set.t ]
     -> (Account_id.t -> Account.t)
-    -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
+    -> t * Transaction_hash.User_command_with_valid_signature.t list =
  fun t_initial ~logger scope f ->
   let requires_revalidation =
     match scope with
@@ -683,167 +685,176 @@ let revalidate :
     | `Subset subset ->
         Set.mem subset
   in
-  Map.fold t_initial.all_by_sender ~init:(t_initial, Sequence.empty)
-    ~f:(fun
-        ~key:sender
-        ~data:(queue, currency_reserved)
-        ((t, dropped_acc) as acc)
-      ->
-      if not (requires_revalidation sender) then acc
-      else
-        let account : Account.t = f sender in
-        let current_balance =
-          Currency.Balance.to_amount
-            (Account.liquid_balance_at_slot
-               ~global_slot:(global_slot_since_genesis t_initial.config)
-               account )
-        in
-        [%log debug]
-          "Revalidating account $account in transaction pool ($account_nonce, \
-           $account_balance)"
-          ~metadata:
-            [ ( "account"
-              , `String (Sexp.to_string @@ Account_id.sexp_of_t sender) )
-            ; ("account_nonce", `Int (Account_nonce.to_int account.nonce))
-            ; ( "account_balance"
-              , `String (Currency.Amount.to_mina_string current_balance) )
-            ] ;
-        let first_cmd = F_sequence.head_exn queue in
-        let first_nonce =
-          first_cmd
-          |> Transaction_hash.User_command_with_valid_signature.command
-          |> User_command.applicable_at_nonce
-        in
-        if
-          not
-            ( Account.has_permission_to_send account
-            && Account.has_permission_to_increment_nonce account )
-        then (
-          [%log debug]
-            "Account no longer has permission to send; dropping queue" ;
-          let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
-          (t_updated, Sequence.append dropped_acc dropped) )
-        else if Account_nonce.(account.nonce < first_nonce) then (
-          [%log debug]
-            "Current account nonce precedes first nonce in queue; dropping \
-             queue" ;
-          let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
-          (t_updated, Sequence.append dropped_acc dropped) )
+  (* As in [drop_until_sufficient_balance], the accumulator is kept reversed
+     and flipped once at the end. *)
+  let t, dropped_rev =
+    Map.fold t_initial.all_by_sender ~init:(t_initial, [])
+      ~f:(fun
+          ~key:sender
+          ~data:(queue, currency_reserved)
+          ((t, dropped_acc) as acc)
+        ->
+        if not (requires_revalidation sender) then acc
         else
-          (* current_nonce >= first_nonce *)
-          let first_applicable_nonce_index =
-            F_sequence.findi queue ~f:(fun cmd' ->
-                let nonce =
-                  Transaction_hash.User_command_with_valid_signature.command
-                    cmd'
-                  |> User_command.applicable_at_nonce
-                in
-                Account_nonce.equal nonce account.nonce )
-            |> Option.value ~default:(F_sequence.length queue)
+          let account : Account.t = f sender in
+          let current_balance =
+            Currency.Balance.to_amount
+              (Account.liquid_balance_at_slot
+                 ~global_slot:(global_slot_since_genesis t_initial.config)
+                 account )
           in
           [%log debug]
-            "Current account nonce succeeds first nonce in queue; splitting \
-             queue at $index"
-            ~metadata:[ ("index", `Int first_applicable_nonce_index) ] ;
-          let dropped_for_nonce, retained_for_nonce =
-            F_sequence.split_at queue first_applicable_nonce_index
+            "Revalidating account $account in transaction pool \
+             ($account_nonce, $account_balance)"
+            ~metadata:
+              [ ( "account"
+                , `String (Sexp.to_string @@ Account_id.sexp_of_t sender) )
+              ; ("account_nonce", `Int (Account_nonce.to_int account.nonce))
+              ; ( "account_balance"
+                , `String (Currency.Amount.to_mina_string current_balance) )
+              ] ;
+          let first_cmd = F_sequence.head_exn queue in
+          let first_nonce =
+            first_cmd
+            |> Transaction_hash.User_command_with_valid_signature.command
+            |> User_command.applicable_at_nonce
           in
-          let currency_reserved_partially_updated =
-            F_sequence.foldl
-              (fun c cmd ->
-                Option.value_exn
-                  Currency.Amount.(c - Option.value_exn (currency_consumed cmd)) )
-              currency_reserved dropped_for_nonce
-          in
-          let keep_queue, currency_reserved_updated, dropped_for_balance =
-            drop_until_sufficient_balance
-              (retained_for_nonce, currency_reserved_partially_updated)
-              current_balance
-          in
-          let to_drop =
-            Sequence.append
-              (F_sequence.to_seq dropped_for_nonce)
-              dropped_for_balance
-          in
-          let keeping_prefix = F_sequence.is_empty dropped_for_nonce in
-          let keeping_suffix = Sequence.is_empty dropped_for_balance in
-          (* t with all_by_sender and applicable_by_fee fields updated *)
-          let t_partially_updated =
-            match F_sequence.uncons keep_queue with
-            | _ when keeping_prefix && keeping_suffix ->
-                (* Nothing dropped, nothing needs to be updated *)
-                t
-            | None ->
-                (* We drop the entire queue, first element needs to be removed from
-                   applicable_by_fee *)
-                let t' = remove_applicable_exn t first_cmd in
-                { t' with all_by_sender = Map.remove t'.all_by_sender sender }
-            | Some _ when keeping_prefix ->
-                (* We drop only transactions from the end of queue, keeping
-                   the head untouched, no need to update applicable_by_fee *)
-                { t with
-                  all_by_sender =
-                    Map.set t.all_by_sender ~key:sender
-                      ~data:(keep_queue, currency_reserved_updated)
-                }
-            | Some (first_kept, _) ->
-                (* We need to replace old queue head with the new queue head
-                   in applicable_by_fee *)
-                let first_kept_unchecked =
-                  Transaction_hash.User_command_with_valid_signature.command
-                    first_kept
-                in
-                let t' = remove_applicable_exn t first_cmd in
-                { t' with
-                  all_by_sender =
-                    Map.set t'.all_by_sender ~key:sender
-                      ~data:(keep_queue, currency_reserved_updated)
-                ; applicable_by_fee =
-                    Applicable_by_fee.insert t'.applicable_by_fee
-                      (User_command.fee_per_wu first_kept_unchecked)
+          if
+            not
+              ( Account.has_permission_to_send account
+              && Account.has_permission_to_increment_nonce account )
+          then (
+            [%log debug]
+              "Account no longer has permission to send; dropping queue" ;
+            let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+            (t_updated, List.rev_append dropped dropped_acc) )
+          else if Account_nonce.(account.nonce < first_nonce) then (
+            [%log debug]
+              "Current account nonce precedes first nonce in queue; dropping \
+               queue" ;
+            let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+            (t_updated, List.rev_append dropped dropped_acc) )
+          else
+            (* current_nonce >= first_nonce *)
+            let first_applicable_nonce_index =
+              F_sequence.findi queue ~f:(fun cmd' ->
+                  let nonce =
+                    Transaction_hash.User_command_with_valid_signature.command
+                      cmd'
+                    |> User_command.applicable_at_nonce
+                  in
+                  Account_nonce.equal nonce account.nonce )
+              |> Option.value ~default:(F_sequence.length queue)
+            in
+            [%log debug]
+              "Current account nonce succeeds first nonce in queue; splitting \
+               queue at $index"
+              ~metadata:[ ("index", `Int first_applicable_nonce_index) ] ;
+            let dropped_for_nonce, retained_for_nonce =
+              F_sequence.split_at queue first_applicable_nonce_index
+            in
+            let currency_reserved_partially_updated =
+              F_sequence.foldl
+                (fun c cmd ->
+                  Option.value_exn
+                    Currency.Amount.(
+                      c - Option.value_exn (currency_consumed cmd) ) )
+                currency_reserved dropped_for_nonce
+            in
+            let keep_queue, currency_reserved_updated, dropped_for_balance =
+              drop_until_sufficient_balance
+                (retained_for_nonce, currency_reserved_partially_updated)
+                current_balance
+            in
+            let to_drop =
+              F_sequence.to_list dropped_for_nonce @ dropped_for_balance
+            in
+            let keeping_prefix = F_sequence.is_empty dropped_for_nonce in
+            let keeping_suffix = List.is_empty dropped_for_balance in
+            (* t with all_by_sender and applicable_by_fee fields updated *)
+            let t_partially_updated =
+              match F_sequence.uncons keep_queue with
+              | _ when keeping_prefix && keeping_suffix ->
+                  (* Nothing dropped, nothing needs to be updated *)
+                  t
+              | None ->
+                  (* We drop the entire queue, first element needs to be removed from
+                     applicable_by_fee *)
+                  let t' = remove_applicable_exn t first_cmd in
+                  { t' with all_by_sender = Map.remove t'.all_by_sender sender }
+              | Some _ when keeping_prefix ->
+                  (* We drop only transactions from the end of queue, keeping
+                     the head untouched, no need to update applicable_by_fee *)
+                  { t with
+                    all_by_sender =
+                      Map.set t.all_by_sender ~key:sender
+                        ~data:(keep_queue, currency_reserved_updated)
+                  }
+              | Some (first_kept, _) ->
+                  (* We need to replace old queue head with the new queue head
+                     in applicable_by_fee *)
+                  let first_kept_unchecked =
+                    Transaction_hash.User_command_with_valid_signature.command
                       first_kept
-                }
-          in
-          let t_updated =
-            Sequence.fold ~init:t_partially_updated
-              ~f:remove_all_by_fee_and_hash_and_expiration_exn to_drop
-          in
-          (t_updated, Sequence.append dropped_acc to_drop) )
+                  in
+                  let t' = remove_applicable_exn t first_cmd in
+                  { t' with
+                    all_by_sender =
+                      Map.set t'.all_by_sender ~key:sender
+                        ~data:(keep_queue, currency_reserved_updated)
+                  ; applicable_by_fee =
+                      Applicable_by_fee.insert t'.applicable_by_fee
+                        (User_command.fee_per_wu first_kept_unchecked)
+                        first_kept
+                  }
+            in
+            let t_updated =
+              List.fold to_drop ~init:t_partially_updated
+                ~f:remove_all_by_fee_and_hash_and_expiration_exn
+            in
+            (t_updated, List.rev_append to_drop dropped_acc) )
+  in
+  (t, List.rev dropped_rev)
 
 let expired_by_global_slot (t : t) :
-    Transaction_hash.User_command_with_valid_signature.t Sequence.t =
+    Transaction_hash.User_command_with_valid_signature.t list =
   let global_slot_since_genesis = global_slot_since_genesis t.config in
   let expired, _, _ =
     Map.split t.transactions_with_expiration global_slot_since_genesis
   in
-  Map.to_sequence expired |> Sequence.map ~f:snd
-  |> Sequence.bind
-       ~f:Transaction_hash.User_command_with_valid_signature.Set.to_sequence
+  Map.data expired
+  |> List.concat_map
+       ~f:
+         (Fn.compose Sequence.to_list
+            Transaction_hash.User_command_with_valid_signature.Set.to_sequence )
 
-let expired (t : t) :
-    Transaction_hash.User_command_with_valid_signature.t Sequence.t =
-  [ expired_by_global_slot t ] |> Sequence.of_list |> Sequence.concat
+let expired (t : t) : Transaction_hash.User_command_with_valid_signature.t list
+    =
+  List.concat [ expired_by_global_slot t ]
 
 let remove_expired t :
-    Transaction_hash.User_command_with_valid_signature.t Sequence.t * t =
-  Sequence.fold (expired t) ~init:(Sequence.empty, t) ~f:(fun acc cmd ->
-      let dropped_acc, t = acc in
-      (*[cmd] would not be in [t] if it depended on an expired transaction already handled*)
-      if
-        member t
-          (Transaction_hash.User_command_with_valid_signature.transaction_hash
-             cmd )
-      then
-        let removed, t' = remove_with_dependents_exn' t cmd in
-        (Sequence.append dropped_acc removed, t')
-      else acc )
+    Transaction_hash.User_command_with_valid_signature.t list * t =
+  let dropped_rev, t =
+    List.fold (expired t) ~init:([], t) ~f:(fun acc cmd ->
+        let dropped_acc, t = acc in
+        (*[cmd] would not be in [t] if it depended on an expired transaction already handled*)
+        if
+          member t
+            (Transaction_hash.User_command_with_valid_signature.transaction_hash
+               cmd )
+        then
+          let removed, t' = remove_with_dependents_exn' t cmd in
+          (List.rev_append removed dropped_acc, t')
+        else acc )
+  in
+  (List.rev dropped_rev, t)
 
 let remove_lowest_fee :
-    t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t * t =
+    t -> Transaction_hash.User_command_with_valid_signature.t list * t =
  fun t ->
   match Map.min_elt t.all_by_fee with
   | None ->
-      (Sequence.empty, t)
+      ([], t)
   | Some (_min_fee, min_fee_set) ->
       remove_with_dependents_exn' t
       @@ Transaction_hash.User_command_with_valid_signature.Set.min_elt_exn
@@ -888,7 +899,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
       -> Currency.Amount.t
       -> Sender_local_state.t ref
       -> ( Transaction_hash.User_command_with_valid_signature.t
-           * Transaction_hash.User_command_with_valid_signature.t Sequence.t
+           * Transaction_hash.User_command_with_valid_signature.t list
          , Update.single
          , Command_error.t )
          M.t =
@@ -963,7 +974,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
         in
         by_sender :=
           { !by_sender with data = Some (F_sequence.singleton cmd, consumed) } ;
-        (cmd, Sequence.empty)
+        (cmd, [])
     | Some (queued_cmds, reserved_currency) ->
         assert (not @@ F_sequence.is_empty queued_cmds) ;
         (* C1/C1b *)
@@ -1003,7 +1014,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
               )
           in
           by_sender := { !by_sender with data = Some new_state } ;
-          (cmd, Sequence.empty) )
+          (cmd, []) )
         else if Account_nonce.equal queue_applicable_at_nonce current_nonce then (
           (* we're replacing a command *)
           let%bind () =
@@ -1058,20 +1069,27 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
           in
           (* check remove_exn dropped the right things *)
           assert (
-            [%equal:
-              Transaction_hash.User_command_with_valid_signature.t Sequence.t]
+            [%equal: Transaction_hash.User_command_with_valid_signature.t list]
               dropped
-              (F_sequence.to_seq drop_queue) ) ;
+              (F_sequence.to_list drop_queue) ) ;
           (* Add the new transaction *)
           let%bind cmd, _ =
             let%map v, dropped' =
               add_from_gossip_exn ~config cmd current_nonce balance by_sender
             in
             (* We've already removed them, so this should always be empty. *)
-            assert (Sequence.is_empty dropped') ;
+            assert (List.is_empty dropped') ;
             (v, dropped)
           in
-          let drop_head, drop_tail = Option.value_exn (Sequence.next dropped) in
+          let drop_head, drop_tail =
+            match dropped with
+            | [] ->
+                (* [remove_with_dependents_exn] above asserts that the queue it
+                   dropped was non-empty. *)
+                assert false
+            | drop_head :: drop_tail ->
+                (drop_head, drop_tail)
+          in
           let increment =
             Option.value_exn Currency.Fee.(fee - User_command.fee to_drop)
           in
@@ -1081,12 +1099,12 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
           *)
           let%bind increment, dropped' =
             let rec go increment dropped dropped' current_nonce : _ M.t =
-              match (Sequence.next dropped, dropped') with
-              | None, Some dropped' ->
+              match (dropped, dropped') with
+              | [], Some dropped' ->
                   return (increment, dropped')
-              | None, None ->
-                  return (increment, Sequence.empty)
-              | Some (cmd, dropped), Some _ -> (
+              | [], None ->
+                  return (increment, [])
+              | cmd :: dropped, Some _ -> (
                   let cmd_unchecked =
                     Transaction_hash.User_command_with_valid_signature.command
                       cmd
@@ -1100,14 +1118,14 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
                         (Insufficient_replace_fee
                            (`Replace_fee replace_fee, increment) )
                       |> M.of_result )
-              | Some (cmd, dropped'), None ->
+              | cmd :: dropped', None ->
                   let current_nonce = Account_nonce.succ current_nonce in
                   let by_sender_pre = !by_sender in
                   M.catch
                     (add_from_gossip_exn ~config cmd current_nonce balance
                        by_sender ) ~f:(function
                     | Ok ((_v, dropped_), ups) ->
-                        assert (Sequence.is_empty dropped_) ;
+                        assert (List.is_empty dropped_) ;
                         let%bind () = M.write_all ups in
                         go increment dropped' None current_nonce
                     | Error _err ->
@@ -1127,7 +1145,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
             |> M.of_result
             (* C3 *)
           in
-          (cmd, Sequence.(append (return drop_head) dropped')) )
+          (cmd, drop_head :: dropped') )
         else
           (*Invalid nonce or duplicate transaction got in- either way error*)
           M.of_result

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -276,7 +276,7 @@ let diff ~before ~after =
      as [after] was derived from [before] by pool operations rather than built
      independently. *)
   Map.symmetric_diff before.all_by_hash after.all_by_hash
-    ~data_equal:(fun _ _ -> true)
+    ~data_equal:(fun _ _ -> true )
   |> Sequence.fold ~init:{ Membership_diff.added = []; removed = [] }
        ~f:(fun acc (_hash, delta) ->
          match delta with
@@ -706,141 +706,142 @@ let revalidate :
     -> (Account_id.t -> Account.t)
     -> t * Transaction_hash.User_command_with_valid_signature.t list =
  fun t_initial ~logger scope f ->
-  let requires_revalidation =
-    match scope with
-    | `Entire_pool ->
-        Fn.const true
-    | `Subset subset ->
-        Set.mem subset
+  let revalidate_sender ~sender ~queue ~currency_reserved (t, dropped_acc) =
+    let account : Account.t = f sender in
+    let current_balance =
+      Currency.Balance.to_amount
+        (Account.liquid_balance_at_slot
+           ~global_slot:(global_slot_since_genesis t_initial.config)
+           account )
+    in
+    [%log debug]
+      "Revalidating account $account in transaction pool ($account_nonce, \
+       $account_balance)"
+      ~metadata:
+        [ ("account", `String (Sexp.to_string @@ Account_id.sexp_of_t sender))
+        ; ("account_nonce", `Int (Account_nonce.to_int account.nonce))
+        ; ( "account_balance"
+          , `String (Currency.Amount.to_mina_string current_balance) )
+        ] ;
+    let first_cmd = F_sequence.head_exn queue in
+    let first_nonce =
+      first_cmd |> Transaction_hash.User_command_with_valid_signature.command
+      |> User_command.applicable_at_nonce
+    in
+    if
+      not
+        ( Account.has_permission_to_send account
+        && Account.has_permission_to_increment_nonce account )
+    then (
+      [%log debug] "Account no longer has permission to send; dropping queue" ;
+      let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+      (t_updated, List.rev_append dropped dropped_acc) )
+    else if Account_nonce.(account.nonce < first_nonce) then (
+      [%log debug]
+        "Current account nonce precedes first nonce in queue; dropping queue" ;
+      let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
+      (t_updated, List.rev_append dropped dropped_acc) )
+    else
+      (* current_nonce >= first_nonce *)
+      let first_applicable_nonce_index =
+        F_sequence.findi queue ~f:(fun cmd' ->
+            let nonce =
+              Transaction_hash.User_command_with_valid_signature.command cmd'
+              |> User_command.applicable_at_nonce
+            in
+            Account_nonce.equal nonce account.nonce )
+        |> Option.value ~default:(F_sequence.length queue)
+      in
+      [%log debug]
+        "Current account nonce succeeds first nonce in queue; splitting queue \
+         at $index"
+        ~metadata:[ ("index", `Int first_applicable_nonce_index) ] ;
+      let dropped_for_nonce, retained_for_nonce =
+        F_sequence.split_at queue first_applicable_nonce_index
+      in
+      let currency_reserved_partially_updated =
+        F_sequence.foldl
+          (fun c cmd ->
+            Option.value_exn
+              Currency.Amount.(c - Option.value_exn (currency_consumed cmd)) )
+          currency_reserved dropped_for_nonce
+      in
+      let keep_queue, currency_reserved_updated, dropped_for_balance =
+        drop_until_sufficient_balance
+          (retained_for_nonce, currency_reserved_partially_updated)
+          current_balance
+      in
+      let to_drop =
+        F_sequence.to_list dropped_for_nonce @ dropped_for_balance
+      in
+      let keeping_prefix = F_sequence.is_empty dropped_for_nonce in
+      let keeping_suffix = List.is_empty dropped_for_balance in
+      (* t with all_by_sender and applicable_by_fee fields updated *)
+      let t_partially_updated =
+        match F_sequence.uncons keep_queue with
+        | _ when keeping_prefix && keeping_suffix ->
+            (* Nothing dropped, nothing needs to be updated *)
+            t
+        | None ->
+            (* We drop the entire queue, first element needs to be removed from
+               applicable_by_fee *)
+            let t' = remove_applicable_exn t first_cmd in
+            { t' with all_by_sender = Map.remove t'.all_by_sender sender }
+        | Some _ when keeping_prefix ->
+            (* We drop only transactions from the end of queue, keeping
+               the head untouched, no need to update applicable_by_fee *)
+            { t with
+              all_by_sender =
+                Map.set t.all_by_sender ~key:sender
+                  ~data:(keep_queue, currency_reserved_updated)
+            }
+        | Some (first_kept, _) ->
+            (* We need to replace old queue head with the new queue head
+               in applicable_by_fee *)
+            let first_kept_unchecked =
+              Transaction_hash.User_command_with_valid_signature.command
+                first_kept
+            in
+            let t' = remove_applicable_exn t first_cmd in
+            { t' with
+              all_by_sender =
+                Map.set t'.all_by_sender ~key:sender
+                  ~data:(keep_queue, currency_reserved_updated)
+            ; applicable_by_fee =
+                Applicable_by_fee.insert t'.applicable_by_fee
+                  (User_command.fee_per_wu first_kept_unchecked)
+                  first_kept
+            }
+      in
+      let t_updated =
+        List.fold to_drop ~init:t_partially_updated
+          ~f:remove_all_by_fee_and_hash_and_expiration_exn
+      in
+      (t_updated, List.rev_append to_drop dropped_acc)
   in
   (* As in [drop_until_sufficient_balance], the accumulator is kept reversed
-     and flipped once at the end. *)
+     and flipped once at the end.
+
+     Both branches visit senders in increasing [Account_id] order -- a map fold
+     and a set fold over the same comparator agree -- so which collection drives
+     the iteration does not change the order senders are processed in, nor the
+     order drops accumulate in. That matters: dropping one sender's queue can
+     change the currency reserved for another whose commands spend from it. *)
   let t, dropped_rev =
-    Map.fold t_initial.all_by_sender ~init:(t_initial, [])
-      ~f:(fun
-          ~key:sender
-          ~data:(queue, currency_reserved)
-          ((t, dropped_acc) as acc)
-        ->
-        if not (requires_revalidation sender) then acc
-        else
-          let account : Account.t = f sender in
-          let current_balance =
-            Currency.Balance.to_amount
-              (Account.liquid_balance_at_slot
-                 ~global_slot:(global_slot_since_genesis t_initial.config)
-                 account )
-          in
-          [%log debug]
-            "Revalidating account $account in transaction pool \
-             ($account_nonce, $account_balance)"
-            ~metadata:
-              [ ( "account"
-                , `String (Sexp.to_string @@ Account_id.sexp_of_t sender) )
-              ; ("account_nonce", `Int (Account_nonce.to_int account.nonce))
-              ; ( "account_balance"
-                , `String (Currency.Amount.to_mina_string current_balance) )
-              ] ;
-          let first_cmd = F_sequence.head_exn queue in
-          let first_nonce =
-            first_cmd
-            |> Transaction_hash.User_command_with_valid_signature.command
-            |> User_command.applicable_at_nonce
-          in
-          if
-            not
-              ( Account.has_permission_to_send account
-              && Account.has_permission_to_increment_nonce account )
-          then (
-            [%log debug]
-              "Account no longer has permission to send; dropping queue" ;
-            let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
-            (t_updated, List.rev_append dropped dropped_acc) )
-          else if Account_nonce.(account.nonce < first_nonce) then (
-            [%log debug]
-              "Current account nonce precedes first nonce in queue; dropping \
-               queue" ;
-            let dropped, t_updated = remove_with_dependents_exn' t first_cmd in
-            (t_updated, List.rev_append dropped dropped_acc) )
-          else
-            (* current_nonce >= first_nonce *)
-            let first_applicable_nonce_index =
-              F_sequence.findi queue ~f:(fun cmd' ->
-                  let nonce =
-                    Transaction_hash.User_command_with_valid_signature.command
-                      cmd'
-                    |> User_command.applicable_at_nonce
-                  in
-                  Account_nonce.equal nonce account.nonce )
-              |> Option.value ~default:(F_sequence.length queue)
-            in
-            [%log debug]
-              "Current account nonce succeeds first nonce in queue; splitting \
-               queue at $index"
-              ~metadata:[ ("index", `Int first_applicable_nonce_index) ] ;
-            let dropped_for_nonce, retained_for_nonce =
-              F_sequence.split_at queue first_applicable_nonce_index
-            in
-            let currency_reserved_partially_updated =
-              F_sequence.foldl
-                (fun c cmd ->
-                  Option.value_exn
-                    Currency.Amount.(
-                      c - Option.value_exn (currency_consumed cmd) ) )
-                currency_reserved dropped_for_nonce
-            in
-            let keep_queue, currency_reserved_updated, dropped_for_balance =
-              drop_until_sufficient_balance
-                (retained_for_nonce, currency_reserved_partially_updated)
-                current_balance
-            in
-            let to_drop =
-              F_sequence.to_list dropped_for_nonce @ dropped_for_balance
-            in
-            let keeping_prefix = F_sequence.is_empty dropped_for_nonce in
-            let keeping_suffix = List.is_empty dropped_for_balance in
-            (* t with all_by_sender and applicable_by_fee fields updated *)
-            let t_partially_updated =
-              match F_sequence.uncons keep_queue with
-              | _ when keeping_prefix && keeping_suffix ->
-                  (* Nothing dropped, nothing needs to be updated *)
-                  t
-              | None ->
-                  (* We drop the entire queue, first element needs to be removed from
-                     applicable_by_fee *)
-                  let t' = remove_applicable_exn t first_cmd in
-                  { t' with all_by_sender = Map.remove t'.all_by_sender sender }
-              | Some _ when keeping_prefix ->
-                  (* We drop only transactions from the end of queue, keeping
-                     the head untouched, no need to update applicable_by_fee *)
-                  { t with
-                    all_by_sender =
-                      Map.set t.all_by_sender ~key:sender
-                        ~data:(keep_queue, currency_reserved_updated)
-                  }
-              | Some (first_kept, _) ->
-                  (* We need to replace old queue head with the new queue head
-                     in applicable_by_fee *)
-                  let first_kept_unchecked =
-                    Transaction_hash.User_command_with_valid_signature.command
-                      first_kept
-                  in
-                  let t' = remove_applicable_exn t first_cmd in
-                  { t' with
-                    all_by_sender =
-                      Map.set t'.all_by_sender ~key:sender
-                        ~data:(keep_queue, currency_reserved_updated)
-                  ; applicable_by_fee =
-                      Applicable_by_fee.insert t'.applicable_by_fee
-                        (User_command.fee_per_wu first_kept_unchecked)
-                        first_kept
-                  }
-            in
-            let t_updated =
-              List.fold to_drop ~init:t_partially_updated
-                ~f:remove_all_by_fee_and_hash_and_expiration_exn
-            in
-            (t_updated, List.rev_append to_drop dropped_acc) )
+    match scope with
+    | `Entire_pool ->
+        Map.fold t_initial.all_by_sender ~init:(t_initial, [])
+          ~f:(fun ~key:sender ~data:(queue, currency_reserved) acc ->
+            revalidate_sender ~sender ~queue ~currency_reserved acc )
+    | `Subset subset ->
+        (* [subset] is the accounts referenced by one block, typically dozens,
+           against up to pool_max_size senders in the pool. *)
+        Set.fold subset ~init:(t_initial, []) ~f:(fun acc sender ->
+            match Map.find t_initial.all_by_sender sender with
+            | None ->
+                acc
+            | Some (queue, currency_reserved) ->
+                revalidate_sender ~sender ~queue ~currency_reserved acc )
   in
   (t, List.rev dropped_rev)
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -259,6 +259,34 @@ let find_by_hash :
     -> Transaction_hash.User_command_with_valid_signature.t option =
  fun { all_by_hash; _ } hash -> Map.find all_by_hash hash
 
+module Membership_diff = struct
+  type t =
+    { added : Transaction_hash.User_command_with_valid_signature.t list
+    ; removed : Transaction_hash.User_command_with_valid_signature.t list
+    }
+end
+
+let diff ~before ~after =
+  (* [all_by_hash] is keyed by transaction hash, so two entries under the same
+     key are the same command and never need comparing -- hence [data_equal]
+     returning true unconditionally, which also means [`Unequal] cannot arise.
+
+     [Map.symmetric_diff] short-circuits on physically equal subtrees, so this
+     costs what the difference costs rather than what the pool holds, as long
+     as [after] was derived from [before] by pool operations rather than built
+     independently. *)
+  Map.symmetric_diff before.all_by_hash after.all_by_hash
+    ~data_equal:(fun _ _ -> true)
+  |> Sequence.fold ~init:{ Membership_diff.added = []; removed = [] }
+       ~f:(fun acc (_hash, delta) ->
+         match delta with
+         | `Left cmd ->
+             { acc with removed = cmd :: acc.removed }
+         | `Right cmd ->
+             { acc with added = cmd :: acc.added }
+         | `Unequal (_, _) ->
+             acc )
+
 let global_slot_since_genesis conf =
   let current_time = Block_time.now conf.Config.time_controller in
   let current_slot =

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -58,6 +58,12 @@ val size : t -> int
 (* The least fee per weight unit of all transactions in the transaction pool *)
 val min_fee : t -> Currency.Fee_rate.t option
 
+(** The applicable commands, highest fee per weight unit first.
+
+    This is the one sequence in the interface that stays lazy: the block
+    producer takes only as long a prefix as the staged ledger has room for, so
+    forcing it would walk the whole pool on every block. Everything else here
+    returns a list. *)
 val transactions :
      logger:Logger.t
   -> t
@@ -66,11 +72,11 @@ val transactions :
 (** Remove the command from the pool with the lowest fee per wu,
     along with any others from the same account with higher nonces. *)
 val remove_lowest_fee :
-  t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t * t
+  t -> Transaction_hash.User_command_with_valid_signature.t list * t
 
 (** Remove all the user commands that are expired. (Valid-until < Current-global-slot) *)
 val remove_expired :
-  t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t * t
+  t -> Transaction_hash.User_command_with_valid_signature.t list * t
 
 (** Get the applicable command in the pool with the highest fee per wu *)
 val get_highest_fee :
@@ -89,7 +95,7 @@ val add_from_gossip_exn :
   -> Currency.Amount.t
   -> ( Transaction_hash.User_command_with_valid_signature.t
        * t
-       * Transaction_hash.User_command_with_valid_signature.t Sequence.t
+       * Transaction_hash.User_command_with_valid_signature.t list
      , Command_error.t )
      Result.t
 (** Returns the commands dropped as a result of adding the command, which will
@@ -129,7 +135,7 @@ val revalidate :
   -> logger:Logger.t
   -> [ `Entire_pool | `Subset of Account_id.Set.t ]
   -> (Account_id.t -> Account.t) (** Lookup an account in the new ledger *)
-  -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
+  -> t * Transaction_hash.User_command_with_valid_signature.t list
 
 (** Get the global slot since genesis according to the pool's time controller. *)
 val global_slot_since_genesis : t -> Mina_numbers.Global_slot_since_genesis.t

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -127,6 +127,22 @@ val find_by_hash :
   -> Transaction_hash.t
   -> Transaction_hash.User_command_with_valid_signature.t option
 
+(** The commands that entered and left the pool between two of its versions. *)
+module Membership_diff : sig
+  type t =
+    { added : Transaction_hash.User_command_with_valid_signature.t list
+    ; removed : Transaction_hash.User_command_with_valid_signature.t list
+    }
+end
+
+(** Commands that entered and left the pool between [before] and [after].
+
+    Costs what the difference costs rather than what the pool holds, provided
+    [after] was derived from [before] by pool operations -- the two then share
+    structure, which the underlying map diff short-circuits on. Comparing two
+    independently built pools with the same contents is not cheap. *)
+val diff : before:t -> after:t -> Membership_diff.t
+
 (** Check the contents of the pool are valid against the current ledger. Call
     this whenever the transition frontier is (re)created.
 *)

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -46,7 +46,7 @@ let singleton_properties () =
         match add_res with
         | Ok (_, pool', dropped) ->
             assert_pool_consistency pool' ;
-            assert (Sequence.is_empty dropped) ;
+            assert (List.is_empty dropped) ;
             [%test_eq: int] (size pool') 1 ;
             assert (
               [%equal:
@@ -55,8 +55,8 @@ let singleton_properties () =
             let dropped', pool'' = remove_lowest_fee pool' in
             assert (
               [%equal:
-                Transaction_hash.User_command_with_valid_signature.t Sequence.t]
-                dropped' (Sequence.singleton cmd) ) ;
+                Transaction_hash.User_command_with_valid_signature.t list]
+                dropped' [ cmd ] ) ;
             assert (equal pool pool'')
         | _ ->
             failwith "should've succeeded" )
@@ -112,7 +112,7 @@ let sequential_adds_all_valid () =
             in
             match add_res with
             | Ok (_, pool', dropped) ->
-                assert (Sequence.is_empty dropped) ;
+                assert (List.is_empty dropped) ;
                 assert_pool_consistency pool' ;
                 pool := pool' ;
                 go rest
@@ -257,7 +257,7 @@ let replacement () =
             match add_from_gossip_exn t cmd init_nonce init_balance with
             | Ok (_, t', removed) ->
                 assert_pool_consistency t' ;
-                assert (Sequence.is_empty removed) ;
+                assert (List.is_empty removed) ;
                 t'
             | _ ->
                 failwith
@@ -310,7 +310,7 @@ let replacement () =
       if Amount.(currency_consumed_post_replace <= init_balance) then
         match add_res with
         | Ok (_, t', dropped) ->
-            assert (not (Sequence.is_empty dropped)) ;
+            assert (not (List.is_empty dropped)) ;
             assert_pool_consistency t'
         | Error e ->
             Command_error.sexp_of_t e |> Sexp.to_string_hum |> failwith
@@ -348,7 +348,7 @@ let remove_lowest_fee () =
     List.fold_left cmds ~init:empty ~f:insert_cmd |> remove_lowest_fee
   in
   (* check that the lowest fee per wu command is returned *)
-  assert (Sequence.(equal cmd_equal removed @@ singleton cmd_lowest_fee))
+  assert (List.equal cmd_equal removed [ cmd_lowest_fee ])
   |> fun () ->
   (* check that the lowest fee per wu command is removed from
      applicable_by_fee *)
@@ -429,7 +429,7 @@ let add_to_pool ~nonce ~balance pool cmd =
     |> Result.map_error ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
     |> Result.ok_or_failwith
   in
-  assert (Sequence.is_empty dropped) ;
+  assert (List.is_empty dropped) ;
   assert_pool_consistency pool' ;
   pool'
 
@@ -501,9 +501,7 @@ let commit_to_pool ledger pool cmd expected_drops =
     List.map
       ~f:Transaction_hash.User_command_with_valid_signature.transaction_hash
   in
-  [%test_eq: Transaction_hash.t list]
-    (lower (Sequence.to_list dropped))
-    (lower expected_drops) ;
+  [%test_eq: Transaction_hash.t list] (lower dropped) (lower expected_drops) ;
   assert_pool_consistency pool ;
   pool
 
@@ -753,7 +751,7 @@ let revalidation_drops_nothing_unless_ledger_changed () =
         Indexed_pool.revalidate pool ~logger `Entire_pool (fun aid ->
             Map.find_exn account_map (Account_id.public_key aid) )
       in
-      assert (Sequence.is_empty dropped) ;
+      assert (List.is_empty dropped) ;
       assert (Indexed_pool.equal pool pool') ;
       let to_apply = Indexed_pool.transactions ~logger pool in
       let to_apply' = Indexed_pool.transactions ~logger pool' in
@@ -805,8 +803,7 @@ let application_invalidates_applied_transactions () =
       in
       assert_pool_consistency pool ;
       [%test_eq: Transaction_hash.Set.t]
-        ( Sequence.to_list dropped |> List.map ~f:txn_hash
-        |> Transaction_hash.Set.of_list )
+        (List.map dropped ~f:txn_hash |> Transaction_hash.Set.of_list)
         ( List.take txns app_count
         |> List.map ~f:(Fn.compose txn_hash sgn_cmd_to_txn)
         |> Transaction_hash.Set.of_list ) )

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -949,3 +949,44 @@ let transaction_replacement_insufficient_balance () =
       assert_pool_consistency pool ;
       [%test_eq: int] (Indexed_pool.size pool) 3 ;
       [%test_eq: int] (Indexed_pool.size pool') 2 )
+
+let hash_set cmds = List.map cmds ~f:txn_hash |> Transaction_hash.Set.of_list
+
+(* [Indexed_pool.diff] is what makes the refcount table derivable from the pool
+   rather than mirrored alongside it, so pin that it reports exactly the
+   membership change, in both directions, for each operation that drops
+   commands. *)
+let diff_reports_membership_changes () =
+  Quickcheck.test ~trials:100 gen_accounts_and_transactions
+    ~f:(fun (account_map, txns) ->
+      let pool = pool_of_transactions ~init:empty ~account_map txns in
+      let check ~before ~after ~expect_removed =
+        let { Indexed_pool.Membership_diff.added; removed } =
+          Indexed_pool.diff ~before ~after
+        in
+        [%test_eq: Transaction_hash.Set.t] (hash_set removed)
+          (hash_set expect_removed) ;
+        assert (List.is_empty added) ;
+        (* Reading the same pair backwards turns removals into additions. *)
+        let { Indexed_pool.Membership_diff.added; removed } =
+          Indexed_pool.diff ~before:after ~after:before
+        in
+        [%test_eq: Transaction_hash.Set.t] (hash_set added)
+          (hash_set expect_removed) ;
+        assert (List.is_empty removed)
+      in
+      (* A pool against itself has no difference at all. *)
+      check ~before:pool ~after:pool ~expect_removed:[] ;
+      (* The generator can produce a sender with no transactions at all. *)
+      if Indexed_pool.size pool > 0 then (
+        let dropped, pool' = Indexed_pool.remove_lowest_fee pool in
+        assert (not (List.is_empty dropped)) ;
+        check ~before:pool ~after:pool' ~expect_removed:dropped ;
+        (* Revalidation against emptied accounts is a second, much larger
+           membership change, exercising the diff over many drops at once
+           rather than the single queue [remove_lowest_fee] takes. *)
+        let pool'', dropped' =
+          Indexed_pool.revalidate pool' ~logger `Entire_pool (fun _ ->
+              Account.empty )
+        in
+        check ~before:pool' ~after:pool'' ~expect_removed:dropped' ) )

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -990,3 +990,45 @@ let diff_reports_membership_changes () =
               Account.empty )
         in
         check ~before:pool' ~after:pool'' ~expect_removed:dropped' ) )
+
+(* The subset scope iterates the subset and looks each sender up, rather than
+   folding every sender in the pool and filtering. The two must agree exactly
+   when the subset is every sender -- including on the order drops come back
+   in, since dropping one sender's queue can change the currency reserved for
+   another whose commands spend from it.
+
+   Compared on drops, size and contents rather than [Indexed_pool.equal]:
+   [equal] is not reflexive across two separately computed results here. On
+   roughly 2% of generated inputs it reports two identical `Entire_pool
+   revalidations of the same pool as different, so it cannot serve as the
+   oracle. That predates this test. *)
+let revalidate_subset_matches_entire_pool () =
+  Quickcheck.test ~trials:100 gen_accounts_and_transactions
+    ~f:(fun (account_map, txns) ->
+      let pool = pool_of_transactions ~init:empty ~account_map txns in
+      let every_sender =
+        Indexed_pool.get_all pool
+        |> List.map ~f:(fun cmd ->
+            Transaction_hash.User_command_with_valid_signature.command cmd
+            |> User_command.fee_payer )
+        |> Account_id.Set.of_list
+      in
+      (* Emptied accounts, so revalidation actually drops something. *)
+      let lookup _ = Account.empty in
+      let entire_pool, dropped_entire =
+        Indexed_pool.revalidate pool ~logger `Entire_pool lookup
+      in
+      let subset, dropped_subset =
+        Indexed_pool.revalidate pool ~logger (`Subset every_sender) lookup
+      in
+      [%test_eq: Transaction_hash.t list]
+        (List.map dropped_entire ~f:txn_hash)
+        (List.map dropped_subset ~f:txn_hash) ;
+      [%test_eq: int] (Indexed_pool.size entire_pool) (Indexed_pool.size subset) ;
+      [%test_eq: Transaction_hash.Set.t]
+        ( Indexed_pool.get_all entire_pool
+        |> List.map ~f:txn_hash |> Transaction_hash.Set.of_list )
+        ( Indexed_pool.get_all subset
+        |> List.map ~f:txn_hash |> Transaction_hash.Set.of_list ) ;
+      assert_pool_consistency entire_pool ;
+      assert_pool_consistency subset )

--- a/src/lib/network_pool/test/main.ml
+++ b/src/lib/network_pool/test/main.ml
@@ -35,6 +35,9 @@ let () =
               revalidation_drops_nothing_unless_ledger_changed
           ; test_case "Diff reports exactly the membership change" `Quick
               diff_reports_membership_changes
+          ; test_case
+              "Revalidating a subset of everything matches the whole pool"
+              `Quick revalidate_subset_matches_entire_pool
           ; test_case "Applying transactions invalidates them" `Quick
               application_invalidates_applied_transactions
           ; test_case "Transaction can be replaced by one with higher fee"

--- a/src/lib/network_pool/test/main.ml
+++ b/src/lib/network_pool/test/main.ml
@@ -33,6 +33,8 @@ let () =
               `Quick nonce_invariant_violation
           ; test_case "Revalidation drops nothing unsless ledger changed" `Quick
               revalidation_drops_nothing_unless_ledger_changed
+          ; test_case "Diff reports exactly the membership change" `Quick
+              diff_reports_membership_changes
           ; test_case "Applying transactions invalidates them" `Quick
               application_invalidates_applied_transactions
           ; test_case "Transaction can be replaced by one with higher fee"

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -449,6 +449,31 @@ struct
       Transition_frontier.best_tip frontier
       |> Breadcrumb.staged_ledger |> Staged_ledger.ledger
 
+    (** Remove [cmds] from both locally-generated tables, returning those that
+        were found in one of them.
+
+        The predicate mutates: [find_and_remove] deletes the entry it reports
+        on, so it has to run exactly once per command. Returning the lazy
+        [Sequence.filter] would instead re-run it on every forcing, and a
+        caller that tests the result for emptiness before listing it would see
+        the first match consumed by the emptiness test and then missing from
+        the list. *)
+    let remove_locally_generated t cmds =
+      Sequence.filter cmds ~f:(fun cmd ->
+          let find_remove_bool tbl =
+            Locally_generated.find_and_remove tbl cmd |> Option.is_some
+          in
+          let dropped_committed =
+            find_remove_bool t.locally_generated_committed
+          in
+          let dropped_uncommitted =
+            find_remove_bool t.locally_generated_uncommitted
+          in
+          (* Nothing should be in both tables. *)
+          assert (not (dropped_committed && dropped_uncommitted)) ;
+          dropped_committed || dropped_uncommitted )
+      |> Sequence.to_list
+
     let drop_until_below_max_size :
            pool_max_size:int
         -> Indexed_pool.t
@@ -906,34 +931,20 @@ struct
                  in
                  Sequence.iter dropped ~f:dec_vk_refcounts ;
                  let dropped_locally_generated =
-                   Sequence.filter dropped ~f:(fun cmd ->
-                       let find_remove_bool tbl =
-                         Locally_generated.find_and_remove tbl cmd
-                         |> Option.is_some
-                       in
-                       let dropped_committed =
-                         find_remove_bool t.locally_generated_committed
-                       in
-                       let dropped_uncommitted =
-                         find_remove_bool t.locally_generated_uncommitted
-                       in
-                       (* Nothing should be in both tables. *)
-                       assert (not (dropped_committed && dropped_uncommitted)) ;
-                       dropped_committed || dropped_uncommitted )
+                   remove_locally_generated t dropped
                  in
                  (* In this situation we don't know whether the commands aren't
                     valid against the new ledger because they were already
                     committed or because they conflict with others,
                     unfortunately. *)
-                 if not (Sequence.is_empty dropped_locally_generated) then
+                 if not (List.is_empty dropped_locally_generated) then
                    [%log info]
                      "Dropped locally generated commands $cmds from pool when \
                       transition frontier was recreated."
                      ~metadata:
                        [ ( "cmds"
                          , `List
-                             (List.map
-                                (Sequence.to_list dropped_locally_generated)
+                             (List.map dropped_locally_generated
                                 ~f:
                                   Transaction_hash
                                   .User_command_with_valid_signature
@@ -2693,6 +2704,43 @@ let%test_module _ =
             Broadcast_pipe.Writer.write t.frontier_pipe_w (Some frontier2)
           in
           assert_pool_txs t (List.drop independent_cmds 3) ;
+          Deferred.unit )
+
+    (* [remove_locally_generated] both mutates the locally-generated tables and
+       reports what it took out of them, so it has to traverse its argument
+       exactly once. A lazy filter under-reports: the caller tests the result
+       for emptiness, which consumes the first match and removes its table
+       entry, and the listing that follows then re-runs the predicate and finds
+       that entry already gone. Pin both halves of the contract -- everything
+       removed is reported, and nothing is left behind. *)
+    let%test_unit "removing locally generated commands reports every one of \
+                   them (user cmds)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind t = setup_test () in
+          let%bind _ = add_commands t independent_cmds in
+          assert_pool_txs t independent_cmds ;
+          let hashed =
+            List.map independent_cmds
+              ~f:Transaction_hash.User_command_with_valid_signature.create
+          in
+          (* Guards the set comparison below against passing vacuously. *)
+          assert (List.length hashed > 1) ;
+          let reported =
+            Test.Resource_pool.remove_locally_generated t.txn_pool
+              (Sequence.of_list hashed)
+          in
+          let hashes cmds =
+            List.map cmds
+              ~f:
+                Transaction_hash.User_command_with_valid_signature
+                .transaction_hash
+            |> Transaction_hash.Set.of_list
+          in
+          [%test_eq: Transaction_hash.Set.t] (hashes hashed) (hashes reported) ;
+          [%test_eq: int] 0
+            (List.length
+               (Locally_generated.to_alist
+                  t.txn_pool.locally_generated_uncommitted ) ) ;
           Deferred.unit )
 
     let%test_unit

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -459,7 +459,7 @@ struct
         the first match consumed by the emptiness test and then missing from
         the list. *)
     let remove_locally_generated t cmds =
-      Sequence.filter cmds ~f:(fun cmd ->
+      List.filter cmds ~f:(fun cmd ->
           let find_remove_bool tbl =
             Locally_generated.find_and_remove tbl cmd |> Option.is_some
           in
@@ -472,22 +472,22 @@ struct
           (* Nothing should be in both tables. *)
           assert (not (dropped_committed && dropped_uncommitted)) ;
           dropped_committed || dropped_uncommitted )
-      |> Sequence.to_list
 
     let drop_until_below_max_size :
            pool_max_size:int
         -> Indexed_pool.t
         -> Indexed_pool.t
-           * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
+           * Transaction_hash.User_command_with_valid_signature.t list =
      fun ~pool_max_size pool ->
+      (* [dropped] is accumulated in reverse and flipped once on the way out. *)
       let rec go pool' dropped =
         if Indexed_pool.size pool' > pool_max_size then (
           let dropped', pool'' = Indexed_pool.remove_lowest_fee pool' in
-          assert (not (Sequence.is_empty dropped')) ;
-          go pool'' @@ Sequence.append dropped dropped' )
-        else (pool', dropped)
+          assert (not (List.is_empty dropped')) ;
+          go pool'' @@ List.rev_append dropped' dropped )
+        else (pool', List.rev dropped)
       in
-      go pool @@ Sequence.empty
+      go pool []
 
     let has_sufficient_fee ~pool_max_size pool cmd : bool =
       match Indexed_pool.min_fee pool with
@@ -617,46 +617,52 @@ struct
           ]
         "Diff: removed: $removed added: $added from best tip" ;
       let pool', dropped_backtrack =
-        List.fold (List.rev removed_commands) ~init:(t.pool, Sequence.empty)
-          ~f:(fun (pool, dropped_so_far) unhashed_cmd ->
-            let cmd =
-              Transaction_hash.User_command_with_valid_signature.create
-                unhashed_cmd.data
-            in
-            ( match
-                Locally_generated.find_and_remove t.locally_generated_committed
-                  cmd
-              with
-            | None ->
-                ()
-            | Some time_added ->
-                [%log' info t.logger]
-                  "Locally generated command $cmd committed in a block!"
-                  ~metadata:
-                    [ ( "cmd"
-                      , With_status.to_yojson User_command.Valid.to_yojson
-                          unhashed_cmd )
-                    ] ;
-                Locally_generated.add_exn t.locally_generated_uncommitted
-                  ~key:cmd ~data:time_added ) ;
-            let pool', dropped_seq =
-              match cmd |> Indexed_pool.add_from_backtrack pool with
-              | Error e ->
-                  let error_str, metadata = indexed_pool_error_log_info e in
-                  log_indexed_pool_error error_str ~metadata cmd ;
-                  (pool, Sequence.empty)
-              | Ok indexed_pool ->
-                  drop_until_below_max_size ~pool_max_size indexed_pool
-            in
-            (pool', Sequence.append dropped_so_far dropped_seq) )
+        (* Accumulated in reverse and flipped once below: appending each chunk
+           with [@] instead would be quadratic in the number of backtracked
+           commands. *)
+        let pool', dropped_rev =
+          List.fold (List.rev removed_commands) ~init:(t.pool, [])
+            ~f:(fun (pool, dropped_so_far) unhashed_cmd ->
+              let cmd =
+                Transaction_hash.User_command_with_valid_signature.create
+                  unhashed_cmd.data
+              in
+              ( match
+                  Locally_generated.find_and_remove
+                    t.locally_generated_committed cmd
+                with
+              | None ->
+                  ()
+              | Some time_added ->
+                  [%log' info t.logger]
+                    "Locally generated command $cmd committed in a block!"
+                    ~metadata:
+                      [ ( "cmd"
+                        , With_status.to_yojson User_command.Valid.to_yojson
+                            unhashed_cmd )
+                      ] ;
+                  Locally_generated.add_exn t.locally_generated_uncommitted
+                    ~key:cmd ~data:time_added ) ;
+              let pool', dropped_seq =
+                match cmd |> Indexed_pool.add_from_backtrack pool with
+                | Error e ->
+                    let error_str, metadata = indexed_pool_error_log_info e in
+                    log_indexed_pool_error error_str ~metadata cmd ;
+                    (pool, [])
+                | Ok indexed_pool ->
+                    drop_until_below_max_size ~pool_max_size indexed_pool
+              in
+              (pool', List.rev_append dropped_seq dropped_so_far) )
+        in
+        (pool', List.rev dropped_rev)
       in
-      Sequence.iter dropped_backtrack ~f:(vk_table_lift_hashed vk_table_dec) ;
+      List.iter dropped_backtrack ~f:(vk_table_lift_hashed vk_table_dec) ;
       (* Track what locally generated commands were removed from the pool
          during backtracking due to the max size constraint. *)
       let locally_generated_dropped =
-        Sequence.filter dropped_backtrack
+        List.filter dropped_backtrack
           ~f:(Locally_generated.mem t.locally_generated_uncommitted)
-        |> Sequence.to_list_rev
+        |> List.rev
       in
       if not (List.is_empty locally_generated_dropped) then
         [%log' debug t.logger]
@@ -710,8 +716,7 @@ struct
               in
               Set.add set cmd_hash )
         in
-        Sequence.to_list dropped_commands
-        |> List.partition_tf ~f:(fun cmd ->
+        List.partition_tf dropped_commands ~f:(fun cmd ->
             Set.mem command_hashes
               (Transaction_hash.User_command_with_valid_signature
                .transaction_hash cmd ) )
@@ -744,7 +749,7 @@ struct
         !"Finished handling diff. Old pool size %i, new pool size %i. Dropped \
           %i commands during backtracking to maintain max size."
         (Indexed_pool.size t.pool) (Indexed_pool.size pool'')
-        (Sequence.length dropped_backtrack) ;
+        (List.length dropped_backtrack) ;
       Mina_metrics.(
         Gauge.set Transaction_pool.pool_size
           (Float.of_int (Indexed_pool.size pool'')) ) ;
@@ -823,7 +828,7 @@ struct
                       [ ("user_command", User_command.to_yojson unchecked) ] ) ;
       (*Remove any expired user commands*)
       let expired_commands, pool = Indexed_pool.remove_expired t.pool in
-      Sequence.iter expired_commands ~f:(fun cmd ->
+      List.iter expired_commands ~f:(fun cmd ->
           [%log' debug t.logger]
             "Dropping expired user command from the pool $cmd"
             ~metadata:
@@ -929,7 +934,7 @@ struct
                        Vk_refcount_table.dec vk_table ~account_id
                          ~vk_hash:vk.hash )
                  in
-                 Sequence.iter dropped ~f:dec_vk_refcounts ;
+                 List.iter dropped ~f:dec_vk_refcounts ;
                  let dropped_locally_generated =
                    remove_locally_generated t dropped
                  in
@@ -953,7 +958,7 @@ struct
                  [%log debug]
                    !"Re-validated transaction pool after restart: dropped %i \
                      of %i previously in pool"
-                   (Sequence.length dropped) (Indexed_pool.size t.pool) ;
+                   (List.length dropped) (Indexed_pool.size t.pool) ;
                  Mina_metrics.(
                    Gauge.set Transaction_pool.pool_size
                      (Float.of_int (Indexed_pool.size new_pool)) ) ;
@@ -1348,7 +1353,7 @@ struct
                 in
                 let account = Map.find_exn fee_payer_accounts (fee_payer cmd) in
                 if already_in_pool then
-                  Ok ((cmd, pool, Sequence.empty), Command_state.Rebroadcast)
+                  Ok ((cmd, pool, []), Command_state.Rebroadcast)
                 else
                   match
                     Indexed_pool.add_from_gossip_exn pool cmd account.nonce
@@ -1380,17 +1385,14 @@ struct
         let dropped_for_add =
           List.filter_map add_results ~f:(function
             | Ok (_, dropped, Command_state.New_command) ->
-                Some (Sequence.to_list dropped)
+                Some dropped
             | Ok (_, _, Command_state.Rebroadcast) | Error _ ->
                 None )
           |> List.concat
         in
         (* drop commands from the pool to retain max size *)
         let pool, dropped_for_size =
-          let pool, dropped =
-            drop_until_below_max_size pool ~pool_max_size:t.config.pool_max_size
-          in
-          (pool, Sequence.to_list dropped)
+          drop_until_below_max_size pool ~pool_max_size:t.config.pool_max_size
         in
         (* handle drops of locally generated commands *)
         let all_dropped_cmds = dropped_for_add @ dropped_for_size in
@@ -2713,8 +2715,9 @@ let%test_module _ =
        entry, and the listing that follows then re-runs the predicate and finds
        that entry already gone. Pin both halves of the contract -- everything
        removed is reported, and nothing is left behind. *)
-    let%test_unit "removing locally generated commands reports every one of \
-                   them (user cmds)" =
+    let%test_unit
+        "removing locally generated commands reports every one of them (user \
+         cmds)" =
       Thread_safe.block_on_async_exn (fun () ->
           let%bind t = setup_test () in
           let%bind _ = add_commands t independent_cmds in
@@ -2726,8 +2729,7 @@ let%test_module _ =
           (* Guards the set comparison below against passing vacuously. *)
           assert (List.length hashed > 1) ;
           let reported =
-            Test.Resource_pool.remove_locally_generated t.txn_pool
-              (Sequence.of_list hashed)
+            Test.Resource_pool.remove_locally_generated t.txn_pool hashed
           in
           let hashes cmds =
             List.map cmds
@@ -2860,8 +2862,9 @@ let%test_module _ =
       Hashtbl.clear t.account_id_to_vks ;
       Hashtbl.clear t.vk_to_account_ids
 
-    let%test_unit "a committed vk stays reachable through the best tip ledger \
-                   once chain refcounts are gone (zkapps)" =
+    let%test_unit
+        "a committed vk stays reachable through the best tip ledger once chain \
+         refcounts are gone (zkapps)" =
       Thread_safe.block_on_async_exn (fun () ->
           let%bind t = setup_test () in
           assert_pool_txs t [] ;
@@ -2917,7 +2920,7 @@ let%test_module _ =
               (Envelope.Incoming.wrap
                  ~data:
                    [ User_command.(
-                       forget_check proof_cmd |> read_all_proofs_from_disk)
+                       forget_check proof_cmd |> read_all_proofs_from_disk )
                    ]
                  ~sender:Envelope.Sender.Local )
           with

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -339,14 +339,12 @@ struct
         { verification_keys :
             (int * Zkapp_vk_cache_tag.t) Zkapp_basic.F_map.Table.t
         ; account_id_to_vks : int Zkapp_basic.F_map.Map.t Account_id.Table.t
-        ; vk_to_account_ids : int Account_id.Map.t Zkapp_basic.F_map.Table.t
         ; vk_cache_db : Zkapp_vk_cache_tag.cache_db
         }
 
       let create vk_cache_db () =
         { verification_keys = Zkapp_basic.F_map.Table.create ()
         ; account_id_to_vks = Account_id.Table.create ()
-        ; vk_to_account_ids = Zkapp_basic.F_map.Table.create ()
         ; vk_cache_db
         }
 
@@ -378,8 +376,6 @@ struct
               (count + 1, vk) ) ;
         Hashtbl.update t.account_id_to_vks account_id
           ~f:(inc_map ~default_map:Zkapp_basic.F_map.Map.empty vk.hash) ;
-        Hashtbl.update t.vk_to_account_ids vk.hash
-          ~f:(inc_map ~default_map:Account_id.Map.empty account_id) ;
         Mina_metrics.(
           Gauge.set Transaction_pool.vk_refcount_table_size
             (Float.of_int (Hashtbl.length t.verification_keys)) )
@@ -398,8 +394,6 @@ struct
                  (count', value) ) ) ;
         Hashtbl.change t.account_id_to_vks account_id
           ~f:(Option.bind ~f:(dec_map vk_hash)) ;
-        Hashtbl.change t.vk_to_account_ids vk_hash
-          ~f:(Option.bind ~f:(dec_map account_id)) ;
         Mina_metrics.(
           Gauge.set Transaction_pool.vk_refcount_table_size
             (Float.of_int (Hashtbl.length t.verification_keys)) )
@@ -472,6 +466,56 @@ struct
           (* Nothing should be in both tables. *)
           assert (not (dropped_committed && dropped_uncommitted)) ;
           dropped_committed || dropped_uncommitted )
+
+    (** The only function permitted to assign [t.pool].
+
+        Refcounts are derived from the pool here rather than restated at each
+        call site: [Indexed_pool.diff] reports exactly which commands entered
+        and left, so the table cannot drift from pool membership.
+
+        This assumes every caller reads [t.pool], derives [new_pool] from it,
+        and calls here without an intervening bind. All of them do today: [apply]
+        is documented as synchronous, and the transition frontier handlers
+        contain no [Deferred] at all. Introducing an await between the read and
+        the call would make the diff report the concurrent writer's additions as
+        removals, corrupting the refcounts silently -- so keep these paths
+        synchronous. *)
+    let set_pool t new_pool =
+      let { Indexed_pool.Membership_diff.added; removed } =
+        Indexed_pool.diff ~before:t.pool ~after:new_pool
+      in
+      let lift = Vk_refcount_table.lift_hashed t.verification_key_table in
+      (* Increment before decrementing: a vk migrating between accounts within
+         a single transition must not transiently hit zero, which would drop
+         its Zkapp_vk_cache_tag and with it the disk cache entry. *)
+      List.iter added ~f:(lift Vk_refcount_table.inc) ;
+      List.iter removed
+        ~f:
+          (lift (fun table ~account_id ~(vk : Verification_key_wire.t) ->
+               Vk_refcount_table.dec table ~account_id ~vk_hash:vk.hash ) ) ;
+      t.pool <- new_pool ;
+      let pool_size = Indexed_pool.size new_pool in
+      (* The degenerate case of the refcount invariant, cheap enough to keep on
+         in the daemon: an empty pool must hold no refcounts. The full
+         recompute costs a pass over the pool with extract_vks per command, so
+         it lives in For_tests instead. Log and meter here -- never crash a node
+         over a mempool side table. *)
+      if
+        pool_size = 0
+        && not (Hashtbl.is_empty t.verification_key_table.verification_keys)
+      then (
+        [%log' error t.logger]
+          "Verification key refcount table still holds $size keys while the \
+           transaction pool is empty"
+          ~metadata:
+            [ ( "size"
+              , `Int (Hashtbl.length t.verification_key_table.verification_keys)
+              )
+            ] ;
+        Mina_metrics.(
+          Counter.inc_one Transaction_pool.vk_refcount_leaks_detected ) ) ;
+      Mina_metrics.(
+        Gauge.set Transaction_pool.pool_size (Float.of_int pool_size) )
 
     let drop_until_below_max_size :
            pool_max_size:int
@@ -573,17 +617,10 @@ struct
          locally_generated_uncommitted to locally_generated_committed and vice
          versa so those hashtables remain in sync with reality.
 
-         Don't forget to modify the refcount table as well as remove from the
-         index pool.
+         The refcount table is not touched here: every pool assignment below
+         goes through [set_pool], which derives the refcount change from the
+         pool itself.
       *)
-      let vk_table_inc = Vk_refcount_table.inc in
-      let vk_table_dec t ~account_id ~(vk : Verification_key_wire.t) =
-        Vk_refcount_table.dec t ~account_id ~vk_hash:vk.hash
-      in
-      let vk_table_lift = Vk_refcount_table.lift t.verification_key_table in
-      let vk_table_lift_hashed =
-        Vk_refcount_table.lift_hashed t.verification_key_table
-      in
       let global_slot = Indexed_pool.global_slot_since_genesis t.pool in
       t.best_tip_ledger <- Some best_tip_ledger ;
       let pool_max_size = t.config.pool_max_size in
@@ -599,8 +636,6 @@ struct
               ]
             @ metadata )
       in
-      List.iter new_commands ~f:(vk_table_lift vk_table_inc) ;
-      List.iter removed_commands ~f:(vk_table_lift vk_table_dec) ;
       let compact_json =
         Fn.compose User_command.fee_payer_summary_json User_command.forget_check
       in
@@ -656,7 +691,6 @@ struct
         in
         (pool', List.rev dropped_rev)
       in
-      List.iter dropped_backtrack ~f:(vk_table_lift_hashed vk_table_dec) ;
       (* Track what locally generated commands were removed from the pool
          during backtracking due to the max size constraint. *)
       let locally_generated_dropped =
@@ -722,7 +756,6 @@ struct
                .transaction_hash cmd ) )
       in
       List.iter committed_commands ~f:(fun cmd ->
-          vk_table_lift_hashed vk_table_dec cmd ;
           Locally_generated.find_and_remove t.locally_generated_uncommitted cmd
           |> Option.iter ~f:(fun data ->
               Locally_generated.add_exn t.locally_generated_committed ~key:cmd
@@ -750,16 +783,12 @@ struct
           %i commands during backtracking to maintain max size."
         (Indexed_pool.size t.pool) (Indexed_pool.size pool'')
         (List.length dropped_backtrack) ;
-      Mina_metrics.(
-        Gauge.set Transaction_pool.pool_size
-          (Float.of_int (Indexed_pool.size pool'')) ) ;
-      t.pool <- pool'' ;
+      set_pool t pool'' ;
       List.iter locally_generated_dropped ~f:(fun cmd ->
           (* If the dropped transaction was included in the winning chain, it'll
              be in locally_generated_committed. If it wasn't, try re-adding to
              the pool. *)
           let remove_cmd () =
-            vk_table_lift_hashed vk_table_dec cmd ;
             assert (
               Option.is_some
               @@ Locally_generated.find_and_remove
@@ -817,11 +846,7 @@ struct
                             , Transaction_hash.User_command_with_valid_signature
                               .to_yojson cmd )
                           ] ;
-                      vk_table_lift_hashed Vk_refcount_table.inc cmd ;
-                      Mina_metrics.(
-                        Gauge.set Transaction_pool.pool_size
-                          (Float.of_int (Indexed_pool.size pool''')) ) ;
-                      t.pool <- pool''' )
+                      set_pool t pool''' )
               | None ->
                   log_and_remove "Fee_payer_account not found"
                     ~metadata:
@@ -836,15 +861,11 @@ struct
                 , Transaction_hash.User_command_with_valid_signature.to_yojson
                     cmd )
               ] ;
-          vk_table_lift_hashed vk_table_dec cmd ;
           ignore
             ( Locally_generated.find_and_remove t.locally_generated_uncommitted
                 cmd
               : (Time_float.t * [ `Batch of int ]) option ) ) ;
-      Mina_metrics.(
-        Gauge.set Transaction_pool.pool_size
-          (Float.of_int (Indexed_pool.size pool)) ) ;
-      t.pool <- pool
+      set_pool t pool
 
     let handle_transition_frontier_diff
         ( ({ new_commands; removed_commands; reorg_best_tip = _ } :
@@ -925,16 +946,6 @@ struct
                                 account"
                              (Base_ledger.get validation_ledger loc) )
                  in
-                 (* The dropped commands leave the pool here, so their vk
-                    refcounts must be decremented to match the increments
-                    made when they were added. *)
-                 let dec_vk_refcounts =
-                   Vk_refcount_table.lift_hashed t.verification_key_table
-                     (fun vk_table ~account_id ~vk ->
-                       Vk_refcount_table.dec vk_table ~account_id
-                         ~vk_hash:vk.hash )
-                 in
-                 List.iter dropped ~f:dec_vk_refcounts ;
                  let dropped_locally_generated =
                    remove_locally_generated t dropped
                  in
@@ -959,10 +970,7 @@ struct
                    !"Re-validated transaction pool after restart: dropped %i \
                      of %i previously in pool"
                    (List.length dropped) (Indexed_pool.size t.pool) ;
-                 Mina_metrics.(
-                   Gauge.set Transaction_pool.pool_size
-                     (Float.of_int (Indexed_pool.size new_pool)) ) ;
-                 t.pool <- new_pool ;
+                 set_pool t new_pool ;
                  t.best_tip_diff_relay <-
                    Some
                      (Broadcast_pipe.Reader.iter
@@ -1375,13 +1383,6 @@ struct
               | Error err ->
                   (pool, Error (cmd, err)) )
         in
-        let added_cmds =
-          List.filter_map add_results ~f:(function
-            | Ok (cmd, _, Command_state.New_command) ->
-                Some cmd
-            | Ok (_, _, Command_state.Rebroadcast) | Error _ ->
-                None )
-        in
         let dropped_for_add =
           List.filter_map add_results ~f:(function
             | Ok (_, dropped, Command_state.New_command) ->
@@ -1396,16 +1397,6 @@ struct
         in
         (* handle drops of locally generated commands *)
         let all_dropped_cmds = dropped_for_add @ dropped_for_size in
-
-        (* apply changes to the vk-refcount-table here *)
-        let () =
-          let lift = Vk_refcount_table.lift_hashed t.verification_key_table in
-          List.iter added_cmds ~f:(lift Vk_refcount_table.inc) ;
-          List.iter all_dropped_cmds
-            ~f:
-              (lift (fun t ~account_id ~vk ->
-                   Vk_refcount_table.dec t ~account_id ~vk_hash:vk.hash ) )
-        in
         let dropped_for_add_hashes =
           List.map dropped_for_add
             ~f:
@@ -1461,10 +1452,9 @@ struct
             | Error _ ->
                 () ) ;
         (* finalize the update to the pool *)
-        t.pool <- pool ;
+        set_pool t pool ;
         let pool_size_after = Indexed_pool.size pool in
         Mina_metrics.(
-          Gauge.set Transaction_pool.pool_size (Float.of_int pool_size_after) ;
           List.iter
             (List.init (max 0 (pool_size_after - pool_size_before)) ~f:Fn.id)
             ~f:(fun _ ->
@@ -1642,6 +1632,60 @@ struct
              (List.map ~f:(fun (txn, _) ->
                   Transaction_hash.User_command_with_valid_signature.command txn
                   |> User_command.read_all_proofs_from_disk ) )
+
+    module For_tests = struct
+      (** Recompute the refcount table from pool membership and check the two
+          agree. If this throws there is a bug -- the same contract as
+          [Indexed_pool.For_tests.assert_pool_consistency], which it
+          deliberately mirrors.
+
+          Living in [For_tests] is the gate: this walks the pool and runs
+          [extract_vks] per command, which is too much for the daemon on a path
+          that runs per gossip diff. [set_pool] keeps the O(1) degenerate case
+          instead. *)
+      let assert_refcount_consistency t =
+        let expected_by_account =
+          Indexed_pool.get_all t.pool
+          |> List.concat_map ~f:(fun cmd ->
+              Transaction_hash.User_command_with_valid_signature.forget_check
+                cmd
+              |> With_hash.data |> User_command.extract_vks )
+          |> List.fold ~init:Account_id.Map.empty
+               ~f:(fun acc (account_id, (vk : Verification_key_wire.t)) ->
+                 Map.update acc account_id ~f:(fun vks ->
+                     Map.update
+                       (Option.value vks ~default:Zkapp_basic.F_map.Map.empty)
+                       vk.hash ~f:(function
+                       | None ->
+                           1
+                       | Some count ->
+                           count + 1 ) ) )
+        in
+        let actual_by_account =
+          Hashtbl.to_alist t.verification_key_table.account_id_to_vks
+          |> Account_id.Map.of_alist_exn
+        in
+        assert (
+          Map.equal (Map.equal Int.equal) expected_by_account actual_by_account ) ;
+        (* [verification_keys] carries one count per vk, summed over every
+           account referencing it. *)
+        let expected_by_vk =
+          Map.fold expected_by_account ~init:Zkapp_basic.F_map.Map.empty
+            ~f:(fun ~key:_ ~data:vks acc ->
+              Map.fold vks ~init:acc ~f:(fun ~key:vk_hash ~data:count acc ->
+                  Map.update acc vk_hash ~f:(function
+                    | None ->
+                        count
+                    | Some total ->
+                        total + count ) ) )
+        in
+        let actual_by_vk =
+          Hashtbl.to_alist t.verification_key_table.verification_keys
+          |> List.map ~f:(fun (vk_hash, (count, _tag)) -> (vk_hash, count))
+          |> Zkapp_basic.F_map.Map.of_alist_exn
+        in
+        assert (Map.equal Int.equal expected_by_vk actual_by_vk)
+    end
   end
 
   include Network_pool_base.Make (Transition_frontier) (Resource_pool)
@@ -1959,6 +2003,7 @@ let%test_module _ =
 
     let assert_pool_txs test txs =
       Indexed_pool.For_tests.assert_pool_consistency test.txn_pool.pool ;
+      Test.Resource_pool.For_tests.assert_refcount_consistency test.txn_pool ;
       assert_locally_generated test.txn_pool ;
       assert_fee_wu_ordering test.txn_pool ;
       assert_user_command_sets_equal
@@ -2852,16 +2897,6 @@ let%test_module _ =
               ~find_vk:(fun _ _ -> Ok vk)
               zkapp_command ) )
 
-    (* Drop every refcount the pool is holding. With an empty pool this leaves
-       exactly the chain refs taken at [handle_transition_frontier_diff_inner],
-       so clearing it reproduces the world in which those two lines are
-       deleted -- without editing the code under test. *)
-    let clear_vk_refcount_table (pool : Test.Resource_pool.t) =
-      let t = pool.verification_key_table in
-      Hashtbl.clear t.verification_keys ;
-      Hashtbl.clear t.account_id_to_vks ;
-      Hashtbl.clear t.vk_to_account_ids
-
     let%test_unit
         "a committed vk stays reachable through the best tip ledger once chain \
          refcounts are gone (zkapps)" =
@@ -2897,17 +2932,13 @@ let%test_module _ =
           let%bind setter = mk_vk_setting_command ~account_idx ~nonce:0 in
           let%bind () = advance_chain t [ setter ] in
           (* The ledger now carries the vk, and the command has left the pool.
-             The one table entry that remains is a chain ref and nothing else:
-             it is held only by the increment taken when the command entered
-             the best tip. Should that increment ever be removed, this expects
-             0 rather than 1, and the rest of the test is unaffected. *)
+             When this test was written the chain refs were still in place, so
+             one table entry survived here and the test cleared the table by
+             hand to reach the state below. Refcounts now track pool membership
+             only, so the empty pool empties the table on its own -- what was a
+             counterfactual is the real behaviour. *)
           assert (Option.is_some (ledger_vk ())) ;
           assert_pool_txs t [] ;
-          [%test_eq: int] 1 (vk_table_size ()) ;
-          (* Delete the chain refs. This is the counterfactual: an empty pool
-             plus an empty table is exactly the state the pool would be in if
-             the two chain-ref lines did not exist. *)
-          clear_vk_refcount_table t.txn_pool ;
           [%test_eq: int] 0 (vk_table_size ()) ;
           (* A proof-authorized command against that account must still
              convert to a verifiable and pass verification, finding the vk via

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2016,7 +2016,8 @@ let%test_module _ =
                User_command.(forget_check tx |> read_all_proofs_from_disk) )
            txs )
 
-    let setup_test ?(verifier = verifier) ?permissions ?slot_tx_end () =
+    let setup_test ?(verifier = verifier) ?(pool_max_size = pool_max_size)
+        ?permissions ?slot_tx_end () =
       let frontier, best_tip_diff_w =
         Mock_transition_frontier.create ?permissions ()
       in
@@ -2830,11 +2831,11 @@ let%test_module _ =
        signature authorization. Even-index test accounts are not zkappified by
        Mock_transition_frontier.create, so for them this is the only way the vk
        can reach the ledger. *)
-    let mk_vk_setting_command ~account_idx ~nonce =
+    let mk_vk_setting_command ?(fee = minimum_fee) ~account_idx ~nonce () =
       let kp = test_keys.(account_idx) in
       let spec : Transaction_snark.For_tests.Update_states_spec.t =
         { sender = (kp, Account.Nonce.of_int nonce)
-        ; fee = Currency.Fee.of_nanomina_int_exn minimum_fee
+        ; fee = Currency.Fee.of_nanomina_int_exn fee
         ; fee_payer = None
         ; receivers = []
         ; amount = Currency.Amount.zero
@@ -2929,7 +2930,7 @@ let%test_module _ =
           [%test_eq: int] 0 (vk_table_size ()) ;
           (* Commit a vk-setting command the way a block would: apply it to the
              ledger and announce it as part of the new best tip. *)
-          let%bind setter = mk_vk_setting_command ~account_idx ~nonce:0 in
+          let%bind setter = mk_vk_setting_command ~account_idx ~nonce:0 () in
           let%bind () = advance_chain t [ setter ] in
           (* The ledger now carries the vk, and the command has left the pool.
              When this test was written the chain refs were still in place, so
@@ -2963,6 +2964,153 @@ let%test_module _ =
                  ledger holding the vk: %s"
                 (Error.to_string_hum (Intf.Verification_error.to_error e))
                 () )
+
+    let vk_table_size (t : test) =
+      Hashtbl.length t.txn_pool.verification_key_table.verification_keys
+
+    let account_id_of_idx idx =
+      Account_id.create
+        (Public_key.compress test_keys.(idx).public_key)
+        Token_id.default
+
+    (* Total refcount held against one account, across every vk. Unlike an
+       aggregate over the whole table this is deterministic, because the
+       commands below are built explicitly rather than generated. *)
+    let vk_refcount_for (t : test) ~account_idx =
+      match
+        Hashtbl.find t.txn_pool.verification_key_table.account_id_to_vks
+          (account_id_of_idx account_idx)
+      with
+      | None ->
+          0
+      | Some vks ->
+          Map.data vks |> List.fold ~init:0 ~f:( + )
+
+    (* The whole point of the effort: a command that commits and stays
+       committed must leave nothing behind in the refcount table. Before
+       refcounts were derived from pool membership, entering the best tip took
+       a reference that only a reorg would ever release, so a healthy chain
+       leaked one per zkApp command forever. *)
+    let%test_unit
+        "committing commands to the chain releases their vk refcounts (zkapps)"
+        =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          let%bind zkapp_cmds = mk_zkapp_commands_single_block 7 t.txn_pool in
+          let%bind () = add_commands' t zkapp_cmds in
+          assert_pool_txs t zkapp_cmds ;
+          (* Guards the final check against passing vacuously. *)
+          [%test_eq: int] 1 (vk_table_size t) ;
+          let%bind () = advance_chain t zkapp_cmds in
+          assert_pool_txs t [] ;
+          [%test_eq: int] 0 (vk_table_size t) ;
+          Deferred.unit )
+
+    (* A command orphaned by a reorg goes back into the pool through
+       add_from_backtrack, which took no reference of its own, so the vk of a
+       command that had been committed and was then orphaned went untracked
+       while the command sat in the pool waiting to be re-included. *)
+    let%test_unit
+        "a command returned to the pool by backtracking holds a vk refcount \
+         (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          (* Even indices are not zkappified by Mock_transition_frontier, so
+             these accounts carry no verification key to begin with. *)
+          let pooled_idx = 0 and orphaned_idx = 2 in
+          let%bind pooled =
+            mk_vk_setting_command ~account_idx:pooled_idx ~nonce:0 ()
+          in
+          let%bind orphaned =
+            mk_vk_setting_command ~account_idx:orphaned_idx ~nonce:0 ()
+          in
+          let%bind () = add_commands' t [ pooled ] in
+          assert_pool_txs t [ pooled ] ;
+          [%test_eq: int] 0 (vk_refcount_for t ~account_idx:orphaned_idx) ;
+          (* [orphaned] belongs to the losing fork's chain and never passed
+             through the pool. The reorg hands it back, and
+             add_from_backtrack puts it in the pool. It is deliberately not
+             applied to the ledger: the mock frontier does not roll the ledger
+             back, so a command committed here would simply be revalidated
+             away again for a stale nonce. *)
+          let%bind () = reorg t [] [ orphaned ] in
+          assert_pool_txs t [ pooled; orphaned ] ;
+          [%test_eq: int] 1 (vk_refcount_for t ~account_idx:orphaned_idx) ;
+          Deferred.unit )
+
+    (* A pooled command can be invalidated by a *different* command committing
+       at the same nonce. Those are partitioned away from the committed ones as
+       commit conflicts, and that branch released no refcount at all. *)
+    let%test_unit
+        "a command dropped for conflicting with a committed one releases its \
+         vk refcount (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          let account_idx = 0 in
+          let%bind conflicted =
+            mk_vk_setting_command ~account_idx ~nonce:0 ()
+          in
+          let%bind () = add_commands' t [ conflicted ] in
+          assert_pool_txs t [ conflicted ] ;
+          [%test_eq: int] 1 (vk_refcount_for t ~account_idx) ;
+          (* A different command from the same account at the same nonce wins
+             the race to the chain, so [conflicted] can never apply. *)
+          let committed =
+            mk_payment ~sender_idx:account_idx ~fee:minimum_fee ~nonce:0
+              ~receiver_idx:5 ~amount:20_000_000_000 ~signature_kind ()
+          in
+          commit_commands t [ committed ] ;
+          let%bind () = reorg t [ committed ] [] in
+          assert_pool_txs t [] ;
+          [%test_eq: int] 0 (vk_refcount_for t ~account_idx) ;
+          Deferred.unit )
+
+    (* The double decrement. A command dropped while backtracking was
+       decremented once for leaving the pool and again when its re-add failed,
+       so a vk shared with a command still in the pool could be evicted from
+       the table -- taking with it the Zkapp_vk_cache_tag that load_vk_cache
+       needs to verify the command that remains. *)
+    let%test_unit
+        "a failed re-add after backtracking leaves a vk another pooled command \
+         still needs (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          (* Small enough that a single backtracked command overflows it. *)
+          let%bind t = setup_test ~pool_max_size:3 () in
+          assert_pool_txs t [] ;
+          (* [victim] pays the minimum, so it is what max-size eviction takes.
+             [keeper] sets the same vk from a different account and stays, so
+             the vk must survive the eviction. *)
+          let%bind victim = mk_vk_setting_command ~account_idx:0 ~nonce:0 () in
+          let%bind keeper =
+            mk_vk_setting_command ~account_idx:2 ~nonce:0
+              ~fee:(minimum_fee * 100) ()
+          in
+          let filler =
+            mk_payment ~sender_idx:6 ~fee:(minimum_fee * 100) ~nonce:0
+              ~receiver_idx:5 ~amount:1_000_000_000 ~signature_kind ()
+          in
+          let%bind () = add_commands' t [ victim; keeper; filler ] in
+          assert_pool_txs t [ victim; keeper; filler ] ;
+          [%test_eq: int] 1 (vk_table_size t) ;
+          [%test_eq: int] 1 (vk_refcount_for t ~account_idx:0) ;
+          [%test_eq: int] 1 (vk_refcount_for t ~account_idx:2) ;
+          (* A command comes back off the losing fork and overflows the pool.
+             [victim] is evicted to make room, and cannot be re-added: the pool
+             is full and its fee is the lowest in it. *)
+          let backtracked =
+            mk_payment ~sender_idx:4 ~fee:(minimum_fee * 100) ~nonce:0
+              ~receiver_idx:5 ~amount:1_000_000_000 ~signature_kind ()
+          in
+          let%bind () = reorg t [] [ backtracked ] in
+          assert_pool_txs t [ keeper; filler; backtracked ] ;
+          [%test_eq: int] 0 (vk_refcount_for t ~account_idx:0) ;
+          (* [keeper] is still in the pool, so its vk must still be tracked. *)
+          [%test_eq: int] 1 (vk_refcount_for t ~account_idx:2) ;
+          [%test_eq: int] 1 (vk_table_size t) ;
+          Deferred.unit )
 
     let%test_unit "transaction replacement works" =
       let signature_kind = Mina_signature_kind.Testnet in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -2731,6 +2731,157 @@ let%test_module _ =
           [%test_eq: int] 0 (vk_table_size ()) ;
           Deferred.unit )
 
+    (* Build a zkApp command that Sets the shared [vk] on [account_idx] under
+       signature authorization. Even-index test accounts are not zkappified by
+       Mock_transition_frontier.create, so for them this is the only way the vk
+       can reach the ledger. *)
+    let mk_vk_setting_command ~account_idx ~nonce =
+      let kp = test_keys.(account_idx) in
+      let spec : Transaction_snark.For_tests.Update_states_spec.t =
+        { sender = (kp, Account.Nonce.of_int nonce)
+        ; fee = Currency.Fee.of_nanomina_int_exn minimum_fee
+        ; fee_payer = None
+        ; receivers = []
+        ; amount = Currency.Amount.zero
+        ; zkapp_account_keypairs = [ kp ]
+        ; memo = Signed_command_memo.create_from_string_exn "set vk"
+        ; new_zkapp_account = false
+        ; snapp_update =
+            { Account_update.Update.dummy with
+              verification_key = Zkapp_basic.Set_or_keep.Set vk
+            }
+        ; current_auth = Permissions.Auth_required.Signature
+        ; call_data = Snark_params.Tick.Field.zero
+        ; events = []
+        ; actions = []
+        ; preconditions = None
+        }
+      in
+      let%map zkapp_command =
+        Transaction_snark.For_tests.update_states ~constraint_constants spec
+      in
+      User_command.Zkapp_command
+        (Or_error.ok_exn
+           (Zkapp_command.Valid.For_tests.to_valid ~failed:false
+              ~find_vk:(fun _ _ -> Ok vk)
+              zkapp_command ) )
+
+    (* Build a command carrying a proof-authorized account update against
+       [account_idx]. Converting this to a verifiable requires finding the vk
+       for that account, which is the lookup under test. *)
+    let mk_proof_authorized_command ~account_idx ~nonce =
+      let kp = test_keys.(account_idx) in
+      let spec : Transaction_snark.For_tests.Update_states_spec.t =
+        { sender = (kp, Account.Nonce.of_int nonce)
+        ; fee = Currency.Fee.of_nanomina_int_exn minimum_fee
+        ; fee_payer = None
+        ; receivers = []
+        ; amount = Currency.Amount.zero
+        ; zkapp_account_keypairs = [ kp ]
+        ; memo = Signed_command_memo.create_from_string_exn "use vk"
+        ; new_zkapp_account = false
+        ; snapp_update =
+            { Account_update.Update.dummy with
+              zkapp_uri = Zkapp_basic.Set_or_keep.Set "https://example.com"
+            }
+        ; current_auth = Permissions.Auth_required.Proof
+        ; call_data = Snark_params.Tick.Field.zero
+        ; events = []
+        ; actions = []
+        ; preconditions = None
+        }
+      in
+      let%map zkapp_command =
+        Transaction_snark.For_tests.update_states ~constraint_constants
+          ~zkapp_prover_and_vk:(prover, Deferred.return vk)
+          spec
+      in
+      User_command.Zkapp_command
+        (Or_error.ok_exn
+           (Zkapp_command.Valid.For_tests.to_valid ~failed:false
+              ~find_vk:(fun _ _ -> Ok vk)
+              zkapp_command ) )
+
+    (* Drop every refcount the pool is holding. With an empty pool this leaves
+       exactly the chain refs taken at [handle_transition_frontier_diff_inner],
+       so clearing it reproduces the world in which those two lines are
+       deleted -- without editing the code under test. *)
+    let clear_vk_refcount_table (pool : Test.Resource_pool.t) =
+      let t = pool.verification_key_table in
+      Hashtbl.clear t.verification_keys ;
+      Hashtbl.clear t.account_id_to_vks ;
+      Hashtbl.clear t.vk_to_account_ids
+
+    let%test_unit "a committed vk stays reachable through the best tip ledger \
+                   once chain refcounts are gone (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          let vk_table_size () =
+            Hashtbl.length t.txn_pool.verification_key_table.verification_keys
+          in
+          (* Even index: Mock_transition_frontier zkappifies only odd ones, so
+             this account starts with no verification key at all. *)
+          let account_idx = 2 in
+          let account_id =
+            Account_id.create
+              (Public_key.compress test_keys.(account_idx).public_key)
+              Token_id.default
+          in
+          let ledger_vk () =
+            let ledger = Option.value_exn t.txn_pool.best_tip_ledger in
+            let%bind.Option loc =
+              Mina_ledger.Ledger.location_of_account ledger account_id
+            in
+            let%bind.Option account = Mina_ledger.Ledger.get ledger loc in
+            let%bind.Option zkapp = account.zkapp in
+            zkapp.verification_key
+          in
+          (* Precondition: the vk is nowhere -- not in the ledger, not in the
+             table. Without this the test could pass vacuously. *)
+          assert (Option.is_none (ledger_vk ())) ;
+          [%test_eq: int] 0 (vk_table_size ()) ;
+          (* Commit a vk-setting command the way a block would: apply it to the
+             ledger and announce it as part of the new best tip. *)
+          let%bind setter = mk_vk_setting_command ~account_idx ~nonce:0 in
+          let%bind () = advance_chain t [ setter ] in
+          (* The ledger now carries the vk, and the command has left the pool.
+             The one table entry that remains is a chain ref and nothing else:
+             it is held only by the increment taken when the command entered
+             the best tip. Should that increment ever be removed, this expects
+             0 rather than 1, and the rest of the test is unaffected. *)
+          assert (Option.is_some (ledger_vk ())) ;
+          assert_pool_txs t [] ;
+          [%test_eq: int] 1 (vk_table_size ()) ;
+          (* Delete the chain refs. This is the counterfactual: an empty pool
+             plus an empty table is exactly the state the pool would be in if
+             the two chain-ref lines did not exist. *)
+          clear_vk_refcount_table t.txn_pool ;
+          [%test_eq: int] 0 (vk_table_size ()) ;
+          (* A proof-authorized command against that account must still
+             convert to a verifiable and pass verification, finding the vk via
+             the ledger alone. *)
+          let%bind proof_cmd =
+            mk_proof_authorized_command ~account_idx ~nonce:1
+          in
+          match%map
+            Test.Resource_pool.Diff.verify t.txn_pool
+              (Envelope.Incoming.wrap
+                 ~data:
+                   [ User_command.(
+                       forget_check proof_cmd |> read_all_proofs_from_disk)
+                   ]
+                 ~sender:Envelope.Sender.Local )
+          with
+          | Ok _ ->
+              ()
+          | Error e ->
+              failwithf
+                "proof-authorized command failed to verify with only the \
+                 ledger holding the vk: %s"
+                (Error.to_string_hum (Intf.Verification_error.to_error e))
+                () )
+
     let%test_unit "transaction replacement works" =
       let signature_kind = Mina_signature_kind.Testnet in
       Thread_safe.block_on_async_exn


### PR DESCRIPTION
## What this fixes

`Vk_refcount_table` is a mutable side table of zkApp verification-key refcounts
that must mirror membership of the persistent `Indexed_pool.t`. Ten hand-written
call sites kept the two in sync, and four of them were wrong:

- commands entering the best tip were incremented with no matching decrement on
  the normal path, so a command that committed and stayed committed leaked its
  refs forever;
- `add_from_backtrack` re-added a command to the pool without incrementing;
- commands dropped for conflicting with a committed one were never decremented;
- commands dropped while backtracking were decremented once wholesale and again
  for their locally generated subset when re-adding them failed — a double
  decrement that can evict a key another pooled command still needs.

The first fires on every block carrying a verification-key-setting zkApp
command, which is considerably more frequent than the frontier-recreation gap
fixed in #19162.

Retained entries pin their `Zkapp_vk_cache_tag`, so the on-disk cache handle is
never reclaimed either. The cost is not only memory: `load_vk_cache` issues a
disk read per retained key per referenced account on every gossip diff, so a
table that never shrinks means steadily growing I/O on the verification path.

## Approach

Patching the four sites would leave six that the next change can break, so the
fix is structural.

`Indexed_pool.diff` reports which commands entered and left between two versions
of the pool. Because the pool is persistent and threaded functionally, the two
versions share structure, and the underlying map diff short-circuits on
physically equal subtrees — so this costs what the difference costs rather than
what the pool holds. That was measured before the design was committed to, flat
in pool size from 500 to 8000 entries across every pool operation.

`set_pool` is then the only function permitted to assign `t.pool`. It derives
the refcount change from that diff, so the table cannot drift from pool
membership. All ten mirror sites are deleted, all five assignments routed
through it. Increments are applied before decrements, so a key migrating between
accounts within one transition never transiently reaches zero and drops its
cache handle.

`set_pool` assumes each caller reads `t.pool`, derives from it, and calls in one
synchronous stretch. Every caller does today — `apply` is documented as
synchronous and the transition frontier handlers contain no `Deferred` at all —
and the comment on `set_pool` says so, because an await introduced between the
read and the call would corrupt refcounts silently.

## Checks

`For_tests.assert_refcount_consistency` recomputes the table from pool
membership and asserts, mirroring the existing `assert_pool_consistency`
precedent. It runs from `assert_pool_txs`, which most pool tests already call.

The daemon keeps only the degenerate case — an empty pool must hold no keys,
which is what this class of leak looks like in practice. It logs and increments
a new `vk_refcount_leaks_detected` counter rather than crashing a node over a
mempool side table.

## Tests

Four tests, one per gap, each verified to fail against the tree before the fix
and pass after — by reconstructing that tree and running them against it, not by
assuming:

| Test | Pre-fix |
| --- | --- |
| committing to the chain releases refcounts | expected 0, got 1 |
| a backtracked command holds a refcount | expected 1, got 0 |
| a commit conflict releases its refcount | expected 0, got 1 |
| a failed re-add keeps a vk another pooled command needs | expected 1, got 0 |

The last one is worth noting: its per-account assertion passed pre-fix. Only the
key-indexed table hit zero, which is exactly the entry carrying the cache handle
`load_vk_cache` reads.

## Supporting changes

Each of these stands alone and is a separate commit.

- **Dropped-command flows return lists, not sequences.** They were accumulated
  by left-nested `Sequence.append` inside folds and traversed up to three times,
  re-walking the nesting each time. Nothing relied on the laziness — audited
  across every caller. At `pool_max_size`, those three traversals cost ~170ms
  against ~15µs for a list. `Indexed_pool.transactions` stays lazy: the block
  producer consumes only a prefix of it, and the `.mli` now records why.
- **A log fix.** The list of dropped locally generated commands was built with a
  `Sequence.filter` whose predicate mutates, then forced twice — so the log
  omitted the first command it should have named, and named none at all when
  exactly one was dropped.
- **`revalidate`'s subset case iterates the subset** rather than folding every
  sender and filtering. Safe because a map fold and a set fold over the same
  comparator agree on ordering, so senders are processed and drops accumulate
  identically.
- **`F_sequence.findi` stops at the match.** It was built on a fold that kept
  going after finding, costing the length of the sequence wherever the match
  was. Every caller looks up a nonce at or near the head of a sender's queue.
- **`F_sequence` is now a thin adapter over `Core.Fdeque`**, −693 lines. The
  hand-rolled finger tree had one client, and every operation the pool performs
  is at the ends of a queue except three splits, each cutting where a nonce scan
  just matched. The `.mli` is unchanged, so `indexed_pool` is untouched and
  every interface-level property test carries over as it was. This also repaired
  a real bug: the finger tree's `equal` matched the both-empty case in a
  catch-all returning `false`, so it never returned `true` for any input.
  Note the tradeoff — `Fdeque` documents its amortized bounds as assuming the
  deque is threaded sequentially, where the finger tree held under arbitrary
  persistent use. Sender queues are threaded sequentially.
- **The density invariant is now checked.** The module header claimed sender
  queues are "ordered by nonce and dense" while the consistency checker only
  asserted nonces strictly increase. Tightened to the successor relation; it
  passed unchanged, so the claim was accurate and is now enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

