### PR TITLE
Archive automode: let the daemon send its hard fork config

### DIFF
--- a/src/app/archive/lib/diff.ml
+++ b/src/app/archive/lib/diff.ml
@@ -29,6 +29,20 @@ module Transition_frontier = struct
     | Root_transitioned of
         Transition_frontier.Diff.Root_transition.Lite.Stable.Latest.t
     | Bootstrap of { lost_blocks : State_hash.Stable.Latest.t list }
+    | Hardfork_config of { config_json : string }
+        (** The runtime configuration a daemon generated for a hard fork,
+            verbatim, as JSON.
+
+            Its [fork] stanza is the fork block's identity -- state hash,
+            blockchain length and global slot -- and its ledger stanzas carry
+            the hashes that locate and verify the genesis ledger. That is
+            everything the archive needs to settle the fork boundary, so this
+            is the only message the hand-over requires.
+
+            Sent by whichever daemon is running: once when the pre-fork daemon
+            generates the configuration, then repeatedly on a slow heartbeat,
+            because a single lost message would otherwise leave the archive
+            with no record of the fork at all. *)
   [@@deriving bin_io_unversioned]
 end
 

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1514,6 +1514,11 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
         (* Start auto hardfork config generation if conditions are met *)
         O1trace.background_thread "auto_hardfork_config_generation" (fun () ->
             Mina_run.start_auto_hardfork_config_generation ~logger mina ) ;
+        (* On a forked network, keep offering the fork configuration to the
+           archive. It is the only message the archive's hand-over needs, so a
+           single lost delivery would leave it with no record of the fork. *)
+        O1trace.background_thread "hardfork_config_heartbeat" (fun () ->
+            Mina_run.start_hardfork_config_heartbeat ~logger mina ) ;
         (*This pipe is consumed only by integration tests*)
         don't_wait_for
           (Pipe_lib.Strict_pipe.Reader.iter_without_pushback

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -68,6 +68,54 @@ let wait_for_best_tip ~logger ~slot_tx_end mina =
             let%map () = after (Time.Span.of_sec 15.0) in
             `Repeat () ) )
 
+(** Send a hard fork runtime configuration to the archive process, if one is
+    configured. Best effort: a failure is logged and swallowed, because the
+    caller either repeats the send or is about to exit for reasons unrelated to
+    the archive. *)
+let send_hardfork_config_to_archive ~logger ~archive_location ~config_json =
+  match archive_location with
+  | None ->
+      Deferred.unit
+  | Some archive_location -> (
+      match%map
+        Mina_lib.Archive_client.dispatch_hardfork_config ~logger
+          archive_location ~config_json
+      with
+      | Ok () ->
+          [%log info] "Auto HF: sent hard fork configuration to the archive"
+      | Error e ->
+          [%log warn]
+            "Auto HF: could not send hard fork configuration to the archive: \
+             $error"
+            ~metadata:[ ("error", Error_json.error_to_yojson e) ] )
+
+(** Re-send this daemon's own hard fork configuration to the archive on a slow
+    cadence, for as long as the daemon runs.
+
+    The configuration is the only message the archive hand-over needs, so a
+    single lost delivery would leave the archive with no record of the fork.
+    Repeating it costs about a kilobyte an hour and additionally heals an
+    archive restored from a backup taken before the fork. *)
+let start_hardfork_config_heartbeat ~logger ?(interval = Time.Span.of_hr 1.)
+    mina =
+  let config = Mina_lib.config mina in
+  let runtime_config = config.precomputed_values.runtime_config in
+  match Runtime_config.fork runtime_config with
+  | None ->
+      (* Not a forked network: nothing for the archive to be told about. *)
+      Deferred.unit
+  | Some _ ->
+      let config_json =
+        Runtime_config.to_yojson runtime_config |> Yojson.Safe.to_string
+      in
+      Deferred.repeat_until_finished () (fun () ->
+          let%bind () =
+            send_hardfork_config_to_archive ~logger
+              ~archive_location:config.archive_process_location ~config_json
+          in
+          let%map () = after interval in
+          `Repeat () )
+
 let start_auto_hardfork_config_generation ~logger mina =
   let open Deferred.Let_syntax in
   let config = Mina_lib.config mina in
@@ -129,6 +177,28 @@ let start_auto_hardfork_config_generation ~logger mina =
               [%log info]
                 "Auto HF: successfully generated hardfork config, shutting \
                  down daemon" ;
+              (* Hand the generated configuration to the archive before we go.
+                 It is the only message the archive's hand-over needs: its
+                 [fork] stanza identifies the fork block, and its ledger
+                 hashes locate and verify the genesis ledger. We are about to
+                 exit, so this is one shot -- the post-fork daemon's heartbeat
+                 is what covers a loss here. *)
+              let%bind () =
+                match%bind
+                  Deferred.Or_error.try_with ~here:[%here] (fun () ->
+                      Reader.file_contents (config_dir ^/ "daemon.json") )
+                with
+                | Ok config_json ->
+                    send_hardfork_config_to_archive ~logger
+                      ~archive_location:config.archive_process_location
+                      ~config_json
+                | Error e ->
+                    [%log error]
+                      "Auto HF: generated a hardfork config but could not read \
+                       it back to send to the archive: $error"
+                      ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
+                    Deferred.unit
+              in
               (* Shutdown like Stop_daemon *)
               Scheduler.yield () >>= fun () -> exit 0
           | Error e ->

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -66,6 +66,11 @@ let dispatch_precomputed_block =
 let dispatch_extensional_block =
   make_dispatch_block Archive_lib.Rpc.extensional_block
 
+let dispatch_hardfork_config ?max_tries ~logger archive_location ~config_json =
+  dispatch ?max_tries ~logger archive_location
+    (Archive_lib.Diff.Transition_frontier
+       (Archive_lib.Diff.Transition_frontier.Hardfork_config { config_json }) )
+
 let transfer
     (breadcrumb_reader :
       Transition_frontier.Extensions.New_breadcrumbs.view

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -13,6 +13,19 @@ val dispatch_extensional_block :
   -> Archive_lib.Extensional.Block.t
   -> unit Async.Deferred.Or_error.t
 
+(** Send a hard fork runtime configuration to the archive process.
+
+    The archive derives the fork block's identity and the genesis ledger's
+    location from the configuration alone, so this is the only message the
+    hand-over needs. Delivery is best effort; the caller is expected to repeat
+    it rather than to rely on a single attempt. *)
+val dispatch_hardfork_config :
+     ?max_tries:int
+  -> logger:Logger.t
+  -> Host_and_port.t Cli_lib.Flag.Types.with_name
+  -> config_json:string
+  -> unit Async.Deferred.Or_error.t
+
 val run :
      logger:Logger.t
   -> precomputed_values:Precomputed_values.t

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -1681,6 +1681,14 @@ let hard_fork_genesis_slot_delta t =
   let%map delta = daemon.hard_fork_genesis_slot_delta in
   Mina_numbers.Global_slot_span.of_int delta
 
+(** The [fork] stanza, present exactly when this configuration describes a
+    network that has already forked. It identifies the block the fork was taken
+    from. *)
+let fork t =
+  let open Option.Let_syntax in
+  let%bind proof = t.proof in
+  proof.fork
+
 (** Compute the hard fork genesis slot from the runtime config, if all the stop
     slots and the genesis slot delta have been set. Note that this is the hard
     fork genesis slot expressed as a


### PR DESCRIPTION
Part of the archive automode series (#19245). Targets `feat/archive_automode`, not a release branch.

## Why

At a hard fork the archive node must settle its chain boundary, upgrade its schema and record the fork genesis. Nothing tells it that any of this is due: the block stream does not announce the fork, it **stops** — which from the archive's side is indistinguishable from a network partition or a crashed daemon.

The fork runtime configuration turns out to be enough to trigger all of it:

- its `fork` stanza — `state_hash`, `blockchain_length`, `global_slot_since_genesis` — **is** the fork block's identity;
- its ledger stanzas carry `hash` and `s3_data_hash`, which locate and verify the genesis ledger.

`generate_tar_and_config` (`src/lib/mina_lib/mina_lib.ml:3040`) already computes the SHA3 of the tarball it produces and records it as `s3_data_hash`, so the configuration is self-verifying: a consumer can prove any ledger it later obtains is byte-identical to what the daemon generated.

This PR is the sending half only. The archive ignores the new variant.

## What

**`Hardfork_config` diff variant** (`src/app/archive/lib/diff.ml`) carrying the configuration verbatim as JSON. `processor.ml` already has a catch-all `Transition_frontier _` branch, so the archive compiles and ignores it unchanged.

**Two senders**, because a single message carrying everything would otherwise be a single point of failure:

| Sender | When | Delivery |
|---|---|---|
| pre-fork daemon, automode thread | once, after `dump_reference_config` succeeds and before `exit 0` | one shot — it is about to exit |
| any daemon on a forked network | hourly, for as long as it runs | heartbeat |

The heartbeat costs roughly a kilobyte an hour and additionally heals an archive restored from a backup taken before the fork.

**`Runtime_config.fork`** — a top-level accessor for the `fork` stanza, in the style of the neighbouring `slot_tx_end` / `hard_fork_genesis_slot_delta`. It is what the heartbeat uses to decide whether this daemon has anything to say.

**`Archive_client.dispatch_hardfork_config`** — `dispatch` was previously unexposed in the `.mli`.

## Deliberately not here

- The archive handling the message, or the `hardfork_state` table
- The boundary repair, the schema upgrade, the dispatcher
- Genesis accounts and ledger resolution

## Notes for review

- Both sends are best effort and log rather than raise. The pre-fork one cannot retry — the daemon is exiting — which is precisely why the heartbeat exists.
- The pre-fork path reads the configuration back from `daemon.json` in the generated directory rather than threading it out of `dump_reference_config`, to keep this PR from touching that function's signature.
- `start_hardfork_config_heartbeat` returns immediately on a network with no `fork` stanza, so unforked networks pay nothing.
- The archive RPCs are declared `~version:0` over `Stable.Latest` types, which assumes both sides are built from the same source. A hard fork is exactly where that stops being true; bumping the version is tracked separately and is not needed for this PR, since the pre-fork daemon only ever talks to a pre-fork archive.

## Testing

Typechecked locally against the mesa switch, after populating the crypto submodules:

```
dune build --root . @src/lib/runtime_config/check \
                    @src/app/archive/lib/check \
                    @src/lib/mina_lib/check      -> exit 0
dune build --root . @src/app/cli/src/check       -> exit 0
```

The second covers `mina_run.ml` and `mina_cli_entrypoint.ml`, where most of the new code is. No new warnings; everything emitted is pre-existing in unrelated crypto and GraphQL code.

Not exercised at runtime — there is no test yet that drives a daemon through the automode path with an archive attached. That arrives with the archive-side handling, where there is something to assert against.
