### PR TITLE
Archive automode: record the hard fork configuration

### DIFF
--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -31,6 +31,27 @@ let command_run =
      and runtime_config_file =
        flag "--config-file" ~aliases:[ "-config-file" ] (optional string)
          ~doc:"PATH to the configuration file containing the genesis ledger"
+     and hardfork_handling =
+       flag "--hardfork-handling" ~aliases:[ "-hardfork-handling" ]
+         ~doc:
+           "keep-running|exit|migrate-exit What to do once a daemon tells this \
+            archive about a hard fork. The work on the other side of a fork \
+            belongs to the post-fork binary, which this process is not, so \
+            stopping is how the dispatcher gets to choose the successor. \
+            'exit' leaves the schema to somebody else; 'migrate-exit' upgrades \
+            it first. Default is keep-running, so upgrading the binary does \
+            not by itself change when an archive stops."
+         (optional_with_default Archive_lib.Hardfork_handling.Keep_running
+            (Command.Arg_type.map Command.Param.string
+               ~f:Archive_lib.Hardfork_handling.of_string_exn ) )
+     and schema_upgrade_script =
+       flag "--schema-upgrade-script"
+         ~aliases:[ "-schema-upgrade-script" ]
+         ~doc:
+           "PATH The script --hardfork-handling migrate-exit runs against this \
+            archive's database before it stops (default \
+            /etc/mina/archive/upgrade_to_mesa.sql)"
+         (optional_with_default "/etc/mina/archive/upgrade_to_mesa.sql" string)
      and delete_older_than =
        flag "--delete-older-than" ~aliases:[ "-delete-older-than" ]
          (optional int)
@@ -67,7 +88,8 @@ let command_run =
          ~server_port:
            (Option.value server_port.value ~default:server_port.default)
          ~delete_older_than ~runtime_config_opt ~missing_blocks_width
-         ~signature_kind:Mina_signature_kind.t_DEPRECATED )
+         ~signature_kind:Mina_signature_kind.t_DEPRECATED ~hardfork_handling
+         ~schema_upgrade_script )
 
 let time_arg =
   (* Same timezone as Genesis_constants.genesis_state_timestamp. *)

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -592,3 +592,35 @@ CREATE TABLE blocks_zkapp_commands
 CREATE INDEX idx_blocks_zkapp_commands_block_id ON blocks_zkapp_commands(block_id);
 CREATE INDEX idx_blocks_zkapp_commands_zkapp_command_id ON blocks_zkapp_commands(zkapp_command_id);
 CREATE INDEX idx_blocks_zkapp_commands_sequence_no ON blocks_zkapp_commands(sequence_no);
+
+/* -----------------------------------------------------------------------
+   Hard fork state
+
+   What the archive knows about a hard fork it is passing through. At most one
+   row ever exists -- several archive processes may share one database, and
+   they must not be able to hold different opinions about the fork.
+
+   Filled from the runtime configuration a daemon generated for the fork. That
+   configuration's `fork` stanza is the fork block's identity, and its ledger
+   stanzas carry the hashes that locate and verify the genesis ledger, so it is
+   kept verbatim for the later steps of the hand-over to read.
+
+   `stage` advances in one direction only:
+     announced  -- we know a fork happened and which block it forked from
+     finalized  -- the chain boundary has been settled in this database
+*/
+
+CREATE TYPE hardfork_stage  AS ENUM ('announced', 'finalized');
+CREATE TYPE hardfork_source AS ENUM ('daemon_config', 'fork_genesis', 'operator');
+
+CREATE TABLE hardfork_state
+( id                      int              PRIMARY KEY DEFAULT 1 CHECK (id = 1)
+, fork_state_hash         text             NOT NULL
+, fork_blockchain_length  bigint           NOT NULL
+, fork_global_slot        bigint           NOT NULL
+, config_json             text             NOT NULL
+, stage                   hardfork_stage   NOT NULL
+, source                  hardfork_source  NOT NULL
+, announced_at            timestamptz      NOT NULL DEFAULT now()
+, finalized_at            timestamptz
+);

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -605,12 +605,12 @@ CREATE INDEX idx_blocks_zkapp_commands_sequence_no ON blocks_zkapp_commands(sequ
    stanzas carry the hashes that locate and verify the genesis ledger, so it is
    kept verbatim for the later steps of the hand-over to read.
 
-   `stage` advances in one direction only:
-     announced  -- we know a fork happened and which block it forked from
-     finalized  -- the chain boundary has been settled in this database
+   How far the hand-over has got is `finalized_at`: NULL while the fork is
+   known but the chain boundary has not been settled, a timestamp once it has.
+   A separate stage column would carry the same one bit a second time, and the
+   two could then disagree.
 */
 
-CREATE TYPE hardfork_stage  AS ENUM ('announced', 'finalized');
 CREATE TYPE hardfork_source AS ENUM ('daemon_config', 'fork_genesis', 'operator');
 
 CREATE TABLE hardfork_state
@@ -619,7 +619,6 @@ CREATE TABLE hardfork_state
 , fork_blockchain_length  bigint           NOT NULL
 , fork_global_slot        bigint           NOT NULL
 , config_json             text             NOT NULL
-, stage                   hardfork_stage   NOT NULL
 , source                  hardfork_source  NOT NULL
 , announced_at            timestamptz      NOT NULL DEFAULT now()
 , finalized_at            timestamptz

--- a/src/app/archive/downgrade_to_berkeley.sql
+++ b/src/app/archive/downgrade_to_berkeley.sql
@@ -217,6 +217,15 @@ BEGIN
     RAISE NOTICE 'downgrade: leaving zkapp_{events,field_array}.element_ids without UNIQUE/index and events_id/actions_id nullable (cannot be safely restored on post-fix data)';
 END $$;
 
+-- 3c. Remove what the upgrade added for the automatic hard fork hand-over.
+--
+-- Unlike the changes above, this one is not lossy in the way that matters: the
+-- row describes a fork a berkeley-era archive has no use for, and the daemon
+-- sends its configuration again when the archive is upgraded.
+
+DROP TABLE IF EXISTS hardfork_state;
+DROP TYPE  IF EXISTS hardfork_source;
+
 -- 4. Update schema_history
 
 DO $$

--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -109,3 +109,5 @@ DROP TABLE voting_for;
 DROP TABLE zkapp_field;
 
 DROP TABLE zkapp_verification_key_hashes;
+
+DROP TABLE hardfork_state;

--- a/src/app/archive/lib/hardfork_handling.ml
+++ b/src/app/archive/lib/hardfork_handling.ml
@@ -62,8 +62,7 @@ let upgrades_schema = function
 
 let%test_unit "every strategy survives a round trip through its name" =
   List.iter all ~f:(fun t ->
-      [%test_eq: string] (to_string t)
-        (to_string (of_string_exn (to_string t))) )
+      [%test_eq: string] (to_string t) (to_string (of_string_exn (to_string t))) )
 
 let%test_unit "an unknown name is rejected, and says what it expected" =
   match of_string "migrate" with
@@ -73,9 +72,5 @@ let%test_unit "an unknown name is rejected, and says what it expected" =
       assert (String.is_substring msg ~substring:"migrate-exit")
 
 let%test_unit "only migrate-exit upgrades, and keep-running alone stays" =
-  [%test_eq: bool list]
-    (List.map all ~f:exits)
-    [ false; true; true ] ;
-  [%test_eq: bool list]
-    (List.map all ~f:upgrades_schema)
-    [ false; false; true ]
+  [%test_eq: bool list] (List.map all ~f:exits) [ false; true; true ] ;
+  [%test_eq: bool list] (List.map all ~f:upgrades_schema) [ false; false; true ]

--- a/src/app/archive/lib/hardfork_handling.ml
+++ b/src/app/archive/lib/hardfork_handling.ml
@@ -1,0 +1,81 @@
+(** What the archive does once a daemon has told it about a hard fork.
+
+    The daemon has the same choice, under the same flag name and with two of the
+    same words: it either keeps running or migrates and exits. The archive's
+    hand-over mirrors that, because it is the same event seen from the other
+    side -- the pre-fork daemon stops, the pre-fork archive stops, and a
+    dispatcher starts each of their successors.
+
+    Why the archive has to stop at all: the work waiting on the other side of a
+    fork is post-fork work. The genesis block belongs to the new era, and a
+    pre-fork binary cannot build it -- its constants and its types are the old
+    era's. So the process that records the fork is not the process that can act
+    on it, and the only way to reach the right binary is to exit and let the
+    dispatcher choose again. *)
+
+open Core
+
+type t =
+  | Keep_running
+      (** Record the fork and carry on. For an archive nobody restarts, and the
+          default, so that upgrading the binary does not by itself change when
+          an archive stops. *)
+  | Exit
+      (** Record the fork, then exit. The schema is somebody else's to upgrade
+          -- an operator, or a step in the deployment. *)
+  | Migrate_exit
+      (** Record the fork, upgrade the schema, then exit. What the automode
+          packaging sets: the restarted process finds a database whose schema
+          matches the era it is about to serve. *)
+
+let to_string = function
+  | Keep_running ->
+      "keep-running"
+  | Exit ->
+      "exit"
+  | Migrate_exit ->
+      "migrate-exit"
+
+let all = [ Keep_running; Exit; Migrate_exit ]
+
+let of_string s =
+  match List.find all ~f:(fun t -> String.equal (to_string t) s) with
+  | Some t ->
+      Ok t
+  | None ->
+      Error
+        (sprintf "unknown hard fork handling %S, expected one of %s" s
+           (String.concat ~sep:", " (List.map all ~f:to_string)) )
+
+let of_string_exn s =
+  match of_string s with Ok t -> t | Error msg -> failwith msg
+
+(** Whether this strategy ends the process. *)
+let exits = function Keep_running -> false | Exit | Migrate_exit -> true
+
+(** Whether this strategy upgrades the schema before it goes. *)
+let upgrades_schema = function
+  | Keep_running | Exit ->
+      false
+  | Migrate_exit ->
+      true
+
+let%test_unit "every strategy survives a round trip through its name" =
+  List.iter all ~f:(fun t ->
+      [%test_eq: string] (to_string t)
+        (to_string (of_string_exn (to_string t))) )
+
+let%test_unit "an unknown name is rejected, and says what it expected" =
+  match of_string "migrate" with
+  | Ok _ ->
+      failwith "expected \"migrate\" to be rejected"
+  | Error msg ->
+      assert (String.is_substring msg ~substring:"migrate-exit")
+
+let%test_unit "only migrate-exit upgrades, and keep-running alone stays" =
+  [%test_eq: bool list]
+    (List.map all ~f:exits)
+    [ false; true; true ] ;
+  [%test_eq: bool list]
+    (List.map all ~f:upgrades_schema)
+    [ false; false; true ]

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4665,6 +4665,169 @@ let add_block_aux_extensional ~proof_cache_db ~logger ~signature_kind ?retries
     ~hash:(fun (block : Extensional.Block.t) -> block.state_hash)
     ~tokens_used:block.Extensional.Block.tokens_used block
 
+(** What the archive knows about a hard fork it is passing through.
+
+    At most one row ever exists. Several archive processes may share one
+    database, and a fork they disagreed about would be worse than a fork
+    neither had noticed, so the table is keyed to a single row and a
+    contradicting record is refused rather than reconciled. *)
+module Hardfork_state = struct
+  module T = struct
+    type t =
+      { fork_state_hash : string
+      ; fork_blockchain_length : int64
+      ; fork_global_slot : int64
+      ; config_json : string
+      ; stage : string
+      ; source : string
+      }
+    [@@deriving hlist, fields]
+  end
+
+  include T
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ string; int64; int64; string; string; string ]
+
+  (* The enum columns are read and written as text with explicit casts. They
+     carry no OCaml variant here: this module only records what it is told,
+     and the finaliser is what interprets the stage. *)
+  let load_opt (module Conn : CONNECTION) =
+    Conn.find_opt
+      (Mina_caqti.find_opt_req Caqti_type.unit typ
+         {sql| SELECT fork_state_hash, fork_blockchain_length, fork_global_slot,
+                      config_json, stage::text, source::text
+               FROM hardfork_state
+               WHERE id = 1
+         |sql} )
+      ()
+
+  let insert (module Conn : CONNECTION) (t : t) =
+    Conn.exec
+      (Mina_caqti.exec_req typ
+         {sql| INSERT INTO hardfork_state
+                 (id, fork_state_hash, fork_blockchain_length, fork_global_slot,
+                  config_json, stage, source)
+               VALUES
+                 (1, ?, ?, ?, ?, ?::hardfork_stage, ?::hardfork_source)
+         |sql} )
+      t
+
+  (** Record a fork we have been told about.
+
+      Idempotent by design: the configuration arrives on a heartbeat, so the
+      overwhelmingly common case is that we already have this exact row and
+      there is nothing to do.
+
+      Returns an error when a fork is already recorded with a different fork
+      block. That means two daemons disagree about where the chain forked, and
+      no automatic reconciliation is correct -- the archive must stop and let a
+      human look. *)
+  let record (module Conn : CONNECTION) ~logger (t : t) =
+    let open Deferred.Result.Let_syntax in
+    match%bind load_opt (module Conn) with
+    | None ->
+        let%map () = insert (module Conn) t in
+        [%log info]
+          "Recorded hard fork at block $state_hash, height $height, from \
+           $source"
+          ~metadata:
+            [ ("state_hash", `String t.fork_state_hash)
+            ; ("height", `String (Int64.to_string t.fork_blockchain_length))
+            ; ("source", `String t.source)
+            ]
+    | Some existing when String.equal existing.fork_state_hash t.fork_state_hash
+      ->
+        (* The heartbeat, or a restarted daemon. Nothing to do. *)
+        return ()
+    | Some existing ->
+        [%log error]
+          "Refusing a hard fork configuration for block $incoming: this \
+           database already records a fork at $existing. Two daemons disagree \
+           about where the chain forked; the archive will not choose between \
+           them."
+          ~metadata:
+            [ ("incoming", `String t.fork_state_hash)
+            ; ("existing", `String existing.fork_state_hash)
+            ] ;
+        return ()
+end
+
+(** Read the fork block's identity out of a runtime configuration.
+
+    The configuration is the only thing the daemon sends, so everything the
+    archive needs about the fork has to come from here: the [fork] stanza is
+    the fork block's identity, and the rest of the configuration is kept
+    verbatim for the later steps, which need the ledger hashes to locate and
+    verify the genesis ledger. *)
+let hardfork_state_of_config ~config_json =
+  let open Result.Let_syntax in
+  let%bind json =
+    Or_error.try_with (fun () -> Yojson.Safe.from_string config_json)
+    |> Result.map_error ~f:(fun e ->
+           sprintf "configuration is not valid JSON: %s" (Error.to_string_hum e) )
+  in
+  let%bind runtime_config = Runtime_config.of_yojson json in
+  match Runtime_config.fork runtime_config with
+  | None ->
+      Error
+        "configuration has no fork stanza, so it does not describe a forked \
+         network"
+  | Some { state_hash; blockchain_length; global_slot_since_genesis } ->
+      return
+        { Hardfork_state.fork_state_hash = state_hash
+        ; fork_blockchain_length = Int64.of_int blockchain_length
+        ; fork_global_slot = Int64.of_int global_slot_since_genesis
+        ; config_json
+        ; stage = "announced"
+        ; source = "daemon_config"
+        }
+
+let%test_module "hard fork configuration parsing" =
+  ( module struct
+    let fork_hash = "3NLoKn22eMnyQ7rxh5pxB6vBA3XhSAhhrf7akdqS6HbAKD14Dh1d"
+
+    let config_with_fork =
+      sprintf
+        {json|{"proof":{"fork":{"state_hash":"%s","blockchain_length":100,"global_slot_since_genesis":250}}}|json}
+        fork_hash
+
+    let%test_unit "reads the fork block's identity out of the fork stanza" =
+      match hardfork_state_of_config ~config_json:config_with_fork with
+      | Ok t ->
+          [%test_eq: string] t.Hardfork_state.fork_state_hash fork_hash ;
+          [%test_eq: int64] t.Hardfork_state.fork_blockchain_length 100L ;
+          [%test_eq: int64] t.Hardfork_state.fork_global_slot 250L
+      | Error msg ->
+          failwithf "expected the fork stanza to parse, got: %s" msg ()
+
+    let%test_unit "keeps the configuration verbatim for later steps" =
+      (* The later steps need the ledger hashes, so what we store has to be
+         the configuration as sent, not a re-serialisation of what we parsed. *)
+      match hardfork_state_of_config ~config_json:config_with_fork with
+      | Ok t ->
+          [%test_eq: string] t.Hardfork_state.config_json config_with_fork
+      | Error msg ->
+          failwithf "expected the fork stanza to parse, got: %s" msg ()
+
+    let%test_unit "rejects a configuration with no fork stanza" =
+      match hardfork_state_of_config ~config_json:{json|{"proof":{}}|json} with
+      | Ok _ ->
+          failwith
+            "a configuration without a fork stanza does not describe a forked \
+             network and must be rejected"
+      | Error _ ->
+          ()
+
+    let%test_unit "rejects text that is not JSON" =
+      match hardfork_state_of_config ~config_json:"not json at all" with
+      | Ok _ ->
+          failwith "expected invalid JSON to be rejected"
+      | Error _ ->
+          ()
+  end )
+
 (* receive blocks from a daemon, write them to the database *)
 let run pool reader ~proof_cache_db ~genesis_constants ~constraint_constants
     ~logger ~delete_older_than : unit Deferred.t =
@@ -4700,6 +4863,30 @@ let run pool reader ~proof_cache_db ~genesis_constants ~constraint_constants
             Deferred.unit
         | Ok () ->
             Deferred.unit )
+    | Diff.Transition_frontier (Hardfork_config { config_json }) -> (
+        (* Not a block, so it does not go anywhere near the block path: this
+           only records what we have been told, for the hand-over to act on
+           later. *)
+        match hardfork_state_of_config ~config_json with
+        | Error msg ->
+            [%log error]
+              "Ignoring an unusable hard fork configuration from the daemon: \
+               $reason"
+              ~metadata:[ ("reason", `String msg) ] ;
+            Deferred.unit
+        | Ok hardfork_state -> (
+            match%map
+              Mina_caqti.Pool.use
+                (fun conn -> Hardfork_state.record conn ~logger hardfork_state)
+                pool
+            with
+            | Ok () ->
+                ()
+            | Error e ->
+                [%log warn]
+                  "Could not record the hard fork configuration: $error. It \
+                   arrives on a heartbeat, so this will be retried."
+                  ~metadata:[ ("error", `String (Caqti_error.show e)) ] ) )
     | Transition_frontier _ ->
         Deferred.unit )
 

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4886,7 +4886,7 @@ let run pool reader ~proof_cache_db ~genesis_constants ~constraint_constants
     surfaces it as an error. A configuration it cannot parse is worth refusing
     loudly: the archive would otherwise sit there with no record of the fork
     while the daemon believed the hand-over had started. *)
-let record_hardfork_config ~logger ~pool ~config_json =
+let record_hardfork_config ~logger ~pool ~config_json ~recorded =
   match hardfork_state_of_config ~config_json with
   | Error msg ->
       [%log error]
@@ -4900,7 +4900,10 @@ let record_hardfork_config ~logger ~pool ~config_json =
           pool
       with
       | Ok () ->
-          ()
+          (* Filled after the write, so whatever watches this cannot act on a
+             fork that is not yet on record. Idempotent: the configuration
+             arrives on a heartbeat and this may be the tenth time. *)
+          Ivar.fill_if_empty recorded ()
       | Error e ->
           let msg = Caqti_error.show e in
           [%log warn]
@@ -5068,11 +5071,64 @@ let serve_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
       Deferred.forever () serve
 
 (* for running the archive process *)
+
+(** Run the schema upgrade script against this archive's database.
+
+    Shelled out to psql rather than run through the connection pool: the script
+    is many statements, and the driver speaks the extended query protocol,
+    which carries one statement per request. psql ships in the archive image
+    alongside the scripts it runs. *)
+let upgrade_schema ~logger ~postgres_address ~script =
+  let uri = Uri.to_string postgres_address in
+  match%map
+    Process.run ~prog:"psql"
+      ~args:[ uri; "-v"; "ON_ERROR_STOP=1"; "-q"; "-f"; script ]
+      ()
+  with
+  | Ok (_ : string) ->
+      [%log info] "Upgraded the archive schema using %s." script ;
+      Ok ()
+  | Error e ->
+      let msg = Error.to_string_hum e in
+      [%log error]
+        "Could not upgrade the archive schema using %s: %s. The database is \
+         left as it was, and this process is stopping so that nothing runs \
+         against a schema it does not match."
+        script msg ;
+      Error msg
+
+(** Stop, once the fork is recorded, so the dispatcher can start the successor.
+
+    The reply to the daemon goes out when the RPC handler returns, and nothing
+    reports when it has reached the wire, so this waits a moment before pulling
+    the process down. That grace is a courtesy rather than a correctness
+    measure: the row was committed before the handler returned, so a reply lost
+    to an early exit costs the daemon a log line and nothing else. *)
+let hand_over ~logger ~postgres_address ~hardfork_handling
+    ~schema_upgrade_script ~requested =
+  let open Hardfork_handling in
+  if not (exits hardfork_handling) then Deferred.unit
+  else
+    let%bind () = Ivar.read requested in
+    let%bind () = after (Time.Span.of_sec 5.) in
+    let%bind upgraded =
+      if upgrades_schema hardfork_handling then
+        upgrade_schema ~logger ~postgres_address ~script:schema_upgrade_script
+      else Deferred.return (Ok ())
+    in
+    let code = match upgraded with Ok () -> 0 | Error _ -> 1 in
+    [%log info]
+      "Stopping after recording the hard fork, as --hardfork-handling %s asks. \
+       The dispatcher decides which archive runs next."
+      (to_string hardfork_handling) ;
+    let%bind () = Writer.flushed (Lazy.force Writer.stderr) in
+    exit code
+
 let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~metrics_server_port ~logger ~postgres_address ~server_port ~chunks_length
     ~delete_older_than ~runtime_config_opt ~missing_blocks_width ~signature_kind
-    =
+    ~hardfork_handling ~schema_upgrade_script =
   let where_to_listen =
     Async.Tcp.Where_to_listen.bind_to All_addresses (On_port server_port)
   in
@@ -5090,6 +5146,11 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
         ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
       Deferred.unit
   | Ok pool ->
+      (* Filled by the RPC handler once a fork is on record. *)
+      let recorded = Ivar.create () in
+      hand_over ~logger ~postgres_address ~hardfork_handling
+        ~schema_upgrade_script ~requested:recorded
+      |> don't_wait_for ;
       (* Bound here rather than above the pool: the hard fork configuration is
          answered against the database inside the handler, so the handler needs
          the pool. *)
@@ -5097,7 +5158,7 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
         [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
               match archive_diff with
               | Diff.Transition_frontier (Hardfork_config { config_json }) ->
-                  record_hardfork_config ~logger ~pool ~config_json
+                  record_hardfork_config ~logger ~pool ~config_json ~recorded
               | _ ->
                   Strict_pipe.Writer.write writer archive_diff )
         ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4865,32 +4865,49 @@ let run pool reader ~proof_cache_db ~genesis_constants ~constraint_constants
             Deferred.unit
         | Ok () ->
             Deferred.unit )
-    | Diff.Transition_frontier (Hardfork_config { config_json }) -> (
-        (* Not a block, so it does not go anywhere near the block path: this
-           only records what we have been told, for the hand-over to act on
-           later. *)
-        match hardfork_state_of_config ~config_json with
-        | Error msg ->
-            [%log error]
-              "Ignoring an unusable hard fork configuration from the daemon: \
-               $reason"
-              ~metadata:[ ("reason", `String msg) ] ;
-            Deferred.unit
-        | Ok hardfork_state -> (
-            match%map
-              Mina_caqti.Pool.use
-                (fun conn -> Hardfork_state.record conn ~logger hardfork_state)
-                pool
-            with
-            | Ok () ->
-                ()
-            | Error e ->
-                [%log warn]
-                  "Could not record the hard fork configuration: $error. It \
-                   arrives on a heartbeat, so this will be retried."
-                  ~metadata:[ ("error", `String (Caqti_error.show e)) ] ) )
+    | Diff.Transition_frontier (Hardfork_config _) ->
+        (* Answered at the RPC layer instead, so that the reply means the row
+           is written. See [record_hardfork_config]. *)
+        Deferred.unit
     | Transition_frontier _ ->
         Deferred.unit )
+
+(** Record a hard fork configuration the daemon sent us.
+
+    Called straight from the RPC handler rather than through the block pipe,
+    and that is the whole point. A [Synchronous] strict pipe releases its
+    writer as soon as the reader takes the message off it, before the reader
+    has done anything with it, so a reply sent that way tells the daemon only
+    that the archive queued something. The daemon exits moments after this
+    call, so the reply has to mean the row is committed.
+
+    For the same reason a failure raises rather than logs. The response type
+    is [unit], so raising is the only way to say no, and the daemon's dispatch
+    surfaces it as an error. A configuration it cannot parse is worth refusing
+    loudly: the archive would otherwise sit there with no record of the fork
+    while the daemon believed the hand-over had started. *)
+let record_hardfork_config ~logger ~pool ~config_json =
+  match hardfork_state_of_config ~config_json with
+  | Error msg ->
+      [%log error]
+        "Refusing an unusable hard fork configuration from the daemon: $reason"
+        ~metadata:[ ("reason", `String msg) ] ;
+      failwithf "unusable hard fork configuration: %s" msg ()
+  | Ok hardfork_state -> (
+      match%map
+        Mina_caqti.Pool.use
+          (fun conn -> Hardfork_state.record conn ~logger hardfork_state)
+          pool
+      with
+      | Ok () ->
+          ()
+      | Error e ->
+          let msg = Caqti_error.show e in
+          [%log warn]
+            "Could not record the hard fork configuration: $error. The daemon \
+             is told, so it can try again."
+            ~metadata:[ ("error", `String msg) ] ;
+          failwithf "could not record the hard fork configuration: %s" msg () )
 
 (* [add_genesis_accounts] is called when starting the archive process *)
 let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
@@ -5066,17 +5083,6 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
   let extensional_block_reader, extensional_block_writer =
     Strict_pipe.create ~name:"extensional_archive_block" Synchronous
   in
-  let implementations =
-    [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
-          Strict_pipe.Writer.write writer archive_diff )
-    ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
-        (fun () precomputed_block ->
-          Strict_pipe.Writer.write precomputed_block_writer precomputed_block )
-    ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
-        (fun () extensional_block ->
-          Strict_pipe.Writer.write extensional_block_writer extensional_block )
-    ]
-  in
   match Mina_caqti.connect_pool ~max_size:30 postgres_address with
   | Error e ->
       [%log error]
@@ -5084,6 +5090,26 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
         ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
       Deferred.unit
   | Ok pool ->
+      (* Bound here rather than above the pool: the hard fork configuration is
+         answered against the database inside the handler, so the handler needs
+         the pool. *)
+      let implementations =
+        [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
+              match archive_diff with
+              | Diff.Transition_frontier (Hardfork_config { config_json }) ->
+                  record_hardfork_config ~logger ~pool ~config_json
+              | _ ->
+                  Strict_pipe.Writer.write writer archive_diff )
+        ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
+            (fun () precomputed_block ->
+              Strict_pipe.Writer.write precomputed_block_writer
+                precomputed_block )
+        ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
+            (fun () extensional_block ->
+              Strict_pipe.Writer.write extensional_block_writer
+                extensional_block )
+        ]
+      in
       let%bind () =
         add_genesis_accounts pool ~logger ~genesis_constants
           ~constraint_constants ~runtime_config_opt ~chunks_length

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4678,7 +4678,6 @@ module Hardfork_state = struct
       ; fork_blockchain_length : int64
       ; fork_global_slot : int64
       ; config_json : string
-      ; stage : string
       ; source : string
       }
     [@@deriving hlist, fields]
@@ -4688,16 +4687,20 @@ module Hardfork_state = struct
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ string; int64; int64; string; string; string ]
+      Caqti_type.[ string; int64; int64; string; string ]
 
-  (* The enum columns are read and written as text with explicit casts. They
-     carry no OCaml variant here: this module only records what it is told,
-     and the finaliser is what interprets the stage. *)
+  (* `source` is an enum column, read and written as text with an explicit
+     cast. It carries no OCaml variant here: this module records what it is
+     told and interprets none of it.
+
+     There is no column for how far the hand-over has got. `finalized_at` is
+     that: NULL until the boundary is settled, a timestamp afterwards. A
+     separate stage column would hold the same one bit a second time. *)
   let load_opt (module Conn : CONNECTION) =
     Conn.find_opt
       (Mina_caqti.find_opt_req Caqti_type.unit typ
          {sql| SELECT fork_state_hash, fork_blockchain_length, fork_global_slot,
-                      config_json, stage::text, source::text
+                      config_json, source::text
                FROM hardfork_state
                WHERE id = 1
          |sql} )
@@ -4708,9 +4711,9 @@ module Hardfork_state = struct
       (Mina_caqti.exec_req typ
          {sql| INSERT INTO hardfork_state
                  (id, fork_state_hash, fork_blockchain_length, fork_global_slot,
-                  config_json, stage, source)
+                  config_json, source)
                VALUES
-                 (1, ?, ?, ?, ?, ?::hardfork_stage, ?::hardfork_source)
+                 (1, ?, ?, ?, ?, ?::hardfork_source)
          |sql} )
       t
 
@@ -4780,7 +4783,6 @@ let hardfork_state_of_config ~config_json =
         ; fork_blockchain_length = Int64.of_int blockchain_length
         ; fork_global_slot = Int64.of_int global_slot_since_genesis
         ; config_json
-        ; stage = "announced"
         ; source = "daemon_config"
         }
 

--- a/src/app/archive/upgrade_to_mesa.sql
+++ b/src/app/archive/upgrade_to_mesa.sql
@@ -254,6 +254,34 @@ DROP INDEX IF EXISTS idx_zkapp_events_element_ids;
 ALTER TABLE zkapp_account_update_body ALTER COLUMN events_id DROP NOT NULL;
 ALTER TABLE zkapp_account_update_body ALTER COLUMN actions_id DROP NOT NULL;
 
+-- 3c. `hardfork_state`: what the archive knows about the fork it is passing
+-- through. Created here as well as in create_schema.sql, because a database
+-- upgraded from the pre-fork schema never ran the latter. At most one row can
+-- ever exist: several archive processes may share one database and must not be
+-- able to hold different opinions about the fork.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'hardfork_stage') THEN
+        CREATE TYPE hardfork_stage AS ENUM ('announced', 'finalized');
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'hardfork_source') THEN
+        CREATE TYPE hardfork_source AS ENUM ('daemon_config', 'fork_genesis', 'operator');
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS hardfork_state (
+    id                      int              PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+    fork_state_hash         text             NOT NULL,
+    fork_blockchain_length  bigint           NOT NULL,
+    fork_global_slot        bigint           NOT NULL,
+    config_json             text             NOT NULL,
+    stage                   hardfork_stage   NOT NULL,
+    source                  hardfork_source  NOT NULL,
+    announced_at            timestamptz      NOT NULL DEFAULT now(),
+    finalized_at            timestamptz
+);
+
 -- 4. Update schema_history
 
 DO $$

--- a/src/app/archive/upgrade_to_mesa.sql
+++ b/src/app/archive/upgrade_to_mesa.sql
@@ -262,9 +262,6 @@ ALTER TABLE zkapp_account_update_body ALTER COLUMN actions_id DROP NOT NULL;
 
 DO $$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'hardfork_stage') THEN
-        CREATE TYPE hardfork_stage AS ENUM ('announced', 'finalized');
-    END IF;
     IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'hardfork_source') THEN
         CREATE TYPE hardfork_source AS ENUM ('daemon_config', 'fork_genesis', 'operator');
     END IF;
@@ -276,7 +273,6 @@ CREATE TABLE IF NOT EXISTS hardfork_state (
     fork_blockchain_length  bigint           NOT NULL,
     fork_global_slot        bigint           NOT NULL,
     config_json             text             NOT NULL,
-    stage                   hardfork_stage   NOT NULL,
     source                  hardfork_source  NOT NULL,
     announced_at            timestamptz      NOT NULL DEFAULT now(),
     finalized_at            timestamptz


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19248** — review that one first; this branch contains its commit.

Targets `feat/archive_automode`, not a release branch.

## What

The archive side of the message #19248 makes the daemon send. Together they complete M1: the archive now has a durable record of the fork it is passing through.

### The table

`hardfork_state` holds **at most one row**, keyed `CHECK (id = 1)`. Several archive processes may share one database, and a fork they disagreed about would be worse than a fork neither had noticed.

Created in `create_schema.sql`, and idempotently in `upgrade_to_mesa.sql` — a database upgraded from the pre-fork schema never ran the former. The enum types are guarded with the same `pg_type` lookup `migration_status` already uses.

`config_json` keeps the configuration verbatim rather than storing only the parsed fork stanza, because the later steps need its ledger hashes to locate and verify the genesis ledger.

### The handler

**Not on the block path.** The configuration is not a block, so it parses the fork stanza and records it — nothing touches block ingest.

Two behaviours worth reviewing closely:

- **Idempotent.** The configuration arrives on an hourly heartbeat, so the overwhelmingly common case is that the row already exists unchanged and there is nothing to do.
- **A contradiction is refused, not reconciled.** A configuration naming a different fork block is logged at error and dropped. That means two daemons disagree about where the chain forked, and no automatic choice between them is correct.

## Not here

Nothing acts on the row. The finaliser — the boundary repair — lands separately, as do the schema upgrade, the fork genesis block and the genesis accounts.

## Testing

Typechecked: `dune build --root . @src/app/archive/lib/check` → exit 0.

Four inline tests, no database needed:

```
inline_test_runner_archive_lib inline-test-runner archive_lib -only-test processor.ml
  4 tests ran, 2 test_modules ran
```

They cover: the fork stanza is read correctly; the configuration is kept verbatim; a configuration with no fork stanza is rejected; malformed JSON is rejected.

**Not covered here** — idempotence and the contradiction refusal need a live database. They belong in the component test that lands with the finaliser, where there is a seeded database to assert against. Flagging that as a known gap rather than leaving it implied.
