### PR TITLE
Let the packaging job decide the suite its packages declare

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -34,6 +34,8 @@ let DebianRepo = ../Constants/DebianRepo.dhall
 
 let DockerPublish = ../Constants/Docker/Publish.dhall
 
+let DockerRepo = ../Constants/DockerRepo.dhall
+
 let DebianChannel = ../Constants/DebianChannel.dhall
 
 let Profiles = ../Constants/Profiles.dhall
@@ -71,6 +73,7 @@ let PackagingSpec =
           , deb_legacy_version : Text
           , deb_legacy_githash_config : Text
           , docker_publish : DockerPublish.Type
+          , docker_repo : DockerRepo.Type
           , suffix : Optional Text
           , if_ : Optional B/If
           , includeIf : List Expr.Type
@@ -93,6 +96,7 @@ let PackagingSpec =
           , deb_legacy_githash_config = ""
           , arch = Arch.Type.Amd64
           , docker_publish = DockerPublish.Type.Essential
+          , docker_repo = DockerRepo.Type.InternalEurope
           , if_ = None B/If
           , includeIf = [] : List Expr.Type
           , excludeIf = [] : List Expr.Type
@@ -788,6 +792,7 @@ let docker_commands
                         (     s
                           //  { deb_release =
                                   DebianChannel.lowerName spec.channel
+                              , docker_repo = spec.docker_repo
                               }
                         )
                 )

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -358,6 +358,8 @@ let build_artifacts
                             , Network.foldMinaBuildMainnetEnv nets
                             , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                             , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
+                            , "MINA_DEB_RELEASE=${DebianChannel.lowerName
+                                                    spec.channel}"
                             ]
                           # BuildFlags.buildEnvs spec.buildFlags
                           # spec.extraBuildEnvs
@@ -383,6 +385,10 @@ let build_artifacts
                 }
 
 let commonBuildEnvs =
+    -- MINA_DEB_RELEASE is the channel. builder-helpers.sh writes it into every
+    -- control file as `Suite:` and defaults it to "unstable", so before it was
+    -- passed here a package built for stable still declared itself unstable,
+    -- and only the promotion step put that right.
           \(spec : PackagingSpec.Type)
       ->  let nets = Artifact.networks spec.artifacts
 
@@ -397,6 +403,7 @@ let commonBuildEnvs =
                 , Network.foldMinaBuildMainnetEnv nets
                 , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                 , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
+                , "MINA_DEB_RELEASE=${DebianChannel.lowerName spec.channel}"
                 ]
               # BuildFlags.buildEnvs spec.buildFlags
               # spec.extraBuildEnvs
@@ -777,7 +784,12 @@ let docker_commands
                 DockerImage.ReleaseSpec.Type
                 Command.Type
                 (     \(s : DockerImage.ReleaseSpec.Type)
-                  ->  DockerImage.generateStep s
+                  ->  DockerImage.generateStep
+                        (     s
+                          //  { deb_release =
+                                  DebianChannel.lowerName spec.channel
+                              }
+                        )
                 )
                 flattened_docker_steps
 


### PR DESCRIPTION
Second step towards publishing straight from a build instead of promoting afterwards. One file, thirteen lines.

### The problem

`PackagingSpec.channel` was declared and **read by nothing**. So `MINA_DEB_RELEASE` never reached the packaging job, `builder-helpers.sh` fell back to its own default of `unstable`, and a package built for any other channel still wrote `Suite: unstable` into its control file. Only the promotion step's `deb-session-replace-suite` put that right.

That is the wrong place for it. When one commit produces one version for one channel, the package can say which channel it is for at the moment it is built, and nothing downstream has to rewrite it.

### What changes

The field now reaches two things:

- `MINA_DEB_RELEASE` in the packaging env, which `builder-helpers.sh` writes as `Suite:`
- `DockerImage.ReleaseSpec.deb_release`, previously hard-coded `"unstable"`, so an image installs from the channel its packages belong to

The docker value is overridden **once** in `docker_commands` rather than on each of the eleven `ReleaseSpec` records built in `docker_step`. Every image of a packaging job belongs to the same channel by construction, so naming it eleven times would only create eleven chances to disagree.

### Behaviour

A no-op for every job that does not set the field, because `unstable` is exactly what `builder-helpers.sh` already defaulted to.

I diffed the full rendered pipeline against `develop`. Every changed line is one added `--env MINA_DEB_RELEASE` and nothing else:

```
      1 --env MINA_DEB_RELEASE=experimental
     13 --env MINA_DEB_RELEASE=unstable
```

Lines changed without `MINA_DEB_RELEASE`: **0**. Files added or removed: **none**.

**One job is not a no-op.** `MinaArtifactOnlyDebianBullseye` already asked for `DebianChannel.Type.Experimental` and was silently getting `unstable`. It now builds what it asked for — which is the bug this field being dead was hiding.

### Note for reviewers

`dhall format` discards comments in most positions, so the reasoning lives on the `let commonBuildEnvs` binding — one of the positions it keeps, and the same place the existing comments in that file sit.

`make all` passes: 18 tests, 48 assertions.