### PR TITLE
[Fix] Use the configured `k` in the bootstrap threshold

### DIFF
--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -77,12 +77,18 @@ let is_transition_for_bootstrap
       false
   | `Take ->
       let slack = 5 in
+      (* How far behind the frontier has to be for none of it to be worth
+         keeping: [k] blocks, because that is how much of the chain the
+         frontier holds. This used to be the literal 290 -- mainnet's k -- so
+         on any network configured with a different k the check was measuring
+         against the wrong chain. *)
+      let k = Unsigned.UInt32.to_int Context.consensus_constants.k in
       if
         Length.to_int
           ( Transition_frontier.best_tip frontier
           |> Transition_frontier.Breadcrumb.consensus_state
           |> Consensus.Data.Consensus_state.blockchain_length )
-        + 290 + slack
+        + k + slack
         < Length.to_int
             (Consensus.Data.Consensus_state.blockchain_length
                new_consensus_state.data )


### PR DESCRIPTION
This PR fixes a configuration oversight: the constant 290 is hard-coded, instead of using `k` from the configuration.

`is_transition_for_bootstrap` decides whether a node's frontier is so far behind that none of it is worth keeping and it should bootstrap rather than catch up. The comparison used the literal 290 -- mainnet's `k` -- rather than the `k` the node is actually running with, so on any network configured otherwise it measured against the wrong chain length.

The frontier holds `k` blocks, so `k` is what the check wants. It is already on the consensus constants the context carries, and is read the same way elsewhere.

The effect is asymmetric. Where `k` is smaller than 290 the check is far too lax: a node stays in catchup while its whole frontier is useless, which on a short chain means it never bootstraps at all. Where `k` is larger it is too eager, discarding a frontier that still overlaps the chain.

Mainnet is unaffected, its `k` being 290.