### PR TITLE
Archive automode: insert the fork genesis block

### DIFF
--- a/scripts/tests/archive-automode/fork-genesis-relink.sh
+++ b/scripts/tests/archive-automode/fork-genesis-relink.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Does the fork genesis insert adopt a child that arrived before it?
+#
+# The post-fork chain's second block reaches the archive over the ordinary block
+# path within minutes of the fork, while the genesis insert waits on a ledger.
+# So the usual order is child first, and a block whose parent is absent is
+# stored with parent_id NULL. The ordinary path repairs that for itself; this
+# insert does not go through it, so it has to do the same by hand -- otherwise
+# the boundary stays severed however long the block sits there.
+#
+# Two passes. The first lets the archive build and insert the genesis, which is
+# how the test learns its state hash. The second puts a child in front of it --
+# parent_hash pointing at the genesis, parent_id NULL, exactly what the ordinary
+# path leaves behind -- removes the genesis, and lets the archive insert it
+# again. The child's parent_id must end up as the genesis's id.
+#
+# Hermetic: the configuration carries its ledger as inline accounts, so nothing
+# is fetched. Needs docker and a built archive.exe.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+CT=${CT:-archive-automode-relink}
+PORT=${PORT:-55452}
+ARCHIVE=${ARCHIVE:-$ROOT/_build/default/src/app/archive/archive.exe}
+CONF="$HERE/inline-ledger-fork-config.json"
+FORK_HASH=3NLwkyj6moic1DsdANXVYeuWUWHuDJGDgfz2Q9nADJpA5mBCcmQn
+CONN="postgresql://postgres:postgres@127.0.0.1:${PORT}/archive"
+WORK=$(mktemp -d)
+APID=""
+
+cleanup() {
+  [[ -n "$APID" ]] && kill "$APID" 2>/dev/null
+  docker rm -f "$CT" >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+[[ -x "$ARCHIVE" ]] || {
+  echo "no archive at $ARCHIVE -- build it first:"
+  echo "  dune build src/app/archive/archive.exe"
+  exit 1
+}
+
+echo "=== postgres"
+docker rm -f "$CT" >/dev/null 2>&1
+docker run -d --name "$CT" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=archive \
+  -p "$PORT:5432" postgres:12-alpine >/dev/null || exit 1
+# The image runs initdb against a temporary server and then restarts, so the
+# first connection that succeeds does not mean the real server is up.
+ready=0
+for _ in $(seq 1 120); do
+  if docker exec -e PGPASSWORD=postgres "$CT" psql -U postgres -d archive -c 'SELECT 1' >/dev/null 2>&1; then
+    sleep 1
+    docker exec -e PGPASSWORD=postgres "$CT" psql -U postgres -d archive -c 'SELECT 1' >/dev/null 2>&1 \
+      && { ready=1; break; }
+  fi
+  sleep 1
+done
+[[ "$ready" -eq 1 ]] || { echo "postgres never came up"; exit 1; }
+
+q() { docker exec -e PGPASSWORD=postgres "$CT" psql -qtAX -U postgres -d archive -c "$1" 2>&1; }
+
+docker exec -e PGPASSWORD=postgres -i "$CT" psql -q -U postgres -d archive \
+  < src/app/archive/create_schema.sql >/dev/null 2>&1
+
+# The fork, as a daemon would have left it. Dollar-quoted: the configuration is
+# JSON, and hand-escaping it into a single-quoted literal silently inserts
+# nothing.
+{
+  printf '%s' "INSERT INTO hardfork_state (id, fork_state_hash, fork_blockchain_length, fork_global_slot, config_json, source) VALUES (1, '$FORK_HASH', 1748, 3059, \$cfg\$"
+  cat "$CONF"
+  printf '%s\n' "\$cfg\$, 'daemon_config');"
+} > "$WORK/fork.sql"
+docker exec -e PGPASSWORD=postgres -i "$CT" psql -q -v ON_ERROR_STOP=1 -U postgres -d archive \
+  < "$WORK/fork.sql" || { echo "could not record the fork"; exit 1; }
+
+start_archive() {
+  "$ARCHIVE" run --postgres-uri "$CONN" --server-port "$1" > "$2" 2>&1 &
+  APID=$!
+  for _ in $(seq 1 120); do
+    grep -q "Archive process ready" "$2" 2>/dev/null && break
+    kill -0 "$APID" 2>/dev/null || { echo "the archive exited during startup:"; tail -20 "$2"; exit 1; }
+    sleep 1
+  done
+}
+
+wait_for_genesis() {
+  local found=""
+  for _ in $(seq 1 40); do
+    found=$(q "SELECT state_hash FROM blocks WHERE global_slot_since_hard_fork = 0 AND height > 1;")
+    [[ -n "$found" ]] && break
+    sleep 3
+  done
+  echo "$found"
+}
+
+echo
+echo "=== pass 1: the archive builds and inserts the genesis"
+start_archive 3111 "$WORK/a.log"
+GEN=$(wait_for_genesis)
+kill "$APID" 2>/dev/null; wait "$APID" 2>/dev/null; APID=""
+
+if [[ -z "$GEN" ]]; then
+  echo "  it never inserted one. Why:"
+  grep -oE "Cannot insert the fork genesis block yet.*|Still cannot insert.*" "$WORK/a.log" \
+    | tail -1 | sed 's/^/    /'
+  echo "=== FAIL"
+  exit 1
+fi
+echo "  inserted $GEN"
+
+echo
+echo "=== pass 2: a child arrives first, then the genesis"
+# A block that points at the genesis by hash and has no parent_id: what the
+# ordinary block path leaves when the parent is not there yet.
+q "INSERT INTO blocks (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+     last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id,
+     min_window_density, sub_window_densities, total_currency, ledger_hash, height,
+     global_slot_since_hard_fork, global_slot_since_genesis, protocol_version_id,
+     timestamp, chain_status)
+   SELECT 99000123, 'ORPHANED_CHILD_OF_THE_GENESIS', NULL, state_hash, creator_id,
+     block_winner_id, last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+     next_epoch_data_id, min_window_density, sub_window_densities, total_currency,
+     ledger_hash, height + 1, global_slot_since_hard_fork + 1,
+     global_slot_since_genesis + 1, protocol_version_id, timestamp, 'pending'
+   FROM blocks WHERE state_hash = '$GEN';" >/dev/null
+q "DELETE FROM blocks WHERE state_hash = '$GEN';" >/dev/null
+
+BEFORE=$(q "SELECT coalesce(parent_id::text,'NULL') FROM blocks WHERE state_hash='ORPHANED_CHILD_OF_THE_GENESIS';")
+echo "  child's parent_id before: $BEFORE"
+[[ "$BEFORE" == "NULL" ]] || { echo "=== FAIL: the child was not left unlinked"; exit 1; }
+
+start_archive 3112 "$WORK/b.log"
+LINKED=NULL
+for _ in $(seq 1 40); do
+  LINKED=$(q "SELECT coalesce(parent_id::text,'NULL') FROM blocks WHERE state_hash='ORPHANED_CHILD_OF_THE_GENESIS';")
+  [[ "$LINKED" != "NULL" ]] && break
+  sleep 3
+done
+kill "$APID" 2>/dev/null; APID=""
+
+GENID=$(q "SELECT id FROM blocks WHERE state_hash='$GEN';")
+echo "  child's parent_id after:  $LINKED"
+echo "  the genesis's block id:   ${GENID:-absent}"
+
+echo
+if [[ -n "$GENID" && "$LINKED" == "$GENID" ]]; then
+  echo "=== PASS: the genesis adopted the child"
+else
+  echo "=== FAIL: the child's parent_id is $LINKED, the genesis is ${GENID:-absent}"
+  exit 1
+fi

--- a/scripts/tests/archive-automode/fork-genesis-relink.sh
+++ b/scripts/tests/archive-automode/fork-genesis-relink.sh
@@ -15,6 +15,11 @@
 # path leaves behind -- removes the genesis, and lets the archive insert it
 # again. The child's parent_id must end up as the genesis's id.
 #
+# Then the same question for the other path that inserts a genesis block: the
+# one --config-file takes at startup. It has the same gap for the same reason,
+# and an archive that ingested blocks before it was given a configuration is
+# exactly where it bites.
+#
 # Hermetic: the configuration carries its ledger as inline accounts, so nothing
 # is fetched. Needs docker and a built archive.exe.
 
@@ -149,8 +154,49 @@ echo "  the genesis's block id:   ${GENID:-absent}"
 
 echo
 if [[ -n "$GENID" && "$LINKED" == "$GENID" ]]; then
-  echo "=== PASS: the genesis adopted the child"
+  echo "  ok: the genesis adopted the child"
 else
   echo "=== FAIL: the child's parent_id is $LINKED, the genesis is ${GENID:-absent}"
+  exit 1
+fi
+
+echo
+echo "=== pass 3: the same, through --config-file at startup"
+# That path resolves the configuration and inserts the genesis itself, with no
+# fork recorded anywhere. Clear the fork record so nothing else can do the work,
+# and orphan the child again.
+q "DELETE FROM hardfork_state;" >/dev/null
+q "UPDATE blocks SET parent_id = NULL WHERE state_hash='ORPHANED_CHILD_OF_THE_GENESIS';" >/dev/null
+q "DELETE FROM blocks WHERE state_hash = '$GEN';" >/dev/null
+
+BEFORE=$(q "SELECT coalesce(parent_id::text,'NULL') FROM blocks WHERE state_hash='ORPHANED_CHILD_OF_THE_GENESIS';")
+echo "  child's parent_id before: $BEFORE"
+[[ "$BEFORE" == "NULL" ]] || { echo "=== FAIL: the child was not left unlinked"; exit 1; }
+
+"$ARCHIVE" run --postgres-uri "$CONN" --server-port 3113 --config-file "$CONF" \
+  > "$WORK/c.log" 2>&1 &
+APID=$!
+for _ in $(seq 1 120); do
+  grep -q "Archive process ready" "$WORK/c.log" 2>/dev/null && break
+  kill -0 "$APID" 2>/dev/null || break
+  sleep 1
+done
+LINKED3=NULL
+for _ in $(seq 1 30); do
+  LINKED3=$(q "SELECT coalesce(parent_id::text,'NULL') FROM blocks WHERE state_hash='ORPHANED_CHILD_OF_THE_GENESIS';")
+  [[ "$LINKED3" != "NULL" ]] && break
+  sleep 2
+done
+kill "$APID" 2>/dev/null; APID=""
+
+GENID3=$(q "SELECT id FROM blocks WHERE state_hash='$GEN';")
+echo "  child's parent_id after:  $LINKED3"
+echo "  the genesis's block id:   ${GENID3:-absent}"
+
+echo
+if [[ -n "$GENID3" && "$LINKED3" == "$GENID3" ]]; then
+  echo "=== PASS: both paths adopt the child"
+else
+  echo "=== FAIL: --config-file left the child at $LINKED3, the genesis is ${GENID3:-absent}"
   exit 1
 fi

--- a/scripts/tests/archive-automode/inline-ledger-fork-config.json
+++ b/scripts/tests/archive-automode/inline-ledger-fork-config.json
@@ -1,0 +1,25 @@
+{
+  "genesis": {
+    "genesis_state_timestamp": "2026-04-02T12:00:00Z"
+  },
+  "proof": {
+    "fork": {
+      "state_hash": "3NLwkyj6moic1DsdANXVYeuWUWHuDJGDgfz2Q9nADJpA5mBCcmQn",
+      "blockchain_length": 1748,
+      "global_slot_since_genesis": 3120
+    }
+  },
+  "ledger": {
+    "add_genesis_winner": false,
+    "accounts": [
+      {
+        "pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+        "balance": "1000000"
+      },
+      {
+        "pk": "B62qkamwHMkTvY3t9wu4Aw4LJTDJY4m6Sk48pJ2kSMtV1fxKP2SSzWq",
+        "balance": "500000"
+      }
+    ]
+  }
+}

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5042,12 +5042,23 @@ module Hardfork_finaliser = struct
         `Repeat () )
 end
 
-(** Put the fork genesis block into the database.
+(** Put the fork genesis block into the database, when nobody else has.
 
-    Without it the first post-fork block is inserted with [parent_id] NULL: the
+    Usually somebody has. The archive subscribes to the daemon's
+    [New_breadcrumbs] view, that view is seeded with the frontier's root, and a
+    broadcast pipe hands a new reader the current value -- so a post-fork daemon
+    whose root is still its genesis block delivers it as the first thing the
+    archive hears. Integration tests that run an archive across a fork exercise
+    that path, and the boundary is normally linked with nobody doing anything.
+
+    It is a delivery rather than a guarantee. The daemon sends once and does not
+    replay, so an archive that was down when the post-fork daemon started misses
+    it, as does one that first connects after the frontier root has advanced
+    past the genesis, or one restored from a backup taken before the fork. Then
+    the first produced post-fork block is stored with [parent_id] NULL: the
     chain is severed at the boundary, canonicalisation cannot walk across it,
-    and the missing-block metrics misread. Nothing raises an error when that
-    happens, which is why it is worth doing automatically.
+    and the missing-block metrics misread, with nothing raising an error. This
+    is the fallback for that, and the reason it also relinks.
 
     The block cannot be built from the configuration alone. Its consensus state
     needs the genesis ledger's total currency, which no configuration carries,

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5443,6 +5443,21 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
                   ~constraint_constants:precomputed_values.constraint_constants
                   genesis_block ~accounts_accessed:[] ~accounts_created:[]
               in
+              (* Adopt whatever is already pointing at this block.
+
+                 An archive that ingested blocks before it was given a
+                 configuration stored the first of them with parent_id NULL,
+                 because its parent was not there. Inserting the parent now does
+                 not fix that by itself: the ordinary block path calls
+                 set_parent_id_if_null on every insert, and this one does not go
+                 through it. *)
+              let%bind.Deferred.Result () =
+                Block.set_parent_id_if_null
+                  (module Conn)
+                  ~parent_hash:
+                    (State_hash.With_state_hashes.state_hash genesis_block)
+                  ~parent_id:genesis_block_id
+              in
               let%bind.Deferred.Result { ledger_hash; _ } =
                 Block.load (module Conn) ~id:genesis_block_id
               in

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4801,6 +4801,16 @@ let hardfork_state_of_config ~config_json =
         ; source = "daemon_config"
         }
 
+(** Make text safe to put inside a log message.
+
+    The logger reads [$name] in a message as an interpolation placeholder and
+    refuses to emit a message whose placeholders have no matching metadata. Text
+    that came from somewhere else is data, not a template, and Postgres error
+    text in particular quotes the statement it failed on -- [$1], [$2] and all.
+    Formatting one of those into a message turns the whole line into "invalid
+    log call", losing exactly the diagnostic that was worth having. *)
+let for_log_message = String.tr ~target:'$' ~replacement:'.'
+
 (** Settle the chain boundary a hard fork leaves behind.
 
     After a fork the last blocks before it are stuck: canonicalisation only
@@ -4994,7 +5004,7 @@ module Hardfork_finaliser = struct
                     [%log info]
                       "Not settling the fork boundary yet: %s. This will be \
                        retried."
-                      (describe reason) ;
+                      (for_log_message (describe reason)) ;
                     let%map (_ : bool) = unlock conn in
                     ()
                 | Ok (fork_block, ancestry) ->
@@ -5244,14 +5254,14 @@ module Fork_genesis_block = struct
               [%log info]
                 "Cannot insert the fork genesis block yet: %s. This will be \
                  retried."
-                (describe reason)
+                (for_log_message (describe reason))
           | Error reason ->
               [%log warn]
                 "Still cannot insert the fork genesis block after %s: %s. The \
                  genesis ledger has not arrived. This will keep being retried, \
                  and will succeed on its own once the ledger is uploaded."
                 (Time.Span.to_string_hum waited)
-                (describe reason)
+                (for_log_message (describe reason))
         in
         let%map () =
           after (if still_expected then brisk_interval else patient_interval)

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5091,11 +5091,18 @@ module Fork_genesis_block = struct
         | Error msg ->
             Deferred.return (Error (Ledger_unavailable msg))
         | Ok runtime_config -> (
+            (* Caught, not just matched on. Resolving a configuration raises for
+               anything the Error case does not cover -- a state hash that is
+               not base58 gets as far as building the constraint constants and
+               throws there -- and this runs on a loop in a process that has an
+               archive to serve. An unusable configuration is a reason to say so
+               and try again later, never a reason to take the process down. *)
             match%map
-              Genesis_ledger_helper.init_from_config_file ~logger
-                ~proof_level:Genesis_constants.Compiled.proof_level
-                ~genesis_constants ~constraint_constants runtime_config
-                ~cli_proof_level:None
+              Monitor.try_with_join_or_error ~here:[%here] (fun () ->
+                  Genesis_ledger_helper.init_from_config_file ~logger
+                    ~proof_level:Genesis_constants.Compiled.proof_level
+                    ~genesis_constants ~constraint_constants runtime_config
+                    ~cli_proof_level:None )
             with
             | Error err ->
                 Error (Ledger_unavailable (Error.to_string_hum err))

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5126,64 +5126,85 @@ module Fork_genesis_block = struct
     | Ok None ->
         return (Error No_fork_recorded)
     | Ok (Some hardfork_state) -> (
-        (* The block has to be built before it can be named, so presence is
-           checked afterwards. That is cheap once the ledger is resolved
-           locally, which it is on every attempt after the first. *)
-        match%bind
-          build ~logger ~genesis_constants ~constraint_constants
-            ~config_json:hardfork_state.Hardfork_state.config_json
-        with
-        | Error reason ->
-            return (Error reason)
-        | Ok (genesis_block, constraint_constants) -> (
-            let state_hash =
-              State_hash.With_state_hashes.state_hash genesis_block
-              |> State_hash.to_base58_check
-            in
-            match%bind
-              Mina_caqti.Pool.use
-                (fun conn ->
-                  let open Deferred.Result.Let_syntax in
-                  match%bind already_present conn ~state_hash with
-                  | true ->
-                      return `Already_present
-                  | false ->
-                      let%bind block_id =
-                        Block.add_if_doesn't_exist conn ~logger
-                          ~constraint_constants genesis_block
-                          ~accounts_accessed:[] ~accounts_created:[]
-                      in
-                      (* Adopt the children that got here first.
+        (* Look for the block before building one.
 
-                         The post-fork chain's second block reaches the archive
-                         over the ordinary block path within minutes of the
-                         fork, while this insert waits on a ledger from S3. So
-                         the usual order is child first, and a block whose
-                         parent is absent is stored with parent_id NULL. The
-                         ordinary path repairs that for itself -- every insert
-                         calls set_parent_id_if_null -- but this one does not
-                         go through it, so without this the boundary stays
-                         severed however long the block sits here. *)
-                      let%map () =
-                        Block.set_parent_id_if_null conn
-                          ~parent_hash:
-                            (State_hash.With_state_hashes.state_hash
-                               genesis_block )
-                          ~parent_id:block_id
-                      in
-                      `Inserted )
-                pool
+           Building means resolving the genesis ledger, and resolving it means
+           opening it as a RocksDB, which this process then holds. A second
+           attempt finds the lock taken and fails with "No locks available", so
+           an attempt that builds every time works exactly once and then never
+           again. It also means an archive that has long since inserted the
+           block would go on materialising a ledger of tens of megabytes for
+           the rest of its life.
+
+           The block is recognisable without building it: an era genesis is the
+           block above the fork with global_slot_since_hard_fork = 0. *)
+        match%bind
+          Mina_caqti.Pool.use
+            (fun conn ->
+              Hardfork_sql.fork_block_above_height conn
+                ~height:hardfork_state.Hardfork_state.fork_blockchain_length )
+            pool
+        with
+        | Error e ->
+            return (Error (Insert_failed (Caqti_error.show e)))
+        | Ok (Some _) ->
+            return (Ok `Already_present)
+        | Ok None -> (
+            match%bind
+              build ~logger ~genesis_constants ~constraint_constants
+                ~config_json:hardfork_state.Hardfork_state.config_json
             with
-            | Error e ->
-                return (Error (Insert_failed (Caqti_error.show e)))
-            | Ok `Already_present ->
-                return (Ok `Already_present)
-            | Ok `Inserted ->
-                [%log info]
-                  "Inserted the fork genesis block $state_hash. The post-fork \
-                   chain now links to the pre-fork one."
-                  ~metadata:[ ("state_hash", `String state_hash) ] ;
-                return (Ok `Inserted) ) )
+            | Error reason ->
+                return (Error reason)
+            | Ok (genesis_block, constraint_constants) -> (
+                let state_hash =
+                  State_hash.With_state_hashes.state_hash genesis_block
+                  |> State_hash.to_base58_check
+                in
+                match%bind
+                  Mina_caqti.Pool.use
+                    (fun conn ->
+                      let open Deferred.Result.Let_syntax in
+                      match%bind already_present conn ~state_hash with
+                      | true ->
+                          return `Already_present
+                      | false ->
+                          let%bind block_id =
+                            Block.add_if_doesn't_exist conn ~logger
+                              ~constraint_constants genesis_block
+                              ~accounts_accessed:[] ~accounts_created:[]
+                          in
+                          (* Adopt the children that got here first.
+
+                             The post-fork chain's second block reaches the archive
+                             over the ordinary block path within minutes of the
+                             fork, while this insert waits on a ledger from S3. So
+                             the usual order is child first, and a block whose
+                             parent is absent is stored with parent_id NULL. The
+                             ordinary path repairs that for itself -- every insert
+                             calls set_parent_id_if_null -- but this one does not
+                             go through it, so without this the boundary stays
+                             severed however long the block sits here. *)
+                          let%map () =
+                            Block.set_parent_id_if_null conn
+                              ~parent_hash:
+                                (State_hash.With_state_hashes.state_hash
+                                   genesis_block )
+                              ~parent_id:block_id
+                          in
+                          `Inserted )
+                    pool
+                with
+                | Error e ->
+                    return (Error (Insert_failed (Caqti_error.show e)))
+                | Ok `Already_present ->
+                    return (Ok `Already_present)
+                | Ok `Inserted ->
+                    [%log info]
+                      "Inserted the fork genesis block $state_hash. The \
+                       post-fork chain now links to the pre-fork one."
+                      ~metadata:[ ("state_hash", `String state_hash) ] ;
+                    return (Ok `Inserted) ) ) )
 
   (** How long the ledger is expected to take to appear, and how often to look
       while that is still the expectation.

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5002,6 +5002,161 @@ module Hardfork_finaliser = struct
         `Repeat () )
 end
 
+(** Put the fork genesis block into the database.
+
+    Without it the first post-fork block is inserted with [parent_id] NULL: the
+    chain is severed at the boundary, canonicalisation cannot walk across it,
+    and the missing-block metrics misread. Nothing raises an error when that
+    happens, which is why it is worth doing automatically.
+
+    The block cannot be built from the configuration alone. Its consensus state
+    needs the genesis ledger's total currency, which no configuration carries,
+    so the ledger has to be resolved first -- locally if it is already there,
+    otherwise fetched and checked against the [s3_data_hash] the daemon
+    recorded over the tarball it produced.
+
+    That makes this the first step in the hand-over that depends on something
+    outside the archive, so it is written to assume the ledger is not there yet
+    and to keep asking. *)
+module Fork_genesis_block = struct
+  (** Resolving the ledger reaches outside the archive, so every failure here is
+      a reason to try again later rather than to give up. *)
+  type not_ready =
+    | No_fork_recorded
+    | Ledger_unavailable of string
+    | Insert_failed of string
+
+  let describe = function
+    | No_fork_recorded ->
+        "no hard fork has been recorded for this database"
+    | Ledger_unavailable msg ->
+        sprintf "the genesis ledger could not be resolved: %s" msg
+    | Insert_failed msg ->
+        sprintf "the fork genesis block could not be inserted: %s" msg
+
+  let already_present (module Conn : CONNECTION) ~state_hash =
+    let open Deferred.Result.Let_syntax in
+    let%map id =
+      Block.find_opt
+        (module Conn)
+        ~state_hash:(State_hash.of_base58_check_exn state_hash)
+    in
+    Option.is_some id
+
+  (** Resolve the ledger and build the block.
+
+      [init_from_config_file] searches the local ledger directories first and
+      falls back to the configured bucket, verifying the download before use, so
+      this is cheap on the second and later attempts. *)
+  let build ~logger ~genesis_constants ~constraint_constants ~config_json =
+    match hardfork_state_of_config ~config_json with
+    | Error msg ->
+        Deferred.return (Error (Ledger_unavailable msg))
+    | Ok _ -> (
+        match
+          Runtime_config.of_yojson (Yojson.Safe.from_string config_json)
+        with
+        | Error msg ->
+            Deferred.return (Error (Ledger_unavailable msg))
+        | Ok runtime_config -> (
+            match%map
+              Genesis_ledger_helper.init_from_config_file ~logger
+                ~proof_level:Genesis_constants.Compiled.proof_level
+                ~genesis_constants ~constraint_constants runtime_config
+                ~cli_proof_level:None
+            with
+            | Error err ->
+                Error (Ledger_unavailable (Error.to_string_hum err))
+            | Ok precomputed_values ->
+                (* Named rather than punned: a punned [hash] resolves to
+                   [With_hash.hash] instead of the bound field. *)
+                let With_hash.{ data = block; hash = the_hash }, _ =
+                  Mina_block.genesis ~precomputed_values
+                in
+                Ok
+                  ( With_hash.{ data = block; hash = the_hash }
+                  , precomputed_values.constraint_constants ) ) )
+
+  (** One attempt. Returns without doing anything once the block is in place, so
+      it is safe to call on a loop. *)
+  let attempt ~logger ~genesis_constants ~constraint_constants ~pool =
+    let open Deferred.Let_syntax in
+    match%bind
+      Mina_caqti.Pool.use (fun conn -> Hardfork_state.load_opt conn) pool
+    with
+    | Error e ->
+        return (Error (Insert_failed (Caqti_error.show e)))
+    | Ok None ->
+        return (Error No_fork_recorded)
+    | Ok (Some hardfork_state) -> (
+        (* The block has to be built before it can be named, so presence is
+           checked afterwards. That is cheap once the ledger is resolved
+           locally, which it is on every attempt after the first. *)
+        match%bind
+          build ~logger ~genesis_constants ~constraint_constants
+            ~config_json:hardfork_state.Hardfork_state.config_json
+        with
+        | Error reason ->
+            return (Error reason)
+        | Ok (genesis_block, constraint_constants) -> (
+            let state_hash =
+              State_hash.With_state_hashes.state_hash genesis_block
+              |> State_hash.to_base58_check
+            in
+            match%bind
+              Mina_caqti.Pool.use
+                (fun conn ->
+                  let open Deferred.Result.Let_syntax in
+                  match%bind already_present conn ~state_hash with
+                  | true ->
+                      return `Already_present
+                  | false ->
+                      let%map (_ : int) =
+                        Block.add_if_doesn't_exist conn ~logger
+                          ~constraint_constants genesis_block
+                          ~accounts_accessed:[] ~accounts_created:[]
+                      in
+                      `Inserted )
+                pool
+            with
+            | Error e ->
+                return (Error (Insert_failed (Caqti_error.show e)))
+            | Ok `Already_present ->
+                return (Ok `Already_present)
+            | Ok `Inserted ->
+                [%log info]
+                  "Inserted the fork genesis block $state_hash. The post-fork \
+                   chain now links to the pre-fork one."
+                  ~metadata:[ ("state_hash", `String state_hash) ] ;
+                return (Ok `Inserted) ) )
+
+  (** Keep trying until the block is in place.
+
+      Deliberately slow: each attempt may fetch a ledger of tens of megabytes,
+      so this polls in minutes rather than seconds. Nothing waits on it -- the
+      archive serves reads throughout, and the boundary repair is independent. *)
+  let run ~logger ~genesis_constants ~constraint_constants
+      ?(interval = Time.Span.of_min 5.) ~pool () =
+    Deferred.repeat_until_finished () (fun () ->
+        let%bind () =
+          match%map
+            attempt ~logger ~genesis_constants ~constraint_constants ~pool
+          with
+          | Ok `Inserted | Ok `Already_present ->
+              ()
+          | Error No_fork_recorded ->
+              (* Ordinary on a database that has never seen a fork. *)
+              ()
+          | Error reason ->
+              [%log info]
+                "Cannot insert the fork genesis block yet: $reason. This will \
+                 be retried."
+                ~metadata:[ ("reason", `String (describe reason)) ]
+        in
+        let%map () = after interval in
+        `Repeat () )
+end
+
 let%test_module "hard fork configuration parsing" =
   ( module struct
     let fork_hash = "3NLoKn22eMnyQ7rxh5pxB6vBA3XhSAhhrf7akdqS6HbAKD14Dh1d"
@@ -5382,6 +5537,12 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
          runs in the background and only ever writes chain_status. *)
       Hardfork_finaliser.run ~logger
         ~required_confirmations:hardfork_confirmations ~pool ()
+      |> don't_wait_for ;
+      (* Put the fork genesis block in place, so the post-fork chain links to
+         the pre-fork one. Independent of the repair above: neither waits on the
+         other, and both are no-ops until a fork is recorded. *)
+      Fork_genesis_block.run ~logger ~genesis_constants ~constraint_constants
+        ~pool ()
       |> don't_wait_for ;
       serve_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
         ~block_window_duration_ms:constraint_constants.block_window_duration_ms

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5143,10 +5143,28 @@ module Fork_genesis_block = struct
                   | true ->
                       return `Already_present
                   | false ->
-                      let%map (_ : int) =
+                      let%bind block_id =
                         Block.add_if_doesn't_exist conn ~logger
                           ~constraint_constants genesis_block
                           ~accounts_accessed:[] ~accounts_created:[]
+                      in
+                      (* Adopt the children that got here first.
+
+                         The post-fork chain's second block reaches the archive
+                         over the ordinary block path within minutes of the
+                         fork, while this insert waits on a ledger from S3. So
+                         the usual order is child first, and a block whose
+                         parent is absent is stored with parent_id NULL. The
+                         ordinary path repairs that for itself -- every insert
+                         calls set_parent_id_if_null -- but this one does not
+                         go through it, so without this the boundary stays
+                         severed however long the block sits here. *)
+                      let%map () =
+                        Block.set_parent_id_if_null conn
+                          ~parent_hash:
+                            (State_hash.With_state_hashes.state_hash
+                               genesis_block )
+                          ~parent_id:block_id
                       in
                       `Inserted )
                 pool
@@ -5162,14 +5180,31 @@ module Fork_genesis_block = struct
                   ~metadata:[ ("state_hash", `String state_hash) ] ;
                 return (Ok `Inserted) ) )
 
+  (** How long the ledger is expected to take to appear, and how often to look
+      while that is still the expectation.
+
+      The daemon writes the tarballs as it generates the configuration, and
+      something else puts them where this archive can fetch them. That upload
+      is not instant and it is not this archive's to observe, so the first
+      stretch is treated as ordinary waiting. *)
+  let brisk_interval = Time.Span.of_sec 30.
+
+  let brisk_for = Time.Span.of_min 15.
+
+  let patient_interval = Time.Span.of_min 5.
+
   (** Keep trying until the block is in place.
 
-      Deliberately slow: each attempt may fetch a ledger of tens of megabytes,
-      so this polls in minutes rather than seconds. Nothing waits on it -- the
-      archive serves reads throughout, and the boundary repair is independent. *)
-  let run ~logger ~genesis_constants ~constraint_constants
-      ?(interval = Time.Span.of_min 5.) ~pool () =
+      Never gives up. Stopping would leave the archive permanently without the
+      fork genesis block, and nothing would say so; an upload that arrives an
+      hour late should still be picked up. What changes with time is the noise:
+      for the first [brisk_for] this is expected waiting and is logged as such,
+      and after that it is something an operator should look at. *)
+  let run ~logger ~genesis_constants ~constraint_constants ~pool () =
+    let started = Time.now () in
     Deferred.repeat_until_finished () (fun () ->
+        let waited = Time.diff (Time.now ()) started in
+        let still_expected = Time.Span.( < ) waited brisk_for in
         let%bind () =
           match%map
             attempt ~logger ~genesis_constants ~constraint_constants ~pool
@@ -5179,13 +5214,22 @@ module Fork_genesis_block = struct
           | Error No_fork_recorded ->
               (* Ordinary on a database that has never seen a fork. *)
               ()
-          | Error reason ->
+          | Error reason when still_expected ->
               [%log info]
-                "Cannot insert the fork genesis block yet: $reason. This will \
-                 be retried."
-                ~metadata:[ ("reason", `String (describe reason)) ]
+                "Cannot insert the fork genesis block yet: %s. This will be \
+                 retried."
+                (describe reason)
+          | Error reason ->
+              [%log warn]
+                "Still cannot insert the fork genesis block after %s: %s. The \
+                 genesis ledger has not arrived. This will keep being retried, \
+                 and will succeed on its own once the ledger is uploaded."
+                (Time.Span.to_string_hum waited)
+                (describe reason)
         in
-        let%map () = after interval in
+        let%map () =
+          after (if still_expected then brisk_interval else patient_interval)
+        in
         `Repeat () )
 end
 


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19252** → #19249 → #19248 — review those first.

Targets `feat/archive_automode`.

## The problem

The fork genesis block sits at `fork_len + 1` and its `previous_state_hash` is the fork block's hash, so it is the link between the pre-fork and post-fork chains.

Without it, the first post-fork block is inserted with `parent_id` NULL — `Block.add_parts_if_doesn't_exist` resolves the parent by looking up `previous_state_hash`, finds nothing, and stores NULL. The chain is severed at the boundary, canonicalisation cannot walk across it, and the missing-block metrics misread.

All of that happens **silently**. No error is raised, which is why it is worth automating rather than documenting.

## A correction to the design

The design note said this step needs only the configuration. **That is wrong**, and the PR is shaped by the correction.

`Mina_block.genesis` requires `Precomputed_values`, whose genesis consensus state needs the genesis ledger's **total currency**. No configuration carries that. The `--from-config-hashes-only` path in `mina_cli_entrypoint.ml` marks the boundary precisely: it derives a *chain id* from configuration hashes, but it cannot derive a block.

So the ledger has to be resolved first, and this becomes the first step of the hand-over that depends on anything outside the archive.

## What

`Genesis_ledger_helper.init_from_config_file` searches the local ledger directories first, falls back to the configured bucket, and **verifies the download against `s3_data_hash`** — the SHA3 the daemon computed over the tarball it produced — before using it.

Because that reaches outside the archive, the loop assumes the ledger is not there yet:

- **Polls in minutes, not seconds.** Each attempt may fetch tens of megabytes; the retry interval is 5 minutes.
- **Every failure is a retry.** A missing ledger, an unreachable bucket, a hash mismatch on a partially-replicated object — all are reasons to come back later, never to accept an unverified ledger.
- **Cheap after the first success.** The helper caches locally, so later attempts resolve without a fetch.
- **Idempotent.** The block is looked up by state hash before insertion; a second attempt does nothing.
- **A no-op until a fork is recorded**, so no flag is needed to disable it.

It runs independently of the boundary repair from #19252. Neither waits on the other.

## Not here

`genesis_accounts` — the table and the load. It shares this ledger resolution, and once the ledger is materialised enumerating accounts is nearly free, but it has its own failure modes and its own resilience requirements and deserves its own review.

## Testing

```
dune build --root . @src/app/archive/lib/check @src/app/archive/cli/check  -> exit 0
inline tests: 4 tests ran, 2 test_modules ran
```

The inline tests cover configuration parsing only, unchanged from #19249.

**Nothing here is exercised behaviourally.** Resolving a ledger and inserting a genesis block needs a real ledger tarball and a seeded database. This belongs in the component test alongside the boundary repair's four refusal paths, and I would not rely on either at a real fork before that exists.

## One thing worth review attention

`build` resolves the ledger on **every** attempt before checking whether the block is already present, because the block cannot be named until it is built. After the first success the resolution is local and cheap, but if you would rather short-circuit on a state hash recorded somewhere, that is a reasonable alternative I did not take.
