### PR TITLE
Bump mina-release-toolkit to 0.0.5

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -8,11 +8,7 @@
 --       deliberately when a newer toolkit is wanted.
 -- NOTE: the amd64 mina-toolchain images are on b8d9c69 (carries the
 --       mina-bench-upload benchmark uploader), while bookworm arm64 stays on
---       ffab0f8. The mina-bench-upload install is amd64-only, so the arm64
---       image content is identical either way; ffab0f8 is already published
---       and the arm64 toolchain build under QEMU is flaky, so there is nothing
---       to gain from rebuilding it. Reunify the sha on the next full toolchain
---       bump.
+--       ffab0f8.
 -- NOTE: minaBase* are the published common base-deps images on docker.io. The tag
 --       format matches build.sh's HASHTAG for service=mina-base: <githash>-<codename>-<network>.
 --       These are frozen references, like minaToolchain*: the daemon/archive/hardfork
@@ -25,21 +21,21 @@
 { toolchainBase =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/ci-toolchain-base:v4"
 , minaToolchainBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-toolchain:b8d9c69-bookworm-devnet"
+    { amd64 = "docker.io/minaprotocol/mina-toolchain:4e95b64-bookworm-devnet"
     , arm64 =
-        "docker.io/minaprotocol/mina-toolchain:ffab0f8-bookworm-devnet-arm64"
+        "docker.io/minaprotocol/mina-toolchain:4e95b64-bookworm-devnet-arm64"
     }
 , minaToolchainBullseye.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:b8d9c69-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:4e95b64-bullseye-devnet"
 , minaToolchainNoble.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:b8d9c69-noble-devnet"
+    "docker.io/minaprotocol/mina-toolchain:4e95b64-noble-devnet"
 , minaToolchainJammy.amd64 =
-    "docker.io/minaprotocol/mina-toolchain:b8d9c69-jammy-devnet"
+    "docker.io/minaprotocol/mina-toolchain:4e95b64-jammy-devnet"
 , minaToolchain =
-    "docker.io/minaprotocol/mina-toolchain:b8d9c69-bullseye-devnet"
+    "docker.io/minaprotocol/mina-toolchain:4e95b64-bullseye-devnet"
 , minaBaseBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet"
-    , arm64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet-arm64"
+    { amd64 = "docker.io/minaprotocol/mina-base:4e95b64-bookworm-devnet"
+    , arm64 = "docker.io/minaprotocol/mina-base:4e95b64-bookworm-devnet-arm64"
     }
 , minaBaseBullseye.amd64 =
     "docker.io/minaprotocol/mina-base:86b89d0-bullseye-devnet"

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -52,5 +52,5 @@
 , xrefcheck =
     "europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/dkhamsing/awesome_bot:latest"
 , nixos = "gcr.io/o1labs-192920/nix-unstable:1.0.0"
-, minaReleaseToolkit = "ghcr.io/minaprotocol/mina-release-toolkit:0.0.3"
+, minaReleaseToolkit = "ghcr.io/minaprotocol/mina-release-toolkit:0.0.5"
 }


### PR DESCRIPTION
One line. Moves the pinned toolkit image from `0.0.3` to [`0.0.5`](https://github.com/MinaProtocol/mina-release-toolkit/releases/tag/v0.0.5).

### Why now

`0.0.5` adds **`release-manager publish`** — put already-built `.deb` files into a repository unchanged, then confirm each one is listed at the version and architecture it was built with. That is what the release pipeline will call instead of `manager.sh`, so the pin has to move before the publish job can exist.

It also puts **`deb-s3` in the runtime image**. Without it `release-manager` could not write to an APT repository from this image at all — which is why the image and the command are one bump rather than two.

### Is it safe for what already uses this image?

Two jobs consume it today: `Command/CacheManagerTest.dhall` (`buildkite-cache-manager`) and `Command/DebianModifications.dhall` (`deb-toolkit session`).

Between `v0.0.3` and `v0.0.5` the `deb-toolkit`, `deb-s3` and `dhall-buildkite` **submodule pointers did not move**, and `buildkite-cache-manager` was not touched. So both consumers get identical binaries.

I checked that by running them in both images rather than by reading the diff:

| | `0.0.3` | `0.0.5` |
|---|---|---|
| `deb-toolkit --version` | `deb-builder 0.1.0` | `deb-builder 0.1.0` |
| `deb-toolkit session` verbs | `apply help insert move open read-field remove rename-package replace replace-suite reversion save` | identical |
| `buildkite-cache-manager` | present | present |
| `deb-s3` with `exist` | — | ✅ new |
| `release-manager publish` | cache-and-re-version | ✅ publishes as built |

The tag is annotated and the release notes are on the toolkit side. `make all` passes: 18 tests, 48 assertions.