### PR TITLE
Archive automode: load the genesis ledger accounts

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -624,3 +624,42 @@ CREATE TABLE hardfork_state
 , announced_at            timestamptz      NOT NULL DEFAULT now()
 , finalized_at            timestamptz
 );
+
+/* -----------------------------------------------------------------------
+   Genesis ledger accounts
+
+   The state every account was in when an era's genesis ledger was
+   established. These accounts were accessed by no transaction -- they are
+   initial conditions, not block effects -- so they do not belong in
+   accounts_accessed, which means exactly "what blocks did".
+
+   Needed because a balance query is a snapshot lookup: it finds the most
+   recent block at or below the requested height where the account appears.
+   An account untouched since its era's genesis appears in no such block, and
+   without this table the query answers zero rather than its real balance.
+
+   APPEND ONLY, keyed by the height the ledger takes effect at. A database
+   spans every era it has lived through, and a balance query at a pre-fork
+   height still needs the earlier era's genesis balance for an account that was
+   untouched throughout it. Deleting a previous era's rows makes that question
+   unanswerable forever.
+
+   Timing columns are NULL for untimed accounts.
+*/
+
+CREATE TABLE genesis_accounts
+( genesis_height           bigint  NOT NULL
+, public_key               text    NOT NULL
+, token                    text    NOT NULL
+, balance                  text    NOT NULL
+, nonce                    bigint  NOT NULL
+, initial_minimum_balance  text
+, cliff_time               bigint
+, cliff_amount             text
+, vesting_period           bigint
+, vesting_increment        text
+, PRIMARY KEY (genesis_height, public_key, token)
+);
+
+CREATE INDEX idx_genesis_accounts_lookup
+  ON genesis_accounts(public_key, token, genesis_height DESC);

--- a/src/app/archive/downgrade_to_berkeley.sql
+++ b/src/app/archive/downgrade_to_berkeley.sql
@@ -220,9 +220,11 @@ END $$;
 -- 3c. Remove what the upgrade added for the automatic hard fork hand-over.
 --
 -- Unlike the changes above, this one is not lossy in the way that matters: the
--- row describes a fork a berkeley-era archive has no use for, and the daemon
--- sends its configuration again when the archive is upgraded.
+-- rows describe a fork a berkeley-era archive has no use for. The daemon sends
+-- its configuration again when the archive is upgraded, and the genesis
+-- accounts are read again from the genesis ledger.
 
+DROP TABLE IF EXISTS genesis_accounts;
 DROP TABLE IF EXISTS hardfork_state;
 DROP TYPE  IF EXISTS hardfork_source;
 

--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -110,4 +110,6 @@ DROP TABLE zkapp_field;
 
 DROP TABLE zkapp_verification_key_hashes;
 
+DROP TABLE genesis_accounts;
+
 DROP TABLE hardfork_state;

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5012,26 +5012,6 @@ module Hardfork_finaliser = struct
                         ; ("count", `Int marked)
                         ] ) ) )
       pool
-
-  (** Keep attempting until the boundary is settled.
-
-      Runs in the background while the archive serves reads. The repair only
-      writes [chain_status], so there is nothing to coordinate with ingest. *)
-  let run ~logger ~required_confirmations ?(interval = Time.Span.of_sec 60.)
-      ~pool () =
-    Deferred.repeat_until_finished () (fun () ->
-        let%bind () =
-          match%map attempt ~logger ~required_confirmations ~pool with
-          | Ok () ->
-              ()
-          | Error e ->
-              [%log warn]
-                "Could not settle the fork boundary: $error. This will be \
-                 retried."
-                ~metadata:[ ("error", `String (Caqti_error.show e)) ]
-        in
-        let%map () = after interval in
-        `Repeat () )
 end
 
 (** Put the fork genesis block into the database.
@@ -5186,58 +5166,6 @@ module Fork_genesis_block = struct
                    chain now links to the pre-fork one."
                   ~metadata:[ ("state_hash", `String state_hash) ] ;
                 return (Ok `Inserted) ) )
-
-  (** How long the ledger is expected to take to appear, and how often to look
-      while that is still the expectation.
-
-      The daemon writes the tarballs as it generates the configuration, and
-      something else puts them where this archive can fetch them. That upload
-      is not instant and it is not this archive's to observe, so the first
-      stretch is treated as ordinary waiting. *)
-  let brisk_interval = Time.Span.of_sec 30.
-
-  let brisk_for = Time.Span.of_min 15.
-
-  let patient_interval = Time.Span.of_min 5.
-
-  (** Keep trying until the block is in place.
-
-      Never gives up. Stopping would leave the archive permanently without the
-      fork genesis block, and nothing would say so; an upload that arrives an
-      hour late should still be picked up. What changes with time is the noise:
-      for the first [brisk_for] this is expected waiting and is logged as such,
-      and after that it is something an operator should look at. *)
-  let run ~logger ~genesis_constants ~constraint_constants ~pool () =
-    let started = Time.now () in
-    Deferred.repeat_until_finished () (fun () ->
-        let waited = Time.diff (Time.now ()) started in
-        let still_expected = Time.Span.( < ) waited brisk_for in
-        let%bind () =
-          match%map
-            attempt ~logger ~genesis_constants ~constraint_constants ~pool
-          with
-          | Ok `Inserted | Ok `Already_present ->
-              ()
-          | Error No_fork_recorded ->
-              (* Ordinary on a database that has never seen a fork. *)
-              ()
-          | Error reason when still_expected ->
-              [%log info]
-                "Cannot insert the fork genesis block yet: %s. This will be \
-                 retried."
-                (describe reason)
-          | Error reason ->
-              [%log warn]
-                "Still cannot insert the fork genesis block after %s: %s. The \
-                 genesis ledger has not arrived. This will keep being retried, \
-                 and will succeed on its own once the ledger is uploaded."
-                (Time.Span.to_string_hum waited)
-                (describe reason)
-        in
-        let%map () =
-          after (if still_expected then brisk_interval else patient_interval)
-        in
-        `Repeat () )
 end
 
 (** Load an era's genesis ledger accounts.
@@ -5448,30 +5376,107 @@ module Genesis_accounts = struct
                                   , `String (Int64.to_string genesis_height) )
                                 ] ;
                             Ok `Loaded ) ) ) ) )
+end
 
-  (** Keep trying until the accounts are in place.
+(** The hand-over, in order.
 
-      Slow on purpose: an attempt may fetch and materialise a ledger of tens of
-      megabytes. Nothing waits on this -- the archive is already serving, the
-      boundary is already repaired, and the only consequence of it never
-      finishing is that untouched accounts answer zero, which is the position
-      today. *)
-  let run ~logger ~genesis_constants ~constraint_constants
-      ?(interval = Time.Span.of_min 10.) ~pool () =
-    Deferred.repeat_until_finished () (fun () ->
+    Three things have to happen to a database after a fork: the post-fork
+    genesis block goes in, the boundary the fork stranded is settled, and the
+    era's genesis accounts are loaded. Each used to run on its own timer, and
+    the order they happened in was whatever the timers produced.
+
+    They are sequenced here instead, behind one gate: the genesis ledger.
+
+    Only the genesis block strictly needs that ledger. The boundary repair needs
+    nothing but the blocks already in the database, so it could go first and
+    finish sooner. It deliberately does not. A database with its chain_status
+    rewritten, no genesis block and no genesis accounts is three different
+    half-states to recognise and reason about; one that has not started yet is
+    one. The blocks in question have been stranded since the fork, so a wait
+    measured in minutes buys that simplicity cheaply.
+
+    Every step is idempotent, so a pass that stops early costs only the pass. *)
+module Hand_over = struct
+  (** How long the ledger is expected to take, and how often to look while that
+      is still the expectation. The daemon writes the tarballs as it generates
+      the configuration and something else uploads them; that is not instant,
+      and not this archive's to observe. *)
+  let brisk_interval = Time.Span.of_sec 30.
+
+  let brisk_for = Time.Span.of_min 15.
+
+  let patient_interval = Time.Span.of_min 5.
+
+  (** One pass. Stops at the first step that cannot finish. *)
+  let attempt ~logger ~genesis_constants ~constraint_constants
+      ~required_confirmations ~pool ~still_expected =
+    let open Deferred.Let_syntax in
+    match%bind
+      Fork_genesis_block.attempt ~logger ~genesis_constants
+        ~constraint_constants ~pool
+    with
+    | Error Fork_genesis_block.No_fork_recorded ->
+        (* Ordinary on a database that has never seen a fork. *)
+        return ()
+    | Error reason ->
+        let detail = Fork_genesis_block.describe reason in
+        if still_expected then
+          [%log info]
+            "The hand-over is waiting on the genesis ledger: %s. Nothing else \
+             runs until it is here."
+            detail
+        else
+          [%log warn]
+            "The hand-over is still waiting on the genesis ledger: %s. Nothing \
+             else runs until it is here. This keeps being retried and will \
+             carry on by itself once the ledger is uploaded."
+            detail ;
+        return ()
+    | Ok (`Inserted | `Already_present) -> (
+        (* The ledger is in hand, so the rest of the hand-over may run. Each of
+           these reports its own outcome and declines for its own reasons. *)
         let%bind () =
           match%map
-            attempt ~logger ~genesis_constants ~constraint_constants ~pool
+            Hardfork_finaliser.attempt ~logger ~required_confirmations ~pool
           with
-          | Ok (`Loaded | `Already_loaded | `No_fork_recorded) ->
+          | Ok () ->
               ()
-          | Error msg ->
-              [%log info]
-                "Cannot load the genesis accounts yet: $reason. This will be \
+          | Error e ->
+              [%log warn]
+                "Could not settle the fork boundary: $error. This will be \
                  retried."
-                ~metadata:[ ("reason", `String msg) ]
+                ~metadata:[ ("error", `String (Caqti_error.show e)) ]
         in
-        let%map () = after interval in
+        match%map
+          Genesis_accounts.attempt ~logger ~genesis_constants
+            ~constraint_constants ~pool
+        with
+        | Ok (`Loaded | `Already_loaded | `No_fork_recorded) ->
+            ()
+        | Error msg ->
+            [%log info]
+              "Cannot load the genesis accounts yet: %s. This will be retried."
+              msg )
+
+  (** Keep going until there is nothing left to do.
+
+      Never gives up. An archive that quietly stopped trying would be worse than
+      one that keeps asking, and an upload that lands an hour late should still
+      be picked up. What changes with time is only how loudly it says so. *)
+  let run ~logger ~genesis_constants ~constraint_constants
+      ~required_confirmations ~pool () =
+    let started = Time.now () in
+    Deferred.repeat_until_finished () (fun () ->
+        let still_expected =
+          Time.Span.( < ) (Time.diff (Time.now ()) started) brisk_for
+        in
+        let%bind () =
+          attempt ~logger ~genesis_constants ~constraint_constants
+            ~required_confirmations ~pool ~still_expected
+        in
+        let%map () =
+          after (if still_expected then brisk_interval else patient_interval)
+        in
         `Repeat () )
 end
 
@@ -5937,23 +5942,12 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
                      Deferred.unit ) ) )
       |> don't_wait_for ;
       (*Update archive metrics*)
-      (* Settle the fork boundary, if a fork has been recorded. A no-op on a
-         database that has never seen one, so it needs no flag to disable: it
-         runs in the background and only ever writes chain_status. *)
-      Hardfork_finaliser.run ~logger
+      (* The hand-over a fork leaves behind: the genesis block, the stranded
+         boundary, the genesis accounts, in that order and all behind the
+         genesis ledger. A no-op on a database that has never seen a fork, so it
+         needs no flag to disable. *)
+      Hand_over.run ~logger ~genesis_constants ~constraint_constants
         ~required_confirmations:hardfork_confirmations ~pool ()
-      |> don't_wait_for ;
-      (* Put the fork genesis block in place, so the post-fork chain links to
-         the pre-fork one. Independent of the repair above: neither waits on the
-         other, and both are no-ops until a fork is recorded. *)
-      Fork_genesis_block.run ~logger ~genesis_constants ~constraint_constants
-        ~pool ()
-      |> don't_wait_for ;
-      (* Last step of the hand-over, and the only one whose failure costs
-         nothing else: everything about the fork is already correct by the time
-         this runs. *)
-      Genesis_accounts.run ~logger ~genesis_constants ~constraint_constants
-        ~pool ()
       |> don't_wait_for ;
       serve_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
         ~block_window_duration_ms:constraint_constants.block_window_duration_ms

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5157,6 +5157,236 @@ module Fork_genesis_block = struct
         `Repeat () )
 end
 
+(** Load an era's genesis ledger accounts.
+
+    A balance query is a snapshot lookup: it finds the most recent block at or
+    below the requested height where the account appears. An account untouched
+    since its era's genesis appears in no such block, so without these rows the
+    query answers zero rather than the real balance -- with a 200, which for an
+    exchange is worse than an error.
+
+    Last step of the hand-over, and the only one that can fail without
+    consequence for the rest. Everything else about the fork is already correct
+    by the time this runs; if it never completes, the position is exactly what
+    it is today. *)
+module Genesis_accounts = struct
+  let insert_batch (module Conn : CONNECTION) ~genesis_height rows =
+    let open Deferred.Result.Let_syntax in
+    Mina_caqti.deferred_result_list_fold rows ~init:() ~f:(fun () row ->
+        let public_key, token, balance, nonce, timing = row in
+        let ( initial_minimum_balance
+            , cliff_time
+            , cliff_amount
+            , vesting_period
+            , vesting_increment ) =
+          match timing with
+          | None ->
+              (None, None, None, None, None)
+          | Some (imb, ct, ca, vp, vi) ->
+              (Some imb, Some ct, Some ca, Some vp, Some vi)
+        in
+        let%map () =
+          Conn.exec
+            (Mina_caqti.exec_req
+               Caqti_type.(
+                 t2
+                   (t4 int64 string string string)
+                   (t2
+                      (t3 int64 (option string) (option int64))
+                      (t3 (option string) (option int64) (option string)) ))
+               {sql| INSERT INTO genesis_accounts
+                       (genesis_height, public_key, token, balance, nonce,
+                        initial_minimum_balance, cliff_time, cliff_amount,
+                        vesting_period, vesting_increment)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               |sql} )
+            ( (genesis_height, public_key, token, balance)
+            , ( (nonce, initial_minimum_balance, cliff_time)
+              , (cliff_amount, vesting_period, vesting_increment) ) )
+        in
+        () )
+
+  let already_loaded (module Conn : CONNECTION) ~genesis_height =
+    Conn.find
+      (Mina_caqti.find_req Caqti_type.int64 Caqti_type.bool
+         "SELECT EXISTS (SELECT 1 FROM genesis_accounts WHERE genesis_height = \
+          ?)" )
+      genesis_height
+
+  (** Project a ledger account onto what a balance query needs.
+
+      Deliberately not a full account snapshot: this table answers "what was
+      the balance and vesting schedule", not "reconstruct the ledger". *)
+  let row_of_account (account : Mina_base.Account.t) =
+    let timing =
+      match account.timing with
+      | Mina_base.Account.Timing.Untimed ->
+          None
+      | Timed
+          { initial_minimum_balance
+          ; cliff_time
+          ; cliff_amount
+          ; vesting_period
+          ; vesting_increment
+          } ->
+          Some
+            ( Currency.Balance.to_string initial_minimum_balance
+            , Mina_numbers.Global_slot_since_genesis.to_uint32 cliff_time
+              |> Unsigned.UInt32.to_int64
+            , Currency.Amount.to_string cliff_amount
+            , Mina_numbers.Global_slot_span.to_uint32 vesting_period
+              |> Unsigned.UInt32.to_int64
+            , Currency.Amount.to_string vesting_increment )
+    in
+    ( Signature_lib.Public_key.Compressed.to_base58_check account.public_key
+    , Mina_base.Token_id.to_string account.token_id
+    , Currency.Balance.to_string account.balance
+    , Mina_base.Account.Nonce.to_uint32 account.nonce
+      |> Unsigned.UInt32.to_int64
+    , timing )
+
+  (** One attempt: resolve the ledger, enumerate it, write every row in a single
+      transaction.
+
+      Atomic on purpose. Completion is detected by the presence of any row for
+      this genesis height, so a partial write would look like a finished one --
+      all or nothing removes that failure mode and makes restarts safe without
+      any progress bookkeeping. *)
+  let attempt ~logger ~genesis_constants ~constraint_constants ~pool =
+    let open Deferred.Let_syntax in
+    match%bind
+      Mina_caqti.Pool.use (fun conn -> Hardfork_state.load_opt conn) pool
+    with
+    | Error e ->
+        return (Error (Caqti_error.show e))
+    | Ok None ->
+        return (Ok `No_fork_recorded)
+    | Ok (Some hardfork_state) -> (
+        let genesis_height =
+          Int64.( + ) hardfork_state.Hardfork_state.fork_blockchain_length 1L
+        in
+        match%bind
+          Mina_caqti.Pool.use
+            (fun conn -> already_loaded conn ~genesis_height)
+            pool
+        with
+        | Error e ->
+            return (Error (Caqti_error.show e))
+        | Ok true ->
+            return (Ok `Already_loaded)
+        | Ok false -> (
+            match%bind
+              Fork_genesis_block.build ~logger ~genesis_constants
+                ~constraint_constants
+                ~config_json:hardfork_state.Hardfork_state.config_json
+            with
+            | Error reason ->
+                return (Error (Fork_genesis_block.describe reason))
+            | Ok _ -> (
+                (* Resolve again for the ledger itself. Local and cheap: the
+                   helper cached it during the build above. *)
+                match
+                  Runtime_config.of_yojson
+                    (Yojson.Safe.from_string
+                       hardfork_state.Hardfork_state.config_json )
+                with
+                | Error msg ->
+                    return (Error msg)
+                | Ok runtime_config -> (
+                    match%bind
+                      Genesis_ledger_helper.init_from_config_file ~logger
+                        ~proof_level:Genesis_constants.Compiled.proof_level
+                        ~genesis_constants ~constraint_constants runtime_config
+                        ~cli_proof_level:None
+                    with
+                    | Error err ->
+                        return (Error (Error.to_string_hum err))
+                    | Ok precomputed_values -> (
+                        let ledger =
+                          Precomputed_values.genesis_ledger precomputed_values
+                          |> Lazy.force
+                        in
+                        let%bind account_ids =
+                          let%map s = Mina_ledger.Ledger.accounts ledger in
+                          Account_id.Set.to_list s
+                        in
+                        let rows =
+                          List.filter_map account_ids ~f:(fun acct_id ->
+                              let open Option.Let_syntax in
+                              let%bind loc =
+                                Mina_ledger.Ledger.location_of_account ledger
+                                  acct_id
+                              in
+                              let%map account =
+                                Mina_ledger.Ledger.get ledger loc
+                              in
+                              row_of_account account )
+                        in
+                        let total = List.length rows in
+                        [%log info]
+                          "Loading $count genesis accounts for the ledger at \
+                           height $height"
+                          ~metadata:
+                            [ ("count", `Int total)
+                            ; ( "height"
+                              , `String (Int64.to_string genesis_height) )
+                            ] ;
+                        let%map result =
+                          Mina_caqti.Pool.use
+                            (fun ((module Conn : CONNECTION) as conn) ->
+                              let open Deferred.Result.Let_syntax in
+                              let%bind () = Conn.start () in
+                              match%bind.Deferred
+                                insert_batch conn ~genesis_height rows
+                              with
+                              | Ok () ->
+                                  Conn.commit ()
+                              | Error e ->
+                                  let%map.Deferred (_ : _ result) =
+                                    Conn.rollback ()
+                                  in
+                                  Error e )
+                            pool
+                        in
+                        match result with
+                        | Error e ->
+                            Error (Caqti_error.show e)
+                        | Ok () ->
+                            [%log info]
+                              "Loaded $count genesis accounts at height $height"
+                              ~metadata:
+                                [ ("count", `Int total)
+                                ; ( "height"
+                                  , `String (Int64.to_string genesis_height) )
+                                ] ;
+                            Ok `Loaded ) ) ) ) )
+
+  (** Keep trying until the accounts are in place.
+
+      Slow on purpose: an attempt may fetch and materialise a ledger of tens of
+      megabytes. Nothing waits on this -- the archive is already serving, the
+      boundary is already repaired, and the only consequence of it never
+      finishing is that untouched accounts answer zero, which is the position
+      today. *)
+  let run ~logger ~genesis_constants ~constraint_constants
+      ?(interval = Time.Span.of_min 10.) ~pool () =
+    Deferred.repeat_until_finished () (fun () ->
+        let%bind () =
+          match%map
+            attempt ~logger ~genesis_constants ~constraint_constants ~pool
+          with
+          | Ok (`Loaded | `Already_loaded | `No_fork_recorded) ->
+              ()
+          | Error msg ->
+              [%log info]
+                "Cannot load the genesis accounts yet: $reason. This will be \
+                 retried."
+                ~metadata:[ ("reason", `String msg) ]
+        in
+        let%map () = after interval in
+        `Repeat () )
+end
+
 let%test_module "hard fork configuration parsing" =
   ( module struct
     let fork_hash = "3NLoKn22eMnyQ7rxh5pxB6vBA3XhSAhhrf7akdqS6HbAKD14Dh1d"
@@ -5542,6 +5772,12 @@ let setup_server ~proof_cache_db ~(genesis_constants : Genesis_constants.t)
          the pre-fork one. Independent of the repair above: neither waits on the
          other, and both are no-ops until a fork is recorded. *)
       Fork_genesis_block.run ~logger ~genesis_constants ~constraint_constants
+        ~pool ()
+      |> don't_wait_for ;
+      (* Last step of the hand-over, and the only one whose failure costs
+         nothing else: everything about the fork is already correct by the time
+         this runs. *)
+      Genesis_accounts.run ~logger ~genesis_constants ~constraint_constants
         ~pool ()
       |> don't_wait_for ;
       serve_metrics_server ~logger ~metrics_server_port ~missing_blocks_width

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -5376,11 +5376,16 @@ module Genesis_accounts = struct
                 | Error msg ->
                     return (Error msg)
                 | Ok runtime_config -> (
+                    (* Caught rather than only matched on, for the same reason
+                       as in [Fork_genesis_block.build]: resolving a
+                       configuration raises for what the Error case does not
+                       cover, and this runs on a loop inside a live archive. *)
                     match%bind
-                      Genesis_ledger_helper.init_from_config_file ~logger
-                        ~proof_level:Genesis_constants.Compiled.proof_level
-                        ~genesis_constants ~constraint_constants runtime_config
-                        ~cli_proof_level:None
+                      Monitor.try_with_join_or_error ~here:[%here] (fun () ->
+                          Genesis_ledger_helper.init_from_config_file ~logger
+                            ~proof_level:Genesis_constants.Compiled.proof_level
+                            ~genesis_constants ~constraint_constants
+                            runtime_config ~cli_proof_level:None )
                     with
                     | Error err ->
                         return (Error (Error.to_string_hum err))

--- a/src/app/archive/upgrade_to_mesa.sql
+++ b/src/app/archive/upgrade_to_mesa.sql
@@ -282,6 +282,30 @@ CREATE TABLE IF NOT EXISTS hardfork_state (
     finalized_at            timestamptz
 );
 
+-- 3d. `genesis_accounts`: the state every account was in when an era's genesis
+-- ledger was established. Not block effects, so not in accounts_accessed.
+-- Append only and keyed by the height the ledger takes effect at: a database
+-- spans every era it has lived through, and a balance query at a pre-fork
+-- height still needs the earlier era's genesis balance for an account that was
+-- untouched throughout it.
+
+CREATE TABLE IF NOT EXISTS genesis_accounts (
+    genesis_height           bigint  NOT NULL,
+    public_key               text    NOT NULL,
+    token                    text    NOT NULL,
+    balance                  text    NOT NULL,
+    nonce                    bigint  NOT NULL,
+    initial_minimum_balance  text,
+    cliff_time               bigint,
+    cliff_amount             text,
+    vesting_period           bigint,
+    vesting_increment        text,
+    PRIMARY KEY (genesis_height, public_key, token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_genesis_accounts_lookup
+  ON genesis_accounts(public_key, token, genesis_height DESC);
+
 -- 4. Update schema_history
 
 DO $$


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19255** → #19252 → #19249 → #19248.

Targets `feat/archive_automode`. This completes the archive-side hand-over.

## The problem

A balance query is a **snapshot lookup**: `Balance_from_last_relevant_command` finds the most recent block at or below the requested height where the account appears, and reads the balance recorded there.

An account untouched since its era's genesis appears in no such block. When that lookup misses, Rosetta returns:

```ocaml
| None ->
    (* account doesn' exist yet at the request block, return zero balance *)
    ... { liquid_balance = 0L; total_balance = 0L }, nonce = 0
```

**Zero balance, 200 OK.** For an exchange a confident wrong number is worse than a failure.

## Why a new table rather than `accounts_accessed`

Those accounts were accessed by no transaction. They are **initial conditions, not block effects**, so putting them in `accounts_accessed` would break what that table means — "what blocks did".

It also buys something practical. The existing loader walks a normalised cascade per account — `public_keys` → `account_identifiers` → `timing_info` → `accounts_accessed` — resolving foreign keys row by row, which is why a chunk size of 5000 once OOM-killed a 16 GiB Postgres and why the default is 100. A flat table has no cascade.

## Append only, keyed by height

```sql
PRIMARY KEY (genesis_height, public_key, token)
```

A database spans every era it has lived through. A balance query at a **pre-fork** height still needs the earlier era's genesis balance for an account untouched throughout that era, so clearing a previous era's rows makes that question unanswerable forever. Rows are added at each fork, never removed.

Timing columns are NULL for untimed accounts, which maps directly onto Rosetta's `timing_info_opt`.

## Atomic, so restarts are safe

The load runs in **one transaction**. Completion is detected by the presence of any row for that genesis height — so a partial write would look like a finished one. All-or-nothing removes that failure mode and means no progress bookkeeping is needed at all.

## Where it sits

Last step of the hand-over, and **the only one whose failure costs nothing else**. By the time it runs the boundary is repaired, the fork genesis is in place, and the archive is serving reads. If it never completes, the position is exactly what it is today: untouched accounts answer zero. Polls every 10 minutes; each attempt may materialise a ledger of tens of megabytes.

## Not here

**The Rosetta query change.** The table is written but nothing reads it yet — Rosetta still does the single-source lookup and still returns zero on a miss. That is Track B (R2), it belongs with the reader work, and it is where the `UNION ALL` over `accounts_accessed` and `genesis_accounts` goes.

So this PR fixes the *cause* and leaves the *symptom* until the reader side lands. Worth knowing if you are measuring the series by whether balances are right yet.

## Testing

```
dune build --root . @src/app/archive/lib/check @src/app/archive/cli/check  -> exit 0
inline tests: 4 tests ran, 2 test_modules ran
```

**Nothing here is exercised behaviourally**, same as #19252 and #19255. This one needs a real ledger tarball and a database to assert against, and the interesting cases are the transaction boundary and the append-across-eras behaviour. Both belong in the component test, which is now the largest outstanding gap in the series.

## Worth review attention

- `attempt` resolves the ledger **twice** — once through `Fork_genesis_block.build` to confirm it is resolvable, then again for the ledger itself. The second is local and cheap because the first cached it, but it is redundant and a shared resolution would be cleaner.
- The projection is deliberately narrow: public key, token, balance, nonce, timing. Enough for a balance query, **not** enough to reconstruct a ledger. If anything later wants a full account snapshot this table will not serve it.
