### PR TITLE
Rosetta: read genesis accounts instead of answering zero

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -138,9 +138,85 @@ module Sql = struct
       ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       ~initial_minimum_balance
 
+  (* The genesis ledger's accounts, which no block ever touched.
+
+     Without these an account that has not moved since its era's genesis
+     appears in no accounts_accessed row, the block lookup misses, and the
+     balance reads as zero. They live in their own table because they are
+     initial conditions rather than block effects. *)
+  module Genesis_account = struct
+    type t =
+      { genesis_height : int64
+      ; balance : int64
+      ; nonce : int64
+      ; timing : Archive_lib.Processor.Timing_info.t option
+      }
+
+    (* Ordered by genesis_height DESC so that on a chain with several forks the
+       most recent era at or below the requested height wins. *)
+    let query =
+      Mina_caqti.find_opt_req
+        Caqti_type.(t3 string string int64)
+        Caqti_type.(
+          t2 (t3 int64 int64 int64)
+            (t2
+               (t3 (option string) (option int64) (option string))
+               (t2 (option int64) (option string)) ))
+        {sql|
+          SELECT genesis_height, balance::bigint, nonce,
+                 initial_minimum_balance, cliff_time, cliff_amount,
+                 vesting_period, vesting_increment
+          FROM genesis_accounts
+          WHERE public_key = $1
+            AND token = $2
+            AND genesis_height <= $3
+          ORDER BY genesis_height DESC
+          LIMIT 1
+        |sql}
+
+    let run (module Conn : Mina_caqti.CONNECTION) ~requested_block_height
+        ~address ~token_id =
+      let open Deferred.Result.Let_syntax in
+      let%map row_opt =
+        Conn.find_opt query (address, token_id, requested_block_height)
+      in
+      Option.map row_opt
+        ~f:(fun
+             ( (genesis_height, balance, nonce)
+             , ( (initial_minimum_balance, cliff_time, cliff_amount)
+               , (vesting_period, vesting_increment) ) )
+           ->
+          let timing =
+            match
+              ( initial_minimum_balance
+              , cliff_time
+              , cliff_amount
+              , vesting_period
+              , vesting_increment )
+            with
+            | ( Some initial_minimum_balance
+              , Some cliff_time
+              , Some cliff_amount
+              , Some vesting_period
+              , Some vesting_increment ) ->
+                Some
+                  { Archive_lib.Processor.Timing_info.account_identifier_id = 0
+                  ; initial_minimum_balance
+                  ; cliff_time
+                  ; cliff_amount
+                  ; vesting_period
+                  ; vesting_increment
+                  }
+            | _ ->
+                (* Untimed: the whole balance is liquid. *)
+                None
+          in
+          { genesis_height; balance; nonce; timing } )
+  end
+
   let find_current_balance (module Conn : Mina_caqti.CONNECTION)
       ~requested_block_global_slot_since_genesis ~last_relevant_command_info
-      ?timing_id () =
+      ?timing_id ?timing_info () =
     let open Deferred.Result.Let_syntax in
     let open Unsigned in
     let ( _
@@ -150,11 +226,15 @@ module Sql = struct
       last_relevant_command_info
     in
     let%bind timing_info_opt =
-      match timing_id with
-      | Some timing_id ->
+      (* [timing_info] is supplied directly by the genesis-ledger path, whose
+         schedule is stored flat rather than behind a timing_info row. *)
+      match (timing_info, timing_id) with
+      | Some _, _ ->
+          return timing_info
+      | None, Some timing_id ->
           Archive_lib.Processor.Timing_info.load_opt (module Conn) timing_id
           |> Errors.Lift.sql ~context:"Finding timing info"
-      | None ->
+      | None, None ->
           return None
     in
     let end_slot =
@@ -231,18 +311,63 @@ module Sql = struct
       ; hash = requested_block_hash
       }
     in
+    (* The genesis ledger is the other place an account's state can come from,
+       and it is the only one for an account untouched since its era began. *)
+    let%bind genesis_account_opt =
+      Genesis_account.run
+        (module Conn)
+        ~requested_block_height ~address ~token_id
+      |> Errors.Lift.sql ~context:"Finding the account in a genesis ledger"
+    in
     let%bind balance_info, nonce =
-      match last_relevant_command_info_opt with
-      | None ->
-          (* account doesn' exist yet at the request block, return zero balance *)
-          let nonce = Unsigned.UInt64.of_int 0 in
-          Deferred.Result.return
-            ({ Balance_info.liquid_balance = 0L; total_balance = 0L }, nonce)
-      | Some (last_relevant_command_info, timing_id) ->
+      (* Both sources answer the same question -- the most recent known state at
+         or below the requested height -- so the later one wins. On a chain with
+         several forks a newer era's genesis can legitimately supersede an older
+         block, which is why this compares heights instead of preferring one
+         source outright. *)
+      let from_blocks_height =
+        Option.map last_relevant_command_info_opt
+          ~f:(fun ((height, _, _, _), _) -> height)
+      in
+      let genesis_height =
+        Option.map genesis_account_opt ~f:(fun g ->
+            g.Genesis_account.genesis_height )
+      in
+      let use_genesis =
+        match (from_blocks_height, genesis_height) with
+        | None, Some _ ->
+            true
+        | Some block_height, Some genesis_height ->
+            Int64.( > ) genesis_height block_height
+        | _, None ->
+            false
+      in
+      match
+        (use_genesis, genesis_account_opt, last_relevant_command_info_opt)
+      with
+      | true, Some genesis_account, _ ->
+          find_current_balance
+            (module Conn)
+            ~requested_block_global_slot_since_genesis
+            ~last_relevant_command_info:
+              ( genesis_account.Genesis_account.genesis_height
+              , requested_block_global_slot_since_genesis
+              , genesis_account.balance
+              , genesis_account.nonce )
+            ?timing_info:genesis_account.timing ()
+      | _, _, Some (last_relevant_command_info, timing_id) ->
           find_current_balance
             (module Conn)
             ~requested_block_global_slot_since_genesis
             ~last_relevant_command_info ~timing_id ()
+      | _ ->
+          (* Neither source knows this account at this height, so it genuinely
+             did not exist yet. This zero is now an answer rather than a gap:
+             before the genesis ledger was consulted, the same zero was also
+             returned for accounts that existed and simply had not moved. *)
+          let nonce = Unsigned.UInt64.of_int 0 in
+          Deferred.Result.return
+            ({ Balance_info.liquid_balance = 0L; total_balance = 0L }, nonce)
     in
     Deferred.Result.return (requested_block_identifier, balance_info, nonce)
 end


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19257**, which writes the table this reads.

Targets `feat/archive_automode`.

## The bug

`Balance_from_last_relevant_command` is a snapshot lookup: it finds the most recent block at or below the requested height where the account appears, and reads the balance recorded there. When that misses:

```ocaml
| None ->
    (* account doesn' exist yet at the request block, return zero balance *)
    ... { liquid_balance = 0L; total_balance = 0L }, nonce = 0
```

The query cannot distinguish **"the account did not exist yet"** from **"I have no data for it"**. An account untouched since its era's genesis appears in no block, so it takes the second path and is reported as holding nothing — with a 200.

## The fix

Rosetta now consults `genesis_accounts` as a second source, and **the later one wins**:

```
from_blocks : the most recent accounts_accessed row at or below H
from_genesis: the most recent genesis ledger at or below H
              -> whichever has the greater height
```

Heights are compared rather than one source being preferred outright. That matters on a chain with several forks: an account untouched since the *most recent* fork has stale `accounts_accessed` rows from an earlier era, and the newer genesis legitimately supersedes them. Preferring blocks would return a pre-fork balance; preferring genesis would ignore real activity.

`find_current_balance` gains `?timing_info` so the genesis path can pass a vesting schedule directly — those columns are flat, since such accounts have no `timing_info` row to point at.

## The zero now means something

It remains when **both** sources miss, and in that case it is correct: the account genuinely did not exist at that height. Before this change the same zero was also returned for accounts that existed and had simply not moved, which is what made it dangerous.

I have **not** turned the remaining case into an error. That would be a behaviour change for every Rosetta client and is a product decision, not an implementation one. It is tracked separately as R3. What this PR does is make the zero honest, which is the precondition for that conversation.

## Testing

```
dune build --root . @src/app/rosetta/lib/check   -> exit 0
inline tests, account.ml: 2 tests ran, 6 test_modules ran
```

The existing balance tests still pass. **No new test covers the new path**, because both the block source and the genesis source need a seeded database to exercise, and the interesting cases are precisely the ones about precedence:

- account in `genesis_accounts` only → genesis balance, not zero
- account in both, block newer → block balance
- account in both, **genesis newer** (a later fork) → genesis balance
- account in neither → zero

That last set is the one I would most want written before this is trusted, and it belongs with the component test the rest of the series is waiting on.

## Worth review attention

- **`balance::bigint`.** Balances are stored as text and are unsigned 64-bit. Total supply is ~10^18 nanomina against a bigint ceiling of ~9.2×10^18, so it fits — and the existing query already decodes balance as `int64`, so this is consistent rather than new. Still, it is a cast that would be wrong for a chain with a much larger supply.
- **`account_identifier_id = 0`** in the synthesised `Timing_info.t`. The field is unused by `min_balance_at_slot`, which only reads the schedule, but it is a placeholder and worth knowing about.
