### PR TITLE
Let the packaging job choose the registry it pushes to

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -34,6 +34,8 @@ let DebianRepo = ../Constants/DebianRepo.dhall
 
 let DockerPublish = ../Constants/Docker/Publish.dhall
 
+let DockerRepo = ../Constants/DockerRepo.dhall
+
 let DebianChannel = ../Constants/DebianChannel.dhall
 
 let Profiles = ../Constants/Profiles.dhall
@@ -71,6 +73,7 @@ let PackagingSpec =
           , deb_legacy_version : Text
           , deb_legacy_githash_config : Text
           , docker_publish : DockerPublish.Type
+          , docker_repo : DockerRepo.Type
           , suffix : Optional Text
           , if_ : Optional B/If
           , includeIf : List Expr.Type
@@ -93,6 +96,7 @@ let PackagingSpec =
           , deb_legacy_githash_config = ""
           , arch = Arch.Type.Amd64
           , docker_publish = DockerPublish.Type.Essential
+          , docker_repo = DockerRepo.Type.InternalEurope
           , if_ = None B/If
           , includeIf = [] : List Expr.Type
           , excludeIf = [] : List Expr.Type
@@ -788,6 +792,7 @@ let docker_commands
                         (     s
                           //  { deb_release =
                                   DebianChannel.lowerName spec.channel
+                              , docker_repo = spec.docker_repo
                               }
                         )
                 )


### PR DESCRIPTION
> **Stacked on [#19250](https://github.com/MinaProtocol/mina/pull/19250)** — base is `dkijania/suite-from-dhall`, so the diff here is five lines. Retarget to `develop` once that merges.

Third step towards publishing straight from a build. This is the "freedom to select where dockers are pushed" piece.

### The problem

`docker_step` never set `docker_repo`, so every image went to the `InternalEurope` registry by the `ReleaseSpec` default and **no job could say otherwise**. A release pipeline wanting its images on `docker.io` had no way to ask — which is why the earlier plan reached them by retagging after the fact.

### What changes

`PackagingSpec` gains `docker_repo`, defaulting to `InternalEurope`, carried into every image of the job in the same `//` override that already carries the channel. Set once for the same reason: every image of a packaging job goes to the same registry by construction, so naming it eleven times would only create eleven chances to disagree.

`ReleaseSpec.docker_repo` also feeds `VerifyDockers`, so the verification now looks in the registry the image was actually pushed to rather than the one it used to assume.

### No credential work needed

I expected this to need a Docker Hub login and it does not — `generateStep` already attaches `docker_login` to every image step, and the rendered plugin config is:

```yaml
"docker-login#v2.0.1":
  'password-env': 'DOCKER_PASSWORD'
  'server': ""
  'username': 'o1botdockerhub'
```

An empty `server` is Docker Hub. The registry was the only thing missing.

### Behaviour

**Inert.** The rendered pipeline is byte-identical to the base branch — I diffed the full render — because the new default is exactly the value `ReleaseSpec` already used.

`make all` passes: 18 tests, 48 assertions.

### Note on ordering

Pushing straight to a public registry is only safe once nothing public happens before the tests pass. That gate is a Buildkite `wait` step in the release pipeline's configuration, not a `depends_on` in Dhall — so it does not appear in this PR, and nothing here changes when images are pushed for any existing pipeline.