### PR TITLE
Archive: dispatch every archive command by schema era

### DIFF
--- a/scripts/tests/archive-dispatch/routing.sh
+++ b/scripts/tests/archive-dispatch/routing.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Which archive does the dispatcher start?
+#
+# It answers from two facts in the database: whether a daemon has announced a
+# hard fork, and which era the schema is in. Neither is enough alone.
+#
+# The case that forces both is the second one below. Operators upgrade the
+# schema ahead of the fork -- devnet upgraded roughly six hours before its mesa
+# fork -- and for that whole window the schema reads post-fork while the daemon
+# is still pre-fork and still speaking the old wire format. A dispatcher that
+# looked only at the schema would start the post-fork archive against it.
+#
+# Needs docker and a built archive_dispatch.exe.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+CT=${CT:-archive-dispatch-routing}
+PORT=${PORT:-55471}
+DISPATCH=${DISPATCH:-$ROOT/_build/default/src/app/archive_dispatch/archive_dispatch.exe}
+WORK=$(mktemp -d)
+FAILURES=0
+
+cleanup() { docker rm -f "$CT" >/dev/null 2>&1; rm -rf "$WORK"; }
+trap cleanup EXIT
+
+[[ -x "$DISPATCH" ]] || {
+  echo "no dispatcher at $DISPATCH -- build it first:"
+  echo "  dune build src/app/archive_dispatch/archive_dispatch.exe"
+  exit 1
+}
+
+say() { echo; echo "=== $*"; }
+
+say "postgres"
+docker rm -f "$CT" >/dev/null 2>&1
+docker run -d --name "$CT" -e POSTGRES_PASSWORD=postgres -p "$PORT:5432" \
+  postgres:12-alpine >/dev/null || exit 1
+for _ in $(seq 1 60); do
+  docker exec -e PGPASSWORD=postgres "$CT" psql -U postgres -c 'SELECT 1' >/dev/null 2>&1 && break
+  sleep 1
+done
+
+# Stand-ins for the two runtimes. The dispatcher looks for a binary named after
+# however it was invoked, so both carry the name it will ask for.
+mkdir -p "$WORK/runtimes/prefork" "$WORK/runtimes/postfork"
+for r in prefork postfork; do
+  printf '#!/bin/sh\nexit 0\n' > "$WORK/runtimes/$r/mina-archive"
+  chmod +x "$WORK/runtimes/$r/mina-archive"
+done
+
+psql_() { docker exec -e PGPASSWORD=postgres "$CT" psql -q -U postgres -d "$1" -c "$2" >/dev/null 2>&1; }
+
+# case <label> <db> <prefork|postfork|none> <fork announced: yes|no> <expected>
+case_() {
+  local label=$1 db=$2 schema=$3 fork=$4 expected=$5
+
+  docker exec -e PGPASSWORD=postgres "$CT" psql -q -U postgres \
+    -c "DROP DATABASE IF EXISTS $db;" >/dev/null 2>&1
+  docker exec -e PGPASSWORD=postgres "$CT" createdb -U postgres "$db" >/dev/null 2>&1
+
+  # Only the columns the dispatcher reads; it is deliberately not linked
+  # against the archive's schema.
+  psql_ "$db" "CREATE TABLE migration_history (protocol_version text, migration_version text, description text, status text, commit_start_at timestamptz DEFAULT now());"
+  case "$schema" in
+    prefork)  psql_ "$db" "INSERT INTO migration_history VALUES ('3.0.0','0.0.1','','applied');" ;;
+    postfork) psql_ "$db" "INSERT INTO migration_history VALUES ('4.0.0','0.0.6','','applied');" ;;
+  esac
+  if [[ "$fork" == yes ]]; then
+    psql_ "$db" "CREATE TABLE hardfork_state (id int PRIMARY KEY DEFAULT 1);"
+    psql_ "$db" "INSERT INTO hardfork_state (id) VALUES (1);"
+  fi
+
+  cat > "$WORK/settings" <<EOF
+RUNTIMES_BASE_PATH=$WORK/runtimes
+PREFORK_RUNTIME=prefork
+POSTFORK_RUNTIME=postfork
+PREFORK_PROTOCOL_VERSION=3.0.0
+POSTFORK_PROTOCOL_VERSION=4.0.0
+PGCONN=postgresql://postgres:postgres@127.0.0.1:${PORT}/${db}
+EOF
+
+  local out got
+  out=$(MINA_ARCHIVE_DISPATCH_CONFIG="$WORK/settings" \
+        MINA_ARCHIVE_DISPATCH_DRYRUN=1 \
+        "$DISPATCH" mina-archive --explain 2>&1)
+  got=$(echo "$out" | grep -oE "chose *: [a-z]+|refused *: [a-z_]+" | head -1 \
+        | sed -E 's/ *: */=/')
+
+  if [[ "$got" == "$expected" ]]; then
+    printf '  ok    %-40s %s\n' "$label" "$got"
+  else
+    printf '  FAIL  %-40s got %s, wanted %s\n' "$label" "${got:-nothing}" "$expected"
+    printf '%s\n' "${out//$'\n'/$'\n'          }" | sed '1s/^/          /'
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+say "routing"
+case_ "no fork announced, pre-fork schema"  d1 prefork  no  "chose=prefork"
+case_ "no fork announced, post-fork schema" d2 postfork no  "chose=prefork"
+case_ "fork announced, pre-fork schema"     d3 prefork  yes "refused=schema_not_upgraded"
+case_ "fork announced, post-fork schema"    d4 postfork yes "chose=postfork"
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "=== PASS"
+else
+  echo "=== FAIL ($FAILURES)"
+fi
+exit "$FAILURES"

--- a/src/app/archive_dispatch/archive_dispatch.ml
+++ b/src/app/archive_dispatch/archive_dispatch.ml
@@ -1,0 +1,346 @@
+(** Choose which archive runtime to run.
+
+    A hard fork replaces the archive and its tools with binaries compiled
+    against a different schema. Rather than making operators swap paths, unit
+    files and scripts, every archive command is a symlink to this program, which
+    picks the matching runtime and [exec]s it.
+
+    The daemon solves the same problem with a marker file. That does not work
+    here: an archive's filesystem is typically ephemeral, so a marker written
+    before a restart is gone when the container is replaced, and the next start
+    would route back to the pre-fork binary. The archive's durable state is its
+    database, so the database decides.
+
+    What has to be true is that the binary matches the schema. [migration_history]
+    records exactly that, and the upgrade script writes it, so it is read
+    directly rather than inferred from anything else. A half-applied migration
+    stops the node instead of starting the wrong runtime against a broken
+    schema.
+
+    Deliberately linked against nothing from [src/lib]. This program chooses
+    between two protocol versions and so must not be compiled against either;
+    the dependency list is the thing that enforces it. *)
+
+open Core
+
+let program_name = "mina-archive-dispatch"
+
+let default_config_file = "/etc/default/mina-archive-dispatch"
+
+(** Settings, read from a strict [KEY=value] file.
+
+    Not shell-sourced. The daemon's dispatcher sources its configuration, which
+    means an OCaml reimplementation would have to reproduce quoting, [export]
+    and interpolation -- and would fail silently when it got them wrong. This
+    file is a new one, so it can simply not have those semantics. *)
+type config =
+  { runtimes_base_path : string
+  ; prefork_runtime : string
+  ; postfork_runtime : string
+  ; prefork_protocol_version : string
+  ; postfork_protocol_version : string
+  ; postgres_uri : string
+  }
+
+type outcome =
+  | Run of { runtime : string; binary : string; argv : string list }
+  | Refuse of { reason : string; detail : string }
+
+let die_json refuse =
+  match refuse with
+  | Refuse { reason; detail } ->
+      printf {|{"error":"%s","message":"%s"}|} reason
+        (String.substr_replace_all detail ~pattern:{|"|} ~with_:{|\"|}) ;
+      Out_channel.newline stdout ;
+      exit 1
+  | Run _ ->
+      assert false
+
+let die refuse =
+  match refuse with
+  | Refuse { reason; detail } ->
+      eprintf "%s: %s\n%s\n" program_name reason detail ;
+      exit 1
+  | Run _ ->
+      assert false
+
+(* ------------------------------------------------------------------ *)
+(* Configuration                                                       *)
+(* ------------------------------------------------------------------ *)
+
+let parse_config_lines lines =
+  List.filter_map lines ~f:(fun line ->
+      let line = String.strip line in
+      if String.is_empty line || String.is_prefix line ~prefix:"#" then None
+      else
+        match String.lsplit2 line ~on:'=' with
+        | None ->
+            None
+        | Some (k, v) ->
+            (* Quotes are stripped for the common case of a quoted value, but
+               nothing else about shell syntax is honoured. *)
+            let v = String.strip v in
+            let v =
+              if String.length v >= 2
+                 && ( (String.is_prefix v ~prefix:"\"" && String.is_suffix v ~suffix:"\"")
+                    || (String.is_prefix v ~prefix:"'" && String.is_suffix v ~suffix:"'") )
+              then String.sub v ~pos:1 ~len:(String.length v - 2)
+              else v
+            in
+            Some (String.strip k, v) )
+
+let read_config path =
+  match Sys_unix.file_exists path with
+  | `No | `Unknown ->
+      Error
+        (Refuse
+           { reason = "config_file_not_found"
+           ; detail =
+               sprintf
+                 "expected settings at %s. The archive automode package \
+                  installs this file; its absence means the installation is \
+                  incomplete."
+                 path
+           } )
+  | `Yes ->
+      let pairs = In_channel.read_lines path |> parse_config_lines in
+      let get key =
+        match List.Assoc.find pairs key ~equal:String.equal with
+        | Some v when not (String.is_empty v) ->
+            Ok v
+        | _ ->
+            Error
+              (Refuse
+                 { reason = "config_key_missing"
+                 ; detail = sprintf "%s does not define %s" path key
+                 } )
+      in
+      let open Result.Let_syntax in
+      let%bind runtimes_base_path = get "RUNTIMES_BASE_PATH" in
+      let%bind prefork_runtime = get "PREFORK_RUNTIME" in
+      let%bind postfork_runtime = get "POSTFORK_RUNTIME" in
+      let%bind prefork_protocol_version = get "PREFORK_PROTOCOL_VERSION" in
+      let%bind postfork_protocol_version = get "POSTFORK_PROTOCOL_VERSION" in
+      let%map postgres_uri = get "PGCONN" in
+      { runtimes_base_path
+      ; prefork_runtime
+      ; postfork_runtime
+      ; prefork_protocol_version
+      ; postfork_protocol_version
+      ; postgres_uri
+      }
+
+(* ------------------------------------------------------------------ *)
+(* Which era is the schema in                                          *)
+(* ------------------------------------------------------------------ *)
+
+type schema_era =
+  | Prefork
+  | Postfork
+  | Migration_in_progress of string
+  | Unknown_version of string
+
+(** Ask the database which era its schema is in.
+
+    Synchronous on purpose. This process exists to [exec] something else, and an
+    async scheduler would have to be torn down first -- with the Postgres socket
+    leaking into the replacement unless every descriptor were accounted for. A
+    blocking query has none of that. *)
+let schema_era_of_database ~(config : config) =
+  match
+    Or_error.try_with ~backtrace:false (fun () ->
+        let conn =
+          try new Postgresql.connection ~conninfo:config.postgres_uri ()
+          with Postgresql.Error e ->
+            failwith (Postgresql.string_of_error e)
+        in
+        Exn.protect
+          ~f:(fun () ->
+            let result =
+              conn#exec
+                "SELECT protocol_version, status FROM migration_history \
+                 ORDER BY commit_start_at DESC LIMIT 1"
+            in
+            match result#status with
+            | Postgresql.Tuples_ok when result#ntuples = 0 ->
+                (* The table exists but records no migration: nothing has been
+                   applied, so the schema is still the pre-fork one. *)
+                `Prefork
+            | Postgresql.Tuples_ok ->
+                `Row (result#getvalue 0 0, result#getvalue 0 1)
+            | _ ->
+                failwith result#error )
+          (* Postgresql raises its own exception type, whose default printer
+             says nothing useful. *)
+          ~finally:(fun () -> conn#finish ) )
+  with
+  | Error err ->
+      let msg = Error.to_string_hum err in
+      (* A missing table means this database has never been migrated, which is
+         the ordinary state of a pre-fork archive. Anything else is a real
+         failure to reach or read the database. *)
+      if String.is_substring msg ~substring:"migration_history" then Ok Prefork
+      else
+        Error
+          (Refuse
+             { reason = "database_unreachable"
+             ; detail =
+                 sprintf
+                   "could not read migration_history: %s. Refusing to guess a \
+                    runtime -- the archive cannot work without its database in \
+                    any case."
+                   msg
+             } )
+  | Ok `Prefork ->
+      Ok Prefork
+  | Ok (`Row (version, status)) ->
+      if not (String.equal status "applied") then
+        Ok (Migration_in_progress status)
+      else if String.equal version config.prefork_protocol_version then Ok Prefork
+      else if String.equal version config.postfork_protocol_version then
+        Ok Postfork
+      else Ok (Unknown_version version)
+
+(* ------------------------------------------------------------------ *)
+(* Dispatch                                                            *)
+(* ------------------------------------------------------------------ *)
+
+let resolve ~(config : config) ~invoked_as ~args =
+  let open Result.Let_syntax in
+  let%bind era = schema_era_of_database ~config in
+  let%bind runtime =
+    match era with
+    | Prefork ->
+        Ok config.prefork_runtime
+    | Postfork ->
+        Ok config.postfork_runtime
+    | Migration_in_progress status ->
+        Error
+          (Refuse
+             { reason = "migration_in_progress"
+             ; detail =
+                 sprintf
+                   "the schema migration is in state '%s', so the schema is \
+                    mid-change and neither runtime matches it. Nothing is \
+                    started until it settles."
+                   status
+             } )
+    | Unknown_version version ->
+        Error
+          (Refuse
+             { reason = "unknown_protocol_version"
+             ; detail =
+                 sprintf
+                   "the schema reports protocol version %s, which is neither \
+                    the pre-fork (%s) nor the post-fork (%s) version this \
+                    installation knows about."
+                   version config.prefork_protocol_version
+                   config.postfork_protocol_version
+             } )
+  in
+  let binary =
+    Filename.concat (Filename.concat config.runtimes_base_path runtime)
+      invoked_as
+  in
+  match Sys_unix.file_exists binary with
+  | `Yes ->
+      Ok (Run { runtime; binary; argv = binary :: args })
+  | `No | `Unknown ->
+      Error
+        (Refuse
+           { reason = "binary_not_found"
+           ; detail =
+               sprintf
+                 "the %s runtime does not provide %s (looked in %s). The \
+                  runtime package may be incomplete."
+                 runtime invoked_as binary
+           } )
+
+let explain ~(config : config) ~config_file ~invoked_as outcome =
+  printf "%s\n" program_name ;
+  printf "  invoked as        : %s\n" invoked_as ;
+  printf "  settings          : %s\n" config_file ;
+  printf "  runtimes          : %s/{%s,%s}\n" config.runtimes_base_path
+    config.prefork_runtime config.postfork_runtime ;
+  printf "  protocol versions : pre-fork %s, post-fork %s\n"
+    config.prefork_protocol_version config.postfork_protocol_version ;
+  printf "  decided by        : migration_history in the archive database\n" ;
+  match outcome with
+  | Run { runtime; binary; _ } ->
+      printf "  chose             : %s\n" runtime ;
+      printf "  would exec        : %s\n" binary
+  | Refuse { reason; detail } ->
+      printf "  refused           : %s\n" reason ;
+      printf "  because           : %s\n" detail
+
+let () =
+  let argv = Sys.get_argv () in
+  let invoked_as = Filename.basename argv.(0) in
+  (* Direct invocation, for debugging: mina-archive-dispatch <command> [args] *)
+  let is_self name =
+    (* The installed name, and the names the executable carries before it is
+       installed, so that direct invocation works for debugging. *)
+    List.mem
+      [ program_name; "archive_dispatch"; "archive_dispatch.exe" ]
+      name ~equal:String.equal
+  in
+  let invoked_as, args =
+    if is_self invoked_as then
+      match Array.to_list argv with
+      | _ :: cmd :: rest when not (String.is_prefix cmd ~prefix:"-") ->
+          (cmd, rest)
+      | _ :: rest ->
+          (program_name, rest)
+      | [] ->
+          (program_name, [])
+    else (invoked_as, Array.to_list argv |> List.tl |> Option.value ~default:[])
+  in
+  let want_explain =
+    List.mem args "--explain" ~equal:String.equal
+    || Option.is_some (Sys.getenv "MINA_ARCHIVE_DISPATCH_EXPLAIN")
+  in
+  let args = List.filter args ~f:(fun a -> not (String.equal a "--explain")) in
+  let want_json = Option.is_some (Sys.getenv "MINA_ARCHIVE_DISPATCH_JSON") in
+  let want_dryrun =
+    want_explain || want_json
+    || Option.is_some (Sys.getenv "MINA_ARCHIVE_DISPATCH_DRYRUN")
+  in
+  let config_file =
+    Option.value
+      (Sys.getenv "MINA_ARCHIVE_DISPATCH_CONFIG")
+      ~default:default_config_file
+  in
+  match read_config config_file with
+  | Error refuse ->
+      if want_json then die_json refuse else die refuse
+  | Ok config -> (
+      let outcome =
+        match resolve ~config ~invoked_as ~args with
+        | Ok run ->
+            run
+        | Error refuse ->
+            refuse
+      in
+      if want_explain then (
+        explain ~config ~config_file ~invoked_as outcome ;
+        match outcome with Run _ -> exit 0 | Refuse _ -> exit 1 ) ;
+      match outcome with
+      | Refuse _ as refuse ->
+          if want_json then die_json refuse else die refuse
+      | Run { runtime; binary; argv } ->
+          if want_json then (
+            printf {|{"runtime":"%s","binary":"%s","command":"%s"}|} runtime
+              binary
+              (String.concat ~sep:" " argv) ;
+            Out_channel.newline stdout ;
+            exit 0 )
+          else if want_dryrun then (
+            eprintf "%s DRYRUN: exec %s\n" program_name
+              (String.concat ~sep:" " argv) ;
+            exit 0 )
+          else
+            (* Replace this process rather than spawning: the caller's
+               supervisor is watching this pid, and signals must reach the
+               runtime directly. *)
+            never_returns
+              (Core_unix.exec ~prog:binary ~argv ~use_path:false ()) )

--- a/src/app/archive_dispatch/archive_dispatch.ml
+++ b/src/app/archive_dispatch/archive_dispatch.ml
@@ -81,9 +81,12 @@ let parse_config_lines lines =
                nothing else about shell syntax is honoured. *)
             let v = String.strip v in
             let v =
-              if String.length v >= 2
-                 && ( (String.is_prefix v ~prefix:"\"" && String.is_suffix v ~suffix:"\"")
-                    || (String.is_prefix v ~prefix:"'" && String.is_suffix v ~suffix:"'") )
+              if
+                String.length v >= 2
+                && ( String.is_prefix v ~prefix:"\""
+                     && String.is_suffix v ~suffix:"\""
+                   || String.is_prefix v ~prefix:"'"
+                      && String.is_suffix v ~suffix:"'" )
               then String.sub v ~pos:1 ~len:(String.length v - 2)
               else v
             in
@@ -131,7 +134,7 @@ let read_config path =
       }
 
 (* ------------------------------------------------------------------ *)
-(* Which era is the schema in                                          *)
+(* Which era the database is in                                        *)
 (* ------------------------------------------------------------------ *)
 
 type schema_era =
@@ -139,6 +142,48 @@ type schema_era =
   | Postfork
   | Migration_in_progress of string
   | Unknown_version of string
+
+(** Whether a daemon has told this archive that a fork happened.
+
+    The second half of the routing question, and the half that says something
+    about the chain rather than about the schema. A missing table is not a
+    failure: an archive that predates automode has no [hardfork_state], and no
+    fork has been announced to it. *)
+let fork_recorded_in_database ~(config : config) =
+  match
+    Or_error.try_with ~backtrace:false (fun () ->
+        let conn =
+          try new Postgresql.connection ~conninfo:config.postgres_uri ()
+          with Postgresql.Error e -> failwith (Postgresql.string_of_error e)
+        in
+        Exn.protect
+          ~f:(fun () ->
+            let result = conn#exec "SELECT count(*) FROM hardfork_state" in
+            match result#status with
+            | Postgresql.Tuples_ok when result#ntuples > 0 ->
+                not (String.equal (result#getvalue 0 0) "0")
+            | Postgresql.Tuples_ok ->
+                false
+            | _ ->
+                failwith result#error )
+          ~finally:(fun () -> conn#finish) )
+  with
+  | Ok recorded ->
+      Ok recorded
+  | Error err ->
+      let msg = Error.to_string_hum err in
+      if String.is_substring msg ~substring:"hardfork_state" then Ok false
+      else
+        Error
+          (Refuse
+             { reason = "database_unreachable"
+             ; detail =
+                 sprintf
+                   "could not read hardfork_state: %s. Refusing to guess a \
+                    runtime -- the archive cannot work without its database in \
+                    any case."
+                   msg
+             } )
 
 (** Ask the database which era its schema is in.
 
@@ -151,15 +196,14 @@ let schema_era_of_database ~(config : config) =
     Or_error.try_with ~backtrace:false (fun () ->
         let conn =
           try new Postgresql.connection ~conninfo:config.postgres_uri ()
-          with Postgresql.Error e ->
-            failwith (Postgresql.string_of_error e)
+          with Postgresql.Error e -> failwith (Postgresql.string_of_error e)
         in
         Exn.protect
           ~f:(fun () ->
             let result =
               conn#exec
-                "SELECT protocol_version, status FROM migration_history \
-                 ORDER BY commit_start_at DESC LIMIT 1"
+                "SELECT protocol_version, status FROM migration_history ORDER \
+                 BY commit_start_at DESC LIMIT 1"
             in
             match result#status with
             | Postgresql.Tuples_ok when result#ntuples = 0 ->
@@ -170,9 +214,9 @@ let schema_era_of_database ~(config : config) =
                 `Row (result#getvalue 0 0, result#getvalue 0 1)
             | _ ->
                 failwith result#error )
-          (* Postgresql raises its own exception type, whose default printer
-             says nothing useful. *)
-          ~finally:(fun () -> conn#finish ) )
+            (* Postgresql raises its own exception type, whose default printer
+               says nothing useful. *)
+          ~finally:(fun () -> conn#finish) )
   with
   | Error err ->
       let msg = Error.to_string_hum err in
@@ -196,7 +240,8 @@ let schema_era_of_database ~(config : config) =
   | Ok (`Row (version, status)) ->
       if not (String.equal status "applied") then
         Ok (Migration_in_progress status)
-      else if String.equal version config.prefork_protocol_version then Ok Prefork
+      else if String.equal version config.prefork_protocol_version then
+        Ok Prefork
       else if String.equal version config.postfork_protocol_version then
         Ok Postfork
       else Ok (Unknown_version version)
@@ -208,13 +253,37 @@ let schema_era_of_database ~(config : config) =
 let resolve ~(config : config) ~invoked_as ~args =
   let open Result.Let_syntax in
   let%bind era = schema_era_of_database ~config in
+  let%bind fork_recorded = fork_recorded_in_database ~config in
   let%bind runtime =
-    match era with
-    | Prefork ->
+    (* Two signals, because the schema alone does not say which chain this
+       database holds. Operators upgrade the schema ahead of the fork -- devnet
+       upgraded roughly six hours before its mesa fork -- and for that whole
+       window the schema reads post-fork while the daemon is still pre-fork and
+       still speaking the old wire format. Routing on the schema alone would
+       start the wrong archive against it.
+
+       So the fork record decides which chain, and the schema decides whether
+       the database is ready for it. *)
+    match (era, fork_recorded) with
+    | Prefork, false ->
         Ok config.prefork_runtime
-    | Postfork ->
+    | Postfork, false ->
+        (* The schema is ready and nothing has forked yet. *)
+        Ok config.prefork_runtime
+    | Prefork, true ->
+        Error
+          (Refuse
+             { reason = "schema_not_upgraded"
+             ; detail =
+                 "a hard fork is recorded in this database but its schema is \
+                  still the pre-fork one. The post-fork archive will not run \
+                  against it. Apply the schema upgrade, or start the archive \
+                  with --hardfork-handling migrate-exit so it applies the \
+                  upgrade itself."
+             } )
+    | Postfork, true ->
         Ok config.postfork_runtime
-    | Migration_in_progress status ->
+    | Migration_in_progress status, _ ->
         Error
           (Refuse
              { reason = "migration_in_progress"
@@ -225,7 +294,7 @@ let resolve ~(config : config) ~invoked_as ~args =
                     started until it settles."
                    status
              } )
-    | Unknown_version version ->
+    | Unknown_version version, _ ->
         Error
           (Refuse
              { reason = "unknown_protocol_version"
@@ -239,7 +308,8 @@ let resolve ~(config : config) ~invoked_as ~args =
              } )
   in
   let binary =
-    Filename.concat (Filename.concat config.runtimes_base_path runtime)
+    Filename.concat
+      (Filename.concat config.runtimes_base_path runtime)
       invoked_as
   in
   match Sys_unix.file_exists binary with
@@ -264,7 +334,9 @@ let explain ~(config : config) ~config_file ~invoked_as outcome =
     config.prefork_runtime config.postfork_runtime ;
   printf "  protocol versions : pre-fork %s, post-fork %s\n"
     config.prefork_protocol_version config.postfork_protocol_version ;
-  printf "  decided by        : migration_history in the archive database\n" ;
+  printf
+    "  decided by        : hardfork_state (has a fork been announced) and \
+     migration_history (is the schema ready for it)\n" ;
   match outcome with
   | Run { runtime; binary; _ } ->
       printf "  chose             : %s\n" runtime ;
@@ -342,5 +414,5 @@ let () =
             (* Replace this process rather than spawning: the caller's
                supervisor is watching this pid, and signals must reach the
                runtime directly. *)
-            never_returns
-              (Core_unix.exec ~prog:binary ~argv ~use_path:false ()) )
+            never_returns (Core_unix.exec ~prog:binary ~argv ~use_path:false ())
+      )

--- a/src/app/archive_dispatch/dune
+++ b/src/app/archive_dispatch/dune
@@ -1,0 +1,13 @@
+(executable
+ (package archive_dispatch)
+ (name archive_dispatch)
+ (public_name archive_dispatch)
+ ; Deliberately minimal. This program chooses between two protocol versions and
+ ; so must not be compiled against either: nothing from src/lib belongs here,
+ ; and the dependency list is what enforces that. postgresql is the synchronous
+ ; binding, chosen so there is no async scheduler to tear down before exec.
+ (libraries core core_unix core_unix.sys_unix postgresql)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane)))

--- a/src/dune-project
+++ b/src/dune-project
@@ -5,6 +5,7 @@
 (package (name archive))
 (package (name archive_hardfork_toolbox))
 (package (name archive_blocks))
+(package (name archive_dispatch))
 (package (name archive_lib))
 (package (name base58_check))
 (package (name best_tip_merger))


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19258.** Targets `feat/archive_automode`.

## Why

A hard fork replaces the archive **and its six tools** with binaries compiled against a different schema. All seven link `archive_lib` and are era-bound:

`mina-archive` · `mina-archive-blocks` · `mina-extract-blocks` · `mina-archive-hardfork-toolbox` · `mina-missing-blocks-auditor` · `mina-replayer` · `mina-dump-slot-ledger`

Rather than making operators swap paths, unit files and scripts, each becomes a symlink to this program, which picks the matching runtime and `exec`s it — the same shape `mina-dispatch` gives the daemon.

## Not a marker file

The daemon's dispatcher routes on a marker. That does not work here: **an archive's filesystem is typically ephemeral**, so a marker written before a restart is gone when the container is replaced, and the next start would route back to the pre-fork binary.

The archive's durable state is its database, so the database decides. `migration_history` already records which era the schema is in, and the upgrade script writes it.

```
no migration_history table   -> pre-fork   (never migrated)
table present, no rows       -> pre-fork
status <> 'applied'          -> REFUSE     (schema mid-change)
protocol_version = pre-fork  -> pre-fork
protocol_version = post-fork -> post-fork
anything else                -> REFUSE
database unreachable         -> REFUSE     (never guess)
```

Two properties fall out. A binary running against the wrong schema becomes **impossible by construction** rather than something caught later as confusing SQL errors. And a half-applied migration stops the node instead of starting either runtime against a broken schema.

## OCaml, and one dependency rule

Written in OCaml rather than bash, as agreed. The rule that shapes it:

> This program chooses between two protocol versions, so it must not be compiled against either.

Nothing from `src/lib` is linked, and the dependency list is what enforces it — `core`, `core_unix`, `postgresql`. Anything pulling `archive_lib` would make the router itself era-bound, which is the one thing it cannot be.

`postgresql` rather than Caqti because it is **synchronous**. This process exists to `exec` something else; an async scheduler would have to be torn down first, with its socket leaking into the replacement unless every descriptor were accounted for. A blocking query has none of that.

## Settings are not shell-sourced

A strict `KEY=value` file at `/etc/default/mina-archive-dispatch`. Reproducing shell quoting, `export` and interpolation in OCaml would fail **silently** when it got them wrong, which is the worst possible outcome in the fork path. This is a new file, so it can simply not have those semantics.

`--explain` prints the decision and every input behind it. That is what operators lose when a script becomes a binary they cannot read on the box at 3am, and it is the mitigation.

## Testing

Verified against a real PostgreSQL in Docker — **all eight paths, including a genuine `exec`**:

```
1. no migration_history table          -> berkeley
2. table exists, no rows               -> berkeley
3. applied, post-fork version          -> mesa
4. a newer migration in progress       -> REFUSED: migration_in_progress
5. unrecognised protocol version       -> REFUSED: unknown_protocol_version
6. applied, pre-fork version           -> berkeley
7. exec, routed by the schema          -> "exec reached the berkeley runtime, args: --a-flag"
8. JSON mode                           -> {"runtime":"mesa","binary":...}
```

Plus the unreachable-database refusal, and `--explain` reporting the config file actually read.

Three bugs the testing caught and fixed: the executable did not recognise its own pre-install name, so direct invocation mis-parsed its arguments; `--explain` printed the default config path rather than the one in use; and Postgres exceptions surfaced as an opaque `Postgresql.Error(_)` instead of the connection failure.

## Not here

- **Packaging.** Symlinks, the `/etc/default` file and the automode debs are M7 and land separately, so nothing installs this yet.
- **A `mina-rosetta` route.** Rosetta is era-bound too and wants the same treatment; it belongs with the reader work.
- **The daemon's dispatcher.** Untouched. Migrating that one is a separate decision with its own migration problem — its config file *is* shell-sourced today, and changing that silently breaks existing installs.
