### PR TITLE
Write the fee payer once per signed command

### DIFF
--- a/changes/19262.md
+++ b/changes/19262.md
@@ -1,0 +1,5 @@
+Speed up transaction application by removing a redundant ledger write
+
+Every payment and stake delegation wrote its fee payer's account to the ledger twice, and each write re-hashes that account's path through the Merkle tree. The redundant write has been removed, cutting the ledger writes per command by a third for a payment, and by half for a stake delegation or a payment sent to its own sender.
+
+Block producers and nodes applying blocks both spend measurably less time on transaction application as a result, with the benefit growing as the ledger grows. Balances, fees and transaction statuses are entirely unchanged.

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -572,13 +572,6 @@ module Make (L : Ledger_intf.S) :
         Or_error.error_string
           Transaction_status.Failure.(describe Update_not_permitted_nonce)
     in
-    (* Charge the fee. This must happen, whether or not the command itself
-       succeeds, to ensure that the network is compensated for processing this
-       command.
-    *)
-    let%bind () =
-      set_with_location ledger fee_payer_location fee_payer_account
-    in
     let receiver = Signed_command.receiver user_command in
     let exception Reject of Error.t in
     let ok_or_reject = function Ok x -> x | Error err -> raise (Reject err) in
@@ -718,7 +711,15 @@ module Make (L : Ledger_intf.S) :
           ( { common = applied_common; body = applied_body }
             : Transaction_applied.Signed_command_applied.t )
     | Error failure ->
-        (* Do not update the ledger. Except for the fee payer which is already updated *)
+        (* Charge the fee. This must happen, whether or not the command itself
+           succeeds, to ensure that the network is compensated for processing
+           this command. On success the fee payer is written as part of the
+           command's updates, so it is charged here only when the command
+           fails and those updates are discarded.
+        *)
+        let%bind () =
+          set_with_location ledger fee_payer_location fee_payer_account
+        in
         let applied_common : Transaction_applied.Signed_command_applied.Common.t
             =
           { user_command =


### PR DESCRIPTION
## Summary

A signed command writes its fee payer to the ledger twice: once up front to charge the fee, and again as part of the command's updates, which already carry the fee deduction. The first write is never observed, and each write rehashes the account's entire merkle path, so it is pure cost.

This removes the up-front write. The failing branch, which discards the command's updates, now charges the fee explicitly rather than relying on a side effect established seventy lines earlier.

## Behaviour is completely preserved

The resulting ledger is byte-for-byte identical in every case, so this is not a hard-fork change:

- **Applied** — the fee-deducted account used to be written and then immediately overwritten by the fee-and-amount-deducted account from the command's updates. Only the redundant intermediate write disappears; the final account is unchanged. Every success path writes the fee payer: `Payment` returns it in `updated_accounts` both when the receiver is distinct and when the receiver *is* the fee payer (where the updates are deduplicated into a single entry), and `Stake_delegation` returns it as its only update.
- **Failed** — the fee-deducted account is written, exactly as before.
- **Rejected** — a `Reject` returns `Error` and never reaches a block: such commands are excluded by `Transaction_validator` during diff creation, and a peer applying such a block fails and rejects it.

Write *ordering* is also unchanged. The only write removed is the earliest one; the receiver-then-fee-payer order within the update fold is untouched, so assignment of indices to newly created accounts cannot shift.

Nothing reads the fee payer between the two writes. The sole intervening ledger read is of the receiver, and when the receiver is the fee payer even that is skipped in favour of the in-memory account.

## Performance

Ledger writes per command drop by a third for a payment to a distinct receiver (3 → 2), and by half for a self-payment or a stake delegation (2 → 1).

Because each write hashes the account and then merges its way up the full merkle path, this is the dominant cost of transaction application. Measured on a local network at 1022 payments per block, with the mask's per-write work instrumented:

| | before | after | change |
|---|---|---|---|
| account hashing | 1,118 ms | 581 ms | −48% |
| merkle path rehashing | 2,118 ms | 1,097 ms | −48% |
| **total ledger-write cost** | **3,426 ms** | **1,811 ms** | **−47%** |
| first-pass transaction application | 9,237 ms | 5,845 ms | −37% |

Both samples were taken at the same point, after four full blocks. That workload is self-payments, so it sees the 50% case; a distinct-receiver workload should expect roughly a third.

The saving grows with ledger depth, since it removes a whole root-ward path rehash per command.

## Testing

`dune runtest src/lib/transaction_logic` (34 tests) and `dune runtest src/lib/staged_ledger` (31 tests) pass, including the tests covering failed commands and the `Amount_insufficient_to_create_account` failure path that exercises the branch this moves the write into.
