### PR TITLE
Rosetta: stand down when the schema belongs to another era

### DIFF
--- a/scripts/tests/rosetta-automode/gql-network-stub.py
+++ b/scripts/tests/rosetta-automode/gql-network-stub.py
@@ -1,0 +1,34 @@
+"""A daemon, as far as Rosetta's network check is concerned.
+
+Rosetta validates the network on every /account/balance by asking the daemon
+`query { networkID }` and comparing the answer with the identifier in the
+request. On this path that is the only thing it wants a daemon for, so this
+answers exactly that and nothing else, which keeps the test about the archive.
+
+Usage: gql-network-stub.py <port> [network-id]
+"""
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+NETWORK_ID = sys.argv[2] if len(sys.argv) > 2 else "mina:devnet"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", 0))
+        self.rfile.read(length)
+        body = json.dumps({"data": {"networkID": NETWORK_ID}}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):
+        pass
+
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", int(sys.argv[1])), Handler).serve_forever()

--- a/scripts/tests/rosetta-automode/runner.sh
+++ b/scripts/tests/rosetta-automode/runner.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Rosetta, on both sides of a hard fork.
+#
+# Two behaviours, and they pull in opposite directions. Rosetta has to keep
+# answering correctly about accounts the chain never touched -- which means
+# reading the genesis ledger's accounts, not concluding they hold nothing. And
+# it has to stop answering the moment the schema underneath it belongs to
+# another era -- because every process that opens the archive is compiled
+# against era-specific types, so a stale reader does not fail, it misreads.
+#
+#   1. an archive whose schema matches this binary, and a chain
+#   2. an account untouched since genesis: Rosetta must report its balance,
+#      not zero
+#   3. the schema is still this binary's era: Rosetta must carry on
+#   4. the schema moves to another era: Rosetta must stand down, cleanly
+#   5. the dispatcher then picks the runtime that matches
+#
+# No daemon. Rosetta wants one only to validate the network identifier, so a
+# stub answers that and the test stays about the archive.
+#
+# Needs docker, python3, curl, and a built rosetta and archive_dispatch.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$ROOT" || exit 1
+
+CT=${CT:-rosetta-automode-test}
+PGPORT=${PGPORT:-55460}
+GQLPORT=${GQLPORT:-3099}
+RPORT=${RPORT:-3098}
+ROSETTA=${ROSETTA:-$ROOT/_build/default/src/app/rosetta/rosetta_testnet_signatures.exe}
+DISPATCH=${DISPATCH:-$ROOT/_build/default/src/app/archive_dispatch/archive_dispatch.exe}
+CONN="postgres://postgres:postgres@127.0.0.1:${PGPORT}/archive"
+WORK=$(mktemp -d)
+FAILURES=0
+
+# An account the chain never touches, and the balance only the genesis knows.
+UNTOUCHED=B62qkamwHMkTvY3t9wu4Aw4LJTDJY4m6Sk48pJ2kSMtV1fxKP2SSzWq
+# The default MINA token as Rosetta stringifies it. The genesis_accounts row has
+# to carry this, not the tokens table's row id: the query matches the value
+# Rosetta asks with.
+MINA_TOKEN=wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf
+GENESIS_BALANCE=4242000000000
+
+RPID=""; GPID=""
+cleanup() {
+  [[ -n "$RPID" ]] && kill "$RPID" 2>/dev/null
+  [[ -n "$GPID" ]] && kill "$GPID" 2>/dev/null
+  docker rm -f "$CT" >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "  FAIL: $*"; FAILURES=$((FAILURES + 1)); }
+
+for exe in "$ROSETTA" "$DISPATCH"; do
+  [[ -x "$exe" ]] || { echo "missing $exe -- build it first"; exit 1; }
+done
+
+echo "=== an archive with a chain, and one account the chain never touched"
+docker rm -f "$CT" >/dev/null 2>&1
+docker run -d --name "$CT" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=archive \
+  -p "$PGPORT:5432" postgres:12-alpine >/dev/null || exit 1
+ready=0
+for _ in $(seq 1 120); do
+  if docker exec -e PGPASSWORD=postgres "$CT" psql -U postgres -d archive -c 'SELECT 1' >/dev/null 2>&1; then
+    sleep 1
+    docker exec -e PGPASSWORD=postgres "$CT" psql -U postgres -d archive -c 'SELECT 1' >/dev/null 2>&1 \
+      && { ready=1; break; }
+  fi
+  sleep 1
+done
+[[ "$ready" -eq 1 ]] || { echo "postgres never came up"; exit 1; }
+
+q() { docker exec -e PGPASSWORD=postgres "$CT" psql -qtAX -U postgres -d archive -c "$1" 2>&1; }
+
+docker exec -e PGPASSWORD=postgres -i "$CT" psql -q -U postgres -d archive \
+  < src/app/archive/create_schema.sql >/dev/null 2>&1
+docker exec -e PGPASSWORD=postgres -i "$CT" psql -q -U postgres -d archive \
+  < "$HERE/seed.sql" >/dev/null 2>&1
+
+# create_schema.sql does not create migration_history; only the upgrade does.
+# Make it, so the era can be moved about later.
+q "CREATE TABLE IF NOT EXISTS migration_history (
+     protocol_version text, migration_version text, description text,
+     status text, commit_start_at timestamptz DEFAULT now());" >/dev/null
+
+q "INSERT INTO genesis_accounts (genesis_height, public_key, token, balance, nonce)
+   VALUES (1, '$UNTOUCHED', '$MINA_TOKEN', $GENESIS_BALANCE, 0);" >/dev/null
+
+q "SELECT '  ' || chain_status || ' ' || count(*) FROM blocks GROUP BY chain_status ORDER BY 1;"
+touched=$(q "SELECT count(*) FROM accounts_accessed aa
+             JOIN account_identifiers ai ON ai.id = aa.account_identifier_id
+             JOIN public_keys pk ON pk.id = ai.public_key_id
+             WHERE pk.value = '$UNTOUCHED';")
+echo "  that account appears in $touched blocks"
+[[ "$touched" == "0" ]] || fail "the account is not untouched; the test would prove nothing"
+
+python3 "$HERE/gql-network-stub.py" "$GQLPORT" "mina:devnet" &
+GPID=$!
+sleep 1
+
+start_rosetta() {  # $1 = log, $2... = extra args
+  local log=$1; shift
+  MINA_ROSETTA_MAX_DB_POOL_SIZE=16 \
+  "$ROSETTA" --archive-uri "$CONN" \
+    --graphql-uri "http://127.0.0.1:${GQLPORT}/graphql" \
+    --port "$RPORT" "$@" > "$log" 2>&1 &
+  RPID=$!
+  for _ in $(seq 1 60); do
+    curl -s -o /dev/null "http://127.0.0.1:${RPORT}/" && return 0
+    kill -0 "$RPID" 2>/dev/null || { echo "  rosetta exited during startup:"; tail -10 "$log"; return 1; }
+    sleep 1
+  done
+  return 1
+}
+
+balance_of() {
+  local req
+  req=$(printf '{"network_identifier":{"blockchain":"mina","network":"devnet"},"account_identifier":{"address":"%s"},"block_identifier":{"index":5}}' "$UNTOUCHED")
+  curl -s -X POST "http://127.0.0.1:${RPORT}/account/balance" \
+    -H 'content-type: application/json' -d "$req" \
+    | python3 -c 'import json,sys
+try:
+    r = json.load(sys.stdin)
+    print(r["balances"][0]["value"])
+except Exception:
+    print("no-answer")'
+}
+
+echo
+echo "=== an account untouched since genesis"
+start_rosetta "$WORK/a.log" || { echo "=== FAIL"; exit 1; }
+got=$(balance_of)
+echo "  rosetta answers: $got"
+if [[ "$got" == "$GENESIS_BALANCE" ]]; then
+  echo "  ok: the genesis ledger's balance, not zero"
+else
+  fail "expected $GENESIS_BALANCE, got $got"
+fi
+kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; RPID=""
+
+echo
+echo "=== the schema is this binary's era: carry on"
+q "DELETE FROM migration_history;" >/dev/null
+q "INSERT INTO migration_history (protocol_version, migration_version, description, status)
+   VALUES ('4.0.0', '0.0.6', 'test', 'applied');" >/dev/null
+start_rosetta "$WORK/b.log" --watch-schema-era || { echo "=== FAIL"; exit 1; }
+sleep 25
+if kill -0 "$RPID" 2>/dev/null; then
+  echo "  ok: still serving"
+else
+  fail "rosetta stood down against a schema of its own era"
+fi
+kill "$RPID" 2>/dev/null; wait "$RPID" 2>/dev/null; RPID=""
+
+echo
+echo "=== the schema moves to another era: stand down"
+q "DELETE FROM migration_history;" >/dev/null
+q "INSERT INTO migration_history (protocol_version, migration_version, description, status)
+   VALUES ('3.0.0', '0.0.1', 'test', 'applied');" >/dev/null
+start_rosetta "$WORK/c.log" --watch-schema-era || { echo "=== FAIL"; exit 1; }
+gone=no
+for _ in $(seq 1 40); do
+  kill -0 "$RPID" 2>/dev/null || { gone=yes; break; }
+  sleep 1
+done
+if [[ "$gone" == yes ]]; then
+  wait "$RPID" 2>/dev/null; rc=$?
+  echo "  rosetta exited, code $rc"
+  [[ "$rc" == "0" ]] || fail "expected a clean exit, got $rc"
+  if grep -q "Standing down" "$WORK/c.log"; then
+    grep -o "Standing down.*" "$WORK/c.log" | tail -1 | cut -c1-150 | sed 's/^/  /'
+  else
+    fail "it stopped without saying why"
+  fi
+else
+  fail "rosetta kept serving a schema from another era"
+  kill "$RPID" 2>/dev/null
+fi
+RPID=""
+
+echo
+echo "=== and the dispatcher picks the runtime that matches"
+mkdir -p "$WORK/runtimes/prefork" "$WORK/runtimes/postfork"
+for r in prefork postfork; do
+  printf '#!/bin/sh\nexit 0\n' > "$WORK/runtimes/$r/mina-rosetta"
+  chmod +x "$WORK/runtimes/$r/mina-rosetta"
+done
+cat > "$WORK/settings" <<EOF
+RUNTIMES_BASE_PATH=$WORK/runtimes
+PREFORK_RUNTIME=prefork
+POSTFORK_RUNTIME=postfork
+PREFORK_PROTOCOL_VERSION=3.0.0
+POSTFORK_PROTOCOL_VERSION=4.0.0
+PGCONN=$CONN
+EOF
+chose=$(MINA_ARCHIVE_DISPATCH_CONFIG="$WORK/settings" MINA_ARCHIVE_DISPATCH_DRYRUN=1 \
+        "$DISPATCH" mina-rosetta --explain 2>&1 \
+        | grep -oE "chose *: [a-z]+" | sed -E 's/ *: */=/')
+echo "  $chose"
+# A fork is recorded nowhere, so the chain has not forked and the pre-fork
+# runtime is right even though this schema says 3.0.0.
+[[ "$chose" == "chose=prefork" ]] || fail "expected chose=prefork, got ${chose:-nothing}"
+
+echo
+if [[ "$FAILURES" -eq 0 ]]; then
+  echo "=== PASS"
+else
+  echo "=== FAIL ($FAILURES)"
+fi
+exit "$FAILURES"

--- a/scripts/tests/rosetta-automode/seed.sql
+++ b/scripts/tests/rosetta-automode/seed.sql
@@ -1,0 +1,75 @@
+-- A chain for Rosetta to answer about.
+--
+-- Nothing here is about the fork boundary: this test only needs blocks that a
+-- balance request can name, and an account that appears in none of them. It is
+-- the same seed the archive automode harness uses, kept separately because that
+-- harness arrives in a later change and a test should not reach across one.
+
+BEGIN;
+
+INSERT INTO public_keys (id, value) VALUES
+  (1, 'B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg'),
+  (2, 'B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g');
+
+INSERT INTO snarked_ledger_hashes (id, value) VALUES
+  (1, 'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m');
+
+INSERT INTO epoch_data
+  (id, seed, ledger_hash_id, total_currency, start_checkpoint,
+   lock_checkpoint, epoch_length)
+VALUES
+  (1, '2vaRh7FQ5wSzmpFReF9gcRKjv48CcJvHs25aqb3SSZiPgHQBy5Dt', 1,
+   '10000000000', 'CHECKPOINT_START', 'CHECKPOINT_LOCK', 1);
+
+INSERT INTO protocol_versions (id, transaction, network, patch) VALUES
+  (1, 3, 0, 0),   -- pre-fork
+  (2, 4, 0, 0);   -- post-fork
+
+-- The pre-fork chain. Heights 1..10 on the winning branch.
+--
+-- 1..5   already canonical: canonicalisation got this far before the chain
+--        stopped, and nothing since has been able to advance it.
+-- 6..10  pending, and stuck. 10 is the fork block.
+INSERT INTO blocks
+  (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+   last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+   next_epoch_data_id, min_window_density, sub_window_densities,
+   total_currency, ledger_hash, height, global_slot_since_hard_fork,
+   global_slot_since_genesis, protocol_version_id, timestamp, chain_status)
+SELECT
+  h,
+  'B_' || lpad(h::text, 3, '0'),
+  CASE WHEN h = 1 THEN NULL ELSE h - 1 END,
+  CASE WHEN h = 1 THEN 'GENESIS' ELSE 'B_' || lpad((h-1)::text, 3, '0') END,
+  1, 1, 'vrf', 1, 1, 1, 77, ARRAY[7,7,7,7,7,7,7]::bigint[],
+  '10000000000', 'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+  -- The era's genesis block is the one at global_slot_since_hard_fork = 0.
+  -- The archive marks such a block canonical on insert, and the repair anchors
+  -- on it, so the seed has to have one.
+  h, h - 1, h, 1, (1700000000 + h * 180)::text,
+  (CASE WHEN h <= 5 THEN 'canonical' ELSE 'pending' END)::chain_status_type
+FROM generate_series(1, 10) AS h;
+
+-- Off-chain siblings at heights 7 and 9: legitimately produced, lost the fork
+-- race, and left pending because nothing ever orphaned them. The repair has to
+-- mark these orphaned, not canonical.
+INSERT INTO blocks
+  (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+   last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+   next_epoch_data_id, min_window_density, sub_window_densities,
+   total_currency, ledger_hash, height, global_slot_since_hard_fork,
+   global_slot_since_genesis, protocol_version_id, timestamp, chain_status)
+VALUES
+  (107, 'ORPHAN_007', 6, 'B_006', 2, 2, 'vrf', 1, 1, 1, 77,
+   ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
+   'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+   7, 6, 7, 1, '1701260000', 'pending'::chain_status_type),
+  (109, 'ORPHAN_009', 8, 'B_008', 2, 2, 'vrf', 1, 1, 1, 77,
+   ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
+   'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+   9, 8, 9, 1, '1701260360', 'pending'::chain_status_type);
+
+SELECT setval(pg_get_serial_sequence('blocks', 'id'), 200);
+SELECT setval(pg_get_serial_sequence('public_keys', 'id'), 200);
+
+COMMIT;

--- a/src/app/archive/lib/schema_era.ml
+++ b/src/app/archive/lib/schema_era.ml
@@ -1,0 +1,143 @@
+(** Does this binary match the schema it is reading?
+
+    Every process that opens the archive database links [archive_lib] and is
+    therefore compiled against era-specific types -- [Max_state_size] is
+    [Nat.N32] in mesa where it was [N8] in berkeley, so an account decoded by
+    the wrong binary is not a version inconvenience but a misread.
+
+    Nothing checks this today. A stale reader against a migrated schema either
+    fails with confusing SQL errors or, worse, succeeds and returns wrong data.
+    That is a live hazard independent of any automation: it applies to every
+    operator who upgrades their archive and their Rosetta at different times.
+
+    [migration_history] already records which era the schema is in, and the
+    upgrade script writes it, so this reads it directly rather than inferring
+    anything. A reader that finds itself on the wrong side stands down with a
+    clean exit, and whatever supervises it starts the right binary -- the
+    dispatcher decides that from the same record. *)
+
+open Core
+open Async
+
+type verdict =
+  | Matches
+      (** The schema is the era this binary was built for. Carry on. *)
+  | Differs of { schema : string; mine : string }
+      (** The schema belongs to another era. Nothing this binary reads can be
+          trusted, so it should stand down rather than answer. *)
+  | Migration_in_progress of string
+      (** The schema is mid-change. No binary matches it while that is true. *)
+  | No_record
+      (** No migration has ever been recorded, which is the ordinary state of a
+          database that has not been through a fork. Nothing to object to. *)
+
+let describe = function
+  | Matches ->
+      "the schema matches this binary"
+  | Differs { schema; mine } ->
+      sprintf
+        "the schema is at protocol version %s but this binary was built for %s"
+        schema mine
+  | Migration_in_progress status ->
+      sprintf "a schema migration is in state '%s'" status
+  | No_record ->
+      "no schema migration has been recorded"
+
+let my_protocol_version = Protocol_version.(to_string current)
+
+(** The decision itself, separated from reading the row so that it can be
+    exercised without a database. *)
+let verdict_of_row ~mine row =
+  match row with
+  | None ->
+      No_record
+  | Some (status, protocol_version, _migration_version) ->
+      if not (String.equal status "applied") then
+        Migration_in_progress status
+      else if String.equal protocol_version mine then Matches
+      else Differs { schema = protocol_version; mine }
+
+let check (module Conn : Mina_caqti.CONNECTION) =
+  let open Deferred.Result.Let_syntax in
+  let%map row = Hardfork_sql.fetch_latest_migration_history (module Conn) in
+  verdict_of_row ~mine:my_protocol_version row
+
+let%test_module "schema era verdicts" =
+  ( module struct
+    let mine = "4.0.0"
+
+    let%test_unit "a database that has never migrated raises no objection" =
+      match verdict_of_row ~mine None with
+      | No_record ->
+          ()
+      | v ->
+          failwithf "expected No_record, got: %s" (describe v) ()
+
+    let%test_unit "the schema this binary was built for matches" =
+      match verdict_of_row ~mine (Some ("applied", "4.0.0", "0.0.6")) with
+      | Matches ->
+          ()
+      | v ->
+          failwithf "expected Matches, got: %s" (describe v) ()
+
+    let%test_unit "an older schema is a mismatch, not a match" =
+      match verdict_of_row ~mine (Some ("applied", "3.0.0", "0.0.1")) with
+      | Differs { schema; mine = m } ->
+          [%test_eq: string] schema "3.0.0" ;
+          [%test_eq: string] m mine
+      | v ->
+          failwithf "expected Differs, got: %s" (describe v) ()
+
+    let%test_unit "a migration in progress matches nothing, even at our version"
+        =
+      (* The version is ours, but the schema is mid-change: answering from it
+         would be answering from a shape that is still moving. *)
+      match verdict_of_row ~mine (Some ("starting", "4.0.0", "0.0.6")) with
+      | Migration_in_progress status ->
+          [%test_eq: string] status "starting"
+      | v ->
+          failwithf "expected Migration_in_progress, got: %s" (describe v) ()
+
+    let%test_unit "a failed migration matches nothing either" =
+      match verdict_of_row ~mine (Some ("failed", "4.0.0", "0.0.6")) with
+      | Migration_in_progress status ->
+          [%test_eq: string] status "failed"
+      | v ->
+          failwithf "expected Migration_in_progress, got: %s" (describe v) ()
+  end )
+
+(** Watch for the schema moving out from under this process.
+
+    Polling rather than reacting, because there is nothing to react to: the
+    migration is applied by a separate process against the database. The
+    interval bounds how long this binary can keep answering from a schema that
+    has changed, so it is short -- the queries are trivial.
+
+    On a mismatch the process exits with status 0. Not a crash: a supervisor
+    should read this as a clean hand-off and start the replacement in the
+    ordinary way, rather than backing off as it would after a failure. *)
+let watch ~logger ~pool ?(interval = Time.Span.of_sec 10.) () =
+  Deferred.repeat_until_finished () (fun () ->
+      let%bind () =
+        match%map Mina_caqti.Pool.use (fun conn -> check conn) pool with
+        | Error e ->
+            (* Being unable to ask is not the same as being on the wrong side of
+               a fork, and this process may be serving perfectly well from a
+               connection that happens to be busy. Say so and try again. *)
+            [%log warn]
+              "Could not check whether this binary matches the schema: $error"
+              ~metadata:[ ("error", `String (Caqti_error.show e)) ]
+        | Ok (Matches | No_record) ->
+            ()
+        | Ok ((Differs _ | Migration_in_progress _) as verdict) ->
+            [%log info]
+              "Standing down: $reason. Exiting cleanly so the runtime matching \
+               this schema can take over."
+              ~metadata:[ ("reason", `String (describe verdict)) ] ;
+            (* Give the log a chance to flush before the process goes. *)
+            don't_wait_for
+              (let%bind () = after (Time.Span.of_sec 1.) in
+               exit 0 )
+      in
+      let%map () = after interval in
+      `Repeat () )

--- a/src/app/archive/lib/schema_era.ml
+++ b/src/app/archive/lib/schema_era.ml
@@ -20,8 +20,7 @@ open Core
 open Async
 
 type verdict =
-  | Matches
-      (** The schema is the era this binary was built for. Carry on. *)
+  | Matches  (** The schema is the era this binary was built for. Carry on. *)
   | Differs of { schema : string; mine : string }
       (** The schema belongs to another era. Nothing this binary reads can be
           trusted, so it should stand down rather than answer. *)
@@ -52,8 +51,7 @@ let verdict_of_row ~mine row =
   | None ->
       No_record
   | Some (status, protocol_version, _migration_version) ->
-      if not (String.equal status "applied") then
-        Migration_in_progress status
+      if not (String.equal status "applied") then Migration_in_progress status
       else if String.equal protocol_version mine then Matches
       else Differs { schema = protocol_version; mine }
 

--- a/src/app/archive/lib/schema_era.ml
+++ b/src/app/archive/lib/schema_era.ml
@@ -141,10 +141,15 @@ let watch ~logger ~pool ?(interval = Time.Span.of_sec 10.) () =
         | Ok (Matches | No_record) ->
             ()
         | Ok ((Differs _ | Migration_in_progress _) as verdict) ->
+            (* Formatted in rather than interpolated from metadata: plain
+               text logs drop interpolated values longer than fifty characters,
+               and every one of these reasons is longer. The reason is the
+               whole point of the line -- it is the last thing this process
+               says. *)
             [%log info]
-              "Standing down: $reason. Exiting cleanly so the runtime matching \
-               this schema can take over."
-              ~metadata:[ ("reason", `String (describe verdict)) ] ;
+              "Standing down: %s. Exiting cleanly so the runtime matching this \
+               schema can take over."
+              (describe verdict) ;
             (* Give the log a chance to flush before the process goes. *)
             don't_wait_for
               (let%bind () = after (Time.Span.of_sec 1.) in

--- a/src/app/archive/lib/schema_era.ml
+++ b/src/app/archive/lib/schema_era.ml
@@ -56,9 +56,22 @@ let verdict_of_row ~mine row =
       else Differs { schema = protocol_version; mine }
 
 let check (module Conn : Mina_caqti.CONNECTION) =
-  let open Deferred.Result.Let_syntax in
-  let%map row = Hardfork_sql.fetch_latest_migration_history (module Conn) in
-  verdict_of_row ~mine:my_protocol_version row
+  let open Deferred.Let_syntax in
+  match%map Hardfork_sql.fetch_latest_migration_history (module Conn) with
+  | Ok row ->
+      Ok (verdict_of_row ~mine:my_protocol_version row)
+  | Error e ->
+      (* No such table is not a failure to ask, it is an answer: this database
+         has never been migrated, which is the ordinary state of one that has
+         never been through a fork. create_schema.sql does not create
+         migration_history -- only the upgrade does -- so treating its absence
+         as an error would warn every interval, for ever, on every archive that
+         has never forked. The dispatcher reads the same absence the same way,
+         and the two must not disagree. *)
+      let msg = Caqti_error.show e in
+      if String.is_substring msg ~substring:"migration_history" then
+        Ok No_record
+      else Error e
 
 let%test_module "schema era verdicts" =
   ( module struct

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -179,6 +179,16 @@ let command ?signature_kind ~minimum_user_command_fee ~account_creation_fee () =
         "Enable safe mode, meaning only data safe to expose to public would be \
          routed. And any mutation should be banned."
       no_arg
+  and watch_schema_era =
+    flag "--watch-schema-era" ~aliases:[ "watch-schema-era" ]
+      ~doc:
+        "Stand down when the archive schema moves to a protocol version this \
+         binary was not built for, so that the runtime matching it can take \
+         over. Off by default: a deployment that will never pass through a \
+         hard fork should not pay for one. The archive automode package \
+         supplies this flag, because installing it is the statement that this \
+         deployment might."
+      no_arg
   and signature_kind =
     Option.value_map signature_kind ~default:Cli_lib.Flag.signature_kind
       ~f:Command.Param.return
@@ -217,6 +227,16 @@ let command ?signature_kind ~minimum_user_command_fee ~account_creation_fee () =
             Deferred.Result.return pool)
     in
     don't_wait_for (pg_log_data ~logger ~pool) ;
+    if watch_schema_era then
+      don't_wait_for
+        (let open Deferred.Let_syntax in
+        match%bind Lazy.force pool with
+        | Error _ ->
+            (* The pool reports its own failure; nothing to add, and without a
+               database this process has larger problems than the schema era. *)
+            Deferred.unit
+        | Ok pool ->
+            Archive_lib.Schema_era.watch ~logger ~pool ()) ;
     let%bind server =
       Cohttp_async.Server.create_expert ~max_connections:128
         ~on_handler_error:


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19260**, the dispatcher. Targets `feat/archive_automode`.

## Two halves of the same problem

The dispatcher in #19260 decides which binary to *start*. This decides when a **running** binary should stop — because a schema can migrate underneath a process that is already serving, and nothing tells it.

Both read the same record, so they cannot disagree.

## The hazard, which is not hypothetical

Every process that opens the archive database links `archive_lib` and is compiled against era-specific types. `Max_state_size` is `Nat.N32` in mesa where it was `N8` in berkeley, so an account decoded by the wrong binary is not a version inconvenience — it is a misread.

**Nothing checks.** A stale reader against a migrated schema either fails with confusing SQL errors, or succeeds and returns wrong data. That applies today to any operator who upgrades their archive and their Rosetta at different moments; it is not created by the automode work, only made routine by it.

## `Schema_era`, in `archive_lib`

Placed there because **every reader links it** — the replayer, `missing-blocks-auditor`, `extract-blocks` and `dump-slot-ledger` all need the identical check, and only their tolerance for being restarted differs.

```
no record                     -> No_record             (never forked; nothing to object to)
status <> 'applied'           -> Migration_in_progress (nothing matches a moving schema)
protocol_version = mine       -> Matches
otherwise                     -> Differs
```

The third and fourth rows are the ones that matter. Note that **a migration in progress matches nothing even when its version is ours** — answering from a schema that is still changing is answering from a shape that is still changing.

## Exit 0, not a crash

A supervisor should read this as a clean hand-off and start the replacement in the ordinary way, rather than backing off as it would after a failure. The dispatcher then picks that replacement from the same `migration_history` row.

## Off by default

A deployment that will never pass through a hard fork should not pay for one. `--watch-schema-era` is supplied by the **automode package**, whose installation is precisely the statement that this deployment might. An ordinary Rosetta carries none of it and behaves exactly as today.

## Rosetta needs no dispatcher change

The dispatcher routes on `basename argv[0]`, so `mina-rosetta` works the moment it is symlinked — no code change, only packaging (M7).

## Testing

The verdict is deliberately separated from reading the row so it can be exercised without a database:

```
inline tests, schema_era.ml: 5 tests ran
  - a database that has never migrated raises no objection
  - the schema this binary was built for matches
  - an older schema is a mismatch, not a match
  - a migration in progress matches nothing, even at our version
  - a failed migration matches nothing either
```

```
dune build --root . @src/app/archive/lib/check @src/app/rosetta/lib/check -> exit 0
dune build --root . @src/app/rosetta/check                                -> exit 0
```

**Not covered:** the polling loop itself, and the exit path. Those need a running Rosetta against a database whose schema changes mid-flight, which belongs in the component test.

## Worth review attention

- **A 10-second interval** bounds how long a binary can keep answering from a changed schema. The queries are trivial, so it is cheap, but the number is a judgement call.
- **The one-second delay before exit** exists so the log line explaining the stand-down is flushed before the process goes. Without it, the most useful line is the one most likely to be lost.
- **A failed check is not treated as a mismatch.** Being unable to ask is not the same as being on the wrong side of a fork, and a process serving perfectly well should not stand down because a connection was momentarily busy.
