### PR TITLE
Archive automode: exercise the hand-over end to end, and fix what that caught

### DIFF
--- a/scripts/tests/archive-automode/fork_genesis.sql
+++ b/scripts/tests/archive-automode/fork_genesis.sql
@@ -1,0 +1,21 @@
+-- The post-fork chain's genesis block.
+--
+-- It sits one above the fork block and its parent hash is the fork block's, so
+-- it is the chain's own confirmation of what the configuration asserted. The
+-- repair waits for it: until it is here, the fork block is attested by a single
+-- message and nothing corroborates it.
+--
+-- It also carries the new protocol version and global_slot_since_hard_fork = 0,
+-- which is what makes it an era genesis and what bounds the orphaning.
+
+INSERT INTO blocks
+  (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+   last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+   next_epoch_data_id, min_window_density, sub_window_densities,
+   total_currency, ledger_hash, height, global_slot_since_hard_fork,
+   global_slot_since_genesis, protocol_version_id, timestamp, chain_status)
+VALUES
+  (201, 'FORK_GENESIS', 10, 'B_010', 1, 1, 'vrf', 1, 1, 1, 77,
+   ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
+   'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+   11, 0, 20, 2, '1701262000', 'canonical'::chain_status_type);

--- a/scripts/tests/archive-automode/runner.sh
+++ b/scripts/tests/archive-automode/runner.sh
@@ -156,9 +156,15 @@ say "the archive should record the fork but decline to repair it"
 # settled refusal rather than a race.
 sleep 75
 
-STAGE=$(psql_ -c "SELECT stage FROM hardfork_state WHERE id=1;" 2>/dev/null)
-[[ "$STAGE" == "announced" ]] \
-  || fail "expected the fork to be recorded as 'announced', got '${STAGE:-none}'"
+# The fork is on the books -- a row exists -- but the repair has not run, so
+# finalized_at is still NULL.
+RECORDED=$(psql_ -c "SELECT count(*) FROM hardfork_state WHERE id=1;" 2>/dev/null)
+[[ "$RECORDED" == "1" ]] \
+  || fail "the archive did not record the fork it was sent"
+
+SETTLED_AT=$(psql_ -c "SELECT coalesce(finalized_at::text,'') FROM hardfork_state WHERE id=1;" 2>/dev/null)
+[[ -z "$SETTLED_AT" ]] \
+  || fail "the boundary was settled at ${SETTLED_AT}, before the post-fork genesis arrived"
 
 STILL_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pending';")
 [[ "$STILL_PENDING" == "7" ]] \
@@ -179,19 +185,19 @@ docker exec -e PGPASSWORD=pw -i "$PG_CONTAINER" psql -q -U postgres -d "$DB" \
 say "watching the boundary settle"
 SETTLED=0
 for _ in $(seq 1 40); do
-  STAGE=$(psql_ -c "SELECT stage FROM hardfork_state WHERE id=1;" 2>/dev/null)
-  if [[ "$STAGE" == "finalized" ]]; then SETTLED=1; break; fi
+  SETTLED_AT=$(psql_ -c "SELECT coalesce(finalized_at::text,'') FROM hardfork_state WHERE id=1;" 2>/dev/null)
+  if [[ -n "$SETTLED_AT" ]]; then SETTLED=1; break; fi
   sleep 2
 done
 
 echo "hardfork_state:"
-psql_ -c "SELECT stage, source, fork_state_hash, fork_blockchain_length FROM hardfork_state;" | sed 's/^/    /'
+psql_ -c "SELECT source, fork_state_hash, fork_blockchain_length, finalized_at FROM hardfork_state;" | sed 's/^/    /'
 echo "chain_status after:"
 psql_ -c "SELECT chain_status, count(*) FROM blocks GROUP BY 1 ORDER BY 1;" | sed 's/^/    /'
 echo "per block:"
 psql_ -c "SELECT height, state_hash, chain_status FROM blocks ORDER BY height, state_hash;" | sed 's/^/    /'
 
-[[ "$SETTLED" -eq 1 ]] || fail "the boundary never settled (hardfork_state.stage is '${STAGE:-none}')"
+[[ "$SETTLED" -eq 1 ]] || fail "the boundary never settled (hardfork_state.finalized_at is still NULL)"
 
 # The chain up to the fork block is canonical.
 for h in 6 7 8 9 10; do

--- a/scripts/tests/archive-automode/runner.sh
+++ b/scripts/tests/archive-automode/runner.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Drives the archive's hard fork hand-over end to end, without a fork.
+#
+# The archive learns about a fork from exactly one message: the runtime
+# configuration a daemon generated for it. That makes the whole hand-over
+# testable by sending the same message by hand -- which is what
+# `mina advanced send-hardfork-config` exists for.
+#
+# The flow:
+#
+#   1. a database on the pre-fork schema, seeded with the boundary a fork
+#      strands: a band of pending blocks the archive can no longer canonicalise
+#   2. a running archive, in automode
+#   3. the configuration, sent over the archive RPC
+#   4. watch the band heal -- pending becomes canonical on the chain to the fork
+#      block, and orphaned off it
+#
+# Usage:
+#   scripts/tests/archive-automode/runner.sh [--keep] [--pg-port PORT]
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../../.." && pwd)"
+
+PG_PORT="${PG_PORT:-55440}"
+PG_CONTAINER="${PG_CONTAINER:-archive-automode-test-pg}"
+KEEP=0
+ARCHIVE_BIN="${ARCHIVE_BIN:-${ROOT}/_build/default/src/app/archive/archive.exe}"
+CLIENT_BIN="${CLIENT_BIN:-${ROOT}/_build/default/src/app/cli/src/mina_testnet_signatures.exe}"
+ARCHIVE_PORT="${ARCHIVE_PORT:-3187}"
+WORK="$(mktemp -d)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep) KEEP=1; shift;;
+    --pg-port) PG_PORT="$2"; shift 2;;
+    --archive-bin) ARCHIVE_BIN="$2"; shift 2;;
+    --client-bin) CLIENT_BIN="$2"; shift 2;;
+    *) echo "unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+DB=archive_automode
+CONN="postgresql://postgres:pw@127.0.0.1:${PG_PORT}/${DB}"
+
+say()  { printf '\n=== %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; FAILED=1; }
+FAILED=0
+
+cleanup() {
+  [[ -n "${ARCHIVE_PID:-}" ]] && kill "$ARCHIVE_PID" 2>/dev/null
+  if [[ "$KEEP" -eq 0 ]]; then
+    docker rm -f "$PG_CONTAINER" >/dev/null 2>&1
+    rm -rf "$WORK"
+  else
+    echo "kept: container ${PG_CONTAINER}, work dir ${WORK}"
+  fi
+}
+trap cleanup EXIT
+
+for bin in "$ARCHIVE_BIN" "$CLIENT_BIN"; do
+  if [[ ! -x "$bin" ]]; then
+    echo "missing binary: $bin" >&2
+    echo "build with: dune build src/app/archive/archive.exe src/app/cli/src/mina_testnet_signatures.exe" >&2
+    exit 2
+  fi
+done
+
+psql_() { docker exec -e PGPASSWORD=pw -i "$PG_CONTAINER" psql -qtAX -U postgres -d "$DB" "$@"; }
+
+# ---------------------------------------------------------------- 1. database
+say "starting postgres"
+docker rm -f "$PG_CONTAINER" >/dev/null 2>&1
+docker run -d --name "$PG_CONTAINER" -e POSTGRES_PASSWORD=pw \
+  -p "${PG_PORT}:5432" postgres:14 >/dev/null || { echo "could not start postgres"; exit 1; }
+
+# postgres:14 runs initdb against a temporary server and then restarts, so
+# pg_isready answers before the server is really up. Retrying createdb is what
+# proves it: it only succeeds once the final server is accepting connections.
+CREATED=0
+for _ in $(seq 1 90); do
+  if docker exec -e PGPASSWORD=pw "$PG_CONTAINER" createdb -U postgres "$DB" >/dev/null 2>&1; then
+    CREATED=1; break
+  fi
+  sleep 1
+done
+[[ "$CREATED" -eq 1 ]] || { echo "postgres never became usable" >&2; exit 1; }
+
+say "creating the schema"
+docker exec -e PGPASSWORD=pw -i "$PG_CONTAINER" psql -q -U postgres -d "$DB" \
+  < "${ROOT}/src/app/archive/create_schema.sql" >/dev/null 2>&1 \
+  || { echo "schema creation failed"; exit 1; }
+
+say "seeding the boundary a fork strands"
+docker exec -e PGPASSWORD=pw -i "$PG_CONTAINER" psql -q -U postgres -d "$DB" \
+  < "${HERE}/seed.sql" >/dev/null || { echo "seed failed"; exit 1; }
+
+echo "chain_status before:"
+psql_ -c "SELECT chain_status, count(*) FROM blocks GROUP BY 1 ORDER BY 1;" | sed 's/^/    /'
+
+BEFORE_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pending';")
+[[ "$BEFORE_PENDING" == "7" ]] || fail "expected 7 pending blocks to start, got ${BEFORE_PENDING}"
+
+# ---------------------------------------------------------------- 2. config
+# Only the fork stanza matters for the repair. The ledger stanzas would matter
+# for the genesis block and accounts, which need a real ledger and are out of
+# scope here.
+cat > "${WORK}/fork_config.json" <<'JSON'
+{
+  "proof": {
+    "fork": {
+      "state_hash": "B_010",
+      "blockchain_length": 10,
+      "global_slot_since_genesis": 10
+    }
+  }
+}
+JSON
+
+# ---------------------------------------------------------------- 3. archive
+say "starting the archive in automode"
+# --hardfork-confirmations 0: the seeded chain stops at the fork block, so it has
+# no confirmations above it. A real fork accumulates them during the empty-block
+# window; here the point is the repair, not the threshold.
+"$ARCHIVE_BIN" run \
+  --postgres-uri "$CONN" \
+  --server-port "$ARCHIVE_PORT" \
+  --hardfork-confirmations 0 \
+  > "${WORK}/archive.log" 2>&1 &
+ARCHIVE_PID=$!
+
+for _ in $(seq 1 60); do
+  grep -q "Archive process ready" "${WORK}/archive.log" 2>/dev/null && break
+  kill -0 "$ARCHIVE_PID" 2>/dev/null || { echo "archive died:"; tail -20 "${WORK}/archive.log"; exit 1; }
+  sleep 1
+done
+grep -q "Archive process ready" "${WORK}/archive.log" || {
+  echo "archive did not become ready:"; tail -20 "${WORK}/archive.log"; exit 1; }
+echo "    ready (pid ${ARCHIVE_PID})"
+
+# ---------------------------------------------------------------- 4. the message
+say "sending the fork configuration, as a daemon would"
+"$CLIENT_BIN" advanced send-hardfork-config \
+  "${WORK}/fork_config.json" \
+  --archive-address "127.0.0.1:${ARCHIVE_PORT}" 2>&1 | sed 's/^/    /'
+
+# ---------------------------------------------------------------- 5. observe
+say "watching the boundary settle"
+SETTLED=0
+for _ in $(seq 1 40); do
+  STAGE=$(psql_ -c "SELECT stage FROM hardfork_state WHERE id=1;" 2>/dev/null)
+  if [[ "$STAGE" == "finalized" ]]; then SETTLED=1; break; fi
+  sleep 2
+done
+
+echo "hardfork_state:"
+psql_ -c "SELECT stage, source, fork_state_hash, fork_blockchain_length FROM hardfork_state;" | sed 's/^/    /'
+echo "chain_status after:"
+psql_ -c "SELECT chain_status, count(*) FROM blocks GROUP BY 1 ORDER BY 1;" | sed 's/^/    /'
+echo "per block:"
+psql_ -c "SELECT height, state_hash, chain_status FROM blocks ORDER BY height, state_hash;" | sed 's/^/    /'
+
+[[ "$SETTLED" -eq 1 ]] || fail "the boundary never settled (hardfork_state.stage is '${STAGE:-none}')"
+
+# The chain up to the fork block is canonical.
+for h in 6 7 8 9 10; do
+  ST=$(psql_ -c "SELECT chain_status FROM blocks WHERE state_hash='B_$(printf '%03d' $h)';")
+  [[ "$ST" == "canonical" ]] || fail "B_$(printf '%03d' $h) is '${ST}', expected canonical"
+done
+
+# The blocks off it are orphaned, not left pending and not made canonical.
+for sh in ORPHAN_007 ORPHAN_009; do
+  ST=$(psql_ -c "SELECT chain_status FROM blocks WHERE state_hash='${sh}';")
+  [[ "$ST" == "orphaned" ]] || fail "${sh} is '${ST}', expected orphaned"
+done
+
+AFTER_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pending';")
+[[ "$AFTER_PENDING" == "0" ]] || fail "${AFTER_PENDING} blocks still pending after the repair"
+
+say "archive log, hard fork lines"
+grep -iE "hard fork|fork boundary|settl|canonical" "${WORK}/archive.log" | tail -12 | sed 's/^/    /'
+
+if [[ "$FAILED" -eq 0 ]]; then
+  say "PASS"
+else
+  say "FAILURES ABOVE"
+fi
+exit "$FAILED"

--- a/scripts/tests/archive-automode/runner.sh
+++ b/scripts/tests/archive-automode/runner.sh
@@ -13,7 +13,11 @@
 #      strands: a band of pending blocks the archive can no longer canonicalise
 #   2. a running archive, in automode
 #   3. the configuration, sent over the archive RPC
-#   4. watch the band heal -- pending becomes canonical on the chain to the fork
+#   4. the archive records it and *declines* to repair: the fork block is so far
+#      attested only by that message, and nothing has corroborated it
+#   5. the post-fork genesis block arrives, its parent hash confirming the fork
+#      block
+#   6. now the band heals -- pending becomes canonical on the chain to the fork
 #      block, and orphaned off it
 #
 # Usage:
@@ -146,7 +150,32 @@ say "sending the fork configuration, as a daemon would"
   "${WORK}/fork_config.json" \
   --archive-address "127.0.0.1:${ARCHIVE_PORT}" 2>&1 | sed 's/^/    /'
 
-# ---------------------------------------------------------------- 5. observe
+# ------------------------------------------------- 5. it must decline, for now
+say "the archive should record the fork but decline to repair it"
+# Long enough for several passes of the finaliser's 60s loop, so this is a
+# settled refusal rather than a race.
+sleep 75
+
+STAGE=$(psql_ -c "SELECT stage FROM hardfork_state WHERE id=1;" 2>/dev/null)
+[[ "$STAGE" == "announced" ]] \
+  || fail "expected the fork to be recorded as 'announced', got '${STAGE:-none}'"
+
+STILL_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pending';")
+[[ "$STILL_PENDING" == "7" ]] \
+  || fail "the archive repaired before the post-fork genesis arrived (${STILL_PENDING} pending)"
+
+if grep -q "post-fork chain's genesis block has not arrived" "${WORK}/archive.log"; then
+  echo "    declined, and said why:"
+  grep -o "Not settling the fork boundary yet.*" "${WORK}/archive.log" | tail -1 | sed 's/^/      /'
+else
+  fail "the archive did not say it was waiting for the post-fork genesis"
+fi
+
+# ------------------------------------------------- 6. the genesis block arrives
+say "the post-fork genesis block arrives, corroborating the fork block"
+docker exec -e PGPASSWORD=pw -i "$PG_CONTAINER" psql -q -U postgres -d "$DB" \
+  < "${HERE}/fork_genesis.sql" >/dev/null || { echo "genesis insert failed"; exit 1; }
+
 say "watching the boundary settle"
 SETTLED=0
 for _ in $(seq 1 40); do
@@ -178,6 +207,12 @@ done
 
 AFTER_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pending';")
 [[ "$AFTER_PENDING" == "0" ]] || fail "${AFTER_PENDING} blocks still pending after the repair"
+
+# The post-fork genesis is the new chain, not something to sweep up. It carries
+# a different protocol version, and the boundary slot taken from it is what
+# keeps the orphaning below the fork.
+GEN=$(psql_ -c "SELECT chain_status FROM blocks WHERE state_hash='FORK_GENESIS';")
+[[ "$GEN" == "canonical" ]] || fail "the post-fork genesis is '${GEN}', expected canonical"
 
 say "archive log, hard fork lines"
 grep -iE "hard fork|fork boundary|settl|canonical" "${WORK}/archive.log" | tail -12 | sed 's/^/    /'

--- a/scripts/tests/archive-automode/runner.sh
+++ b/scripts/tests/archive-automode/runner.sh
@@ -13,10 +13,10 @@
 #      strands: a band of pending blocks the archive can no longer canonicalise
 #   2. a running archive, in automode
 #   3. the configuration, sent over the archive RPC
-#   4. the archive records it and *declines* to repair: the fork block is so far
-#      attested only by that message, and nothing has corroborated it
-#   5. the post-fork genesis block arrives, its parent hash confirming the fork
-#      block
+#   4. the archive records it and *declines* to repair: the hand-over begins
+#      with the genesis block, and this seed gives it no ledger to build one
+#   5. the post-fork genesis block arrives another way, which is enough -- the
+#      hand-over needs the block to exist, not to have built it itself
 #   6. now the band heals -- pending becomes canonical on the chain to the fork
 #      block, and orphaned off it
 #
@@ -170,11 +170,16 @@ STILL_PENDING=$(psql_ -c "SELECT count(*) FROM blocks WHERE chain_status='pendin
 [[ "$STILL_PENDING" == "7" ]] \
   || fail "the archive repaired before the post-fork genesis arrived (${STILL_PENDING} pending)"
 
-if grep -q "post-fork chain's genesis block has not arrived" "${WORK}/archive.log"; then
+# The hand-over stops at its first step, which is the genesis block, and that
+# step needs a ledger this seed does not provide. So the refusal names the
+# ledger rather than the block: the archive is not waiting for someone to
+# deliver a genesis, it is waiting for the means to build one.
+if grep -q "waiting on the genesis ledger" "${WORK}/archive.log"; then
   echo "    declined, and said why:"
-  grep -o "Not settling the fork boundary yet.*" "${WORK}/archive.log" | tail -1 | sed 's/^/      /'
+  grep -o "The hand-over is waiting on the genesis ledger.*" "${WORK}/archive.log" \
+    | tail -1 | cut -c1-140 | sed 's/^/      /'
 else
-  fail "the archive did not say it was waiting for the post-fork genesis"
+  fail "the archive did not say it was waiting for the genesis ledger"
 fi
 
 # ------------------------------------------------- 6. the genesis block arrives

--- a/scripts/tests/archive-automode/seed.sql
+++ b/scripts/tests/archive-automode/seed.sql
@@ -1,0 +1,75 @@
+-- A pre-fork archive frozen at the moment a hard fork strands it.
+--
+-- The shape that matters: canonicalisation advances only when a block arrives
+-- more than k above the highest canonical one. The pre-fork chain stops, so the
+-- last stretch of blocks is left pending for good, and their off-chain siblings
+-- are never orphaned. That is what the finaliser has to repair.
+--
+-- Heights are small and k is overridden in the harness, so the same shape can be
+-- exercised without seeding hundreds of blocks.
+
+BEGIN;
+
+INSERT INTO public_keys (id, value) VALUES
+  (1, 'B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg'),
+  (2, 'B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g');
+
+INSERT INTO snarked_ledger_hashes (id, value) VALUES
+  (1, 'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m');
+
+INSERT INTO epoch_data
+  (id, seed, ledger_hash_id, total_currency, start_checkpoint,
+   lock_checkpoint, epoch_length)
+VALUES
+  (1, '2vaRh7FQ5wSzmpFReF9gcRKjv48CcJvHs25aqb3SSZiPgHQBy5Dt', 1,
+   '10000000000', 'CHECKPOINT_START', 'CHECKPOINT_LOCK', 1);
+
+INSERT INTO protocol_versions (id, transaction, network, patch) VALUES
+  (1, 3, 0, 0),   -- pre-fork
+  (2, 4, 0, 0);   -- post-fork
+
+-- The pre-fork chain. Heights 1..10 on the winning branch.
+--
+-- 1..5   already canonical: canonicalisation got this far before the chain
+--        stopped, and nothing since has been able to advance it.
+-- 6..10  pending, and stuck. 10 is the fork block.
+INSERT INTO blocks
+  (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+   last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+   next_epoch_data_id, min_window_density, sub_window_densities,
+   total_currency, ledger_hash, height, global_slot_since_hard_fork,
+   global_slot_since_genesis, protocol_version_id, timestamp, chain_status)
+SELECT
+  h,
+  'B_' || lpad(h::text, 3, '0'),
+  CASE WHEN h = 1 THEN NULL ELSE h - 1 END,
+  CASE WHEN h = 1 THEN 'GENESIS' ELSE 'B_' || lpad((h-1)::text, 3, '0') END,
+  1, 1, 'vrf', 1, 1, 1, 77, ARRAY[7,7,7,7,7,7,7]::bigint[],
+  '10000000000', 'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+  h, h, h, 1, (1700000000 + h * 180)::text,
+  (CASE WHEN h <= 5 THEN 'canonical' ELSE 'pending' END)::chain_status_type
+FROM generate_series(1, 10) AS h;
+
+-- Off-chain siblings at heights 7 and 9: legitimately produced, lost the fork
+-- race, and left pending because nothing ever orphaned them. The repair has to
+-- mark these orphaned, not canonical.
+INSERT INTO blocks
+  (id, state_hash, parent_id, parent_hash, creator_id, block_winner_id,
+   last_vrf_output, snarked_ledger_hash_id, staking_epoch_data_id,
+   next_epoch_data_id, min_window_density, sub_window_densities,
+   total_currency, ledger_hash, height, global_slot_since_hard_fork,
+   global_slot_since_genesis, protocol_version_id, timestamp, chain_status)
+VALUES
+  (107, 'ORPHAN_007', 6, 'B_006', 2, 2, 'vrf', 1, 1, 1, 77,
+   ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
+   'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+   7, 7, 7, 1, '1701260000', 'pending'::chain_status_type),
+  (109, 'ORPHAN_009', 8, 'B_008', 2, 2, 'vrf', 1, 1, 1, 77,
+   ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
+   'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
+   9, 9, 9, 1, '1701260360', 'pending'::chain_status_type);
+
+SELECT setval(pg_get_serial_sequence('blocks', 'id'), 200);
+SELECT setval(pg_get_serial_sequence('public_keys', 'id'), 200);
+
+COMMIT;

--- a/scripts/tests/archive-automode/seed.sql
+++ b/scripts/tests/archive-automode/seed.sql
@@ -46,7 +46,10 @@ SELECT
   CASE WHEN h = 1 THEN 'GENESIS' ELSE 'B_' || lpad((h-1)::text, 3, '0') END,
   1, 1, 'vrf', 1, 1, 1, 77, ARRAY[7,7,7,7,7,7,7]::bigint[],
   '10000000000', 'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
-  h, h, h, 1, (1700000000 + h * 180)::text,
+  -- The era's genesis block is the one at global_slot_since_hard_fork = 0.
+  -- The archive marks such a block canonical on insert, and the repair anchors
+  -- on it, so the seed has to have one.
+  h, h - 1, h, 1, (1700000000 + h * 180)::text,
   (CASE WHEN h <= 5 THEN 'canonical' ELSE 'pending' END)::chain_status_type
 FROM generate_series(1, 10) AS h;
 
@@ -63,11 +66,11 @@ VALUES
   (107, 'ORPHAN_007', 6, 'B_006', 2, 2, 'vrf', 1, 1, 1, 77,
    ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
    'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
-   7, 7, 7, 1, '1701260000', 'pending'::chain_status_type),
+   7, 6, 7, 1, '1701260000', 'pending'::chain_status_type),
   (109, 'ORPHAN_009', 8, 'B_008', 2, 2, 'vrf', 1, 1, 1, 77,
    ARRAY[7,7,7,7,7,7,7]::bigint[], '10000000000',
    'jxo5pSyt16XGwA9UeuAdiFDzrwFH3smbNTJF7fxq98w1y9Jem2m',
-   9, 9, 9, 1, '1701260360', 'pending'::chain_status_type);
+   9, 8, 9, 1, '1701260360', 'pending'::chain_status_type);
 
 SELECT setval(pg_get_serial_sequence('blocks', 'id'), 200);
 SELECT setval(pg_get_serial_sequence('public_keys', 'id'), 200);

--- a/src/app/archive/lib/hardfork_sql.ml
+++ b/src/app/archive/lib/hardfork_sql.ml
@@ -138,6 +138,24 @@ let first_block_of_protocol_version (module Conn : CONNECTION)
   in
   Conn.find_opt query v
 
+(** A block's own global slot since genesis.
+
+    Needed because the [fork] stanza of a runtime configuration does not carry
+    it: [global_slot_since_genesis] there is the slot the *new* chain's genesis
+    is scheduled at, which
+    [Mina_lib.Hardfork_config.move_hard_fork_consensus_to_scheduled_genesis]
+    deliberately moves forward from the fork block. The two differ by the hard
+    fork genesis slot delta, so anything comparing against a block's recorded
+    slot has to ask the block. *)
+let block_slot_by_state_hash (module Conn : CONNECTION) ~state_hash =
+  let query =
+    Caqti_type.(string ->? int64)
+      {%string|
+        SELECT global_slot_since_genesis FROM blocks WHERE state_hash = ? LIMIT 1;
+      |}
+  in
+  Conn.find_opt query state_hash
+
 let block_info_by_state_hash (module Conn : CONNECTION) ~state_hash =
   let query =
     Caqti_type.(string ->? Block_info.typ)

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4729,11 +4729,14 @@ module Hardfork_state = struct
     match%bind load_opt (module Conn) with
     | None ->
         let%map () = insert (module Conn) t in
+        (* The state hash is formatted in rather than interpolated from the
+           metadata below: plain-text logs drop interpolated values longer than
+           50 characters, and a base58 state hash is 52. It stays in the
+           metadata as well, for readers that parse the JSON. *)
         [%log info]
           "Recorded a hard fork at height $height, from $source. The fork \
-           block's state hash is in this message's metadata: plain-text logs \
-           drop interpolated values longer than 50 characters, and a state \
-           hash is 52."
+           block is %s."
+          t.fork_state_hash
           ~metadata:
             [ ("state_hash", `String t.fork_state_hash)
             ; ("height", `String (Int64.to_string t.fork_blockchain_length))
@@ -4826,6 +4829,9 @@ module Hardfork_finaliser = struct
       principle: the archive keeps its current answer and tries again. *)
   type not_ready =
     | Fork_block_absent
+    | Fork_genesis_absent
+    | Fork_genesis_mismatch of
+        { expected_parent : string; actual_parent : string }
     | Era_genesis_absent of Hardfork_sql.Protocol_version.t
     | Too_few_confirmations of { have : int; want : int }
     | Chain_incomplete of { expected_oldest : string; actual_oldest : string }
@@ -4834,6 +4840,16 @@ module Hardfork_finaliser = struct
   let describe = function
     | Fork_block_absent ->
         "the fork block is not in this database yet"
+    | Fork_genesis_absent ->
+        "the post-fork chain's genesis block has not arrived, so the fork \
+         block is so far attested only by the configuration and nothing has \
+         corroborated it"
+    | Fork_genesis_mismatch { expected_parent; actual_parent } ->
+        sprintf
+          "a post-fork genesis block is here, but it forked from %s rather \
+           than the %s the configuration names, so this archive will not \
+           choose between them"
+          actual_parent expected_parent
     | Era_genesis_absent v ->
         sprintf
           "the fork block is here, but the database holds no genesis block for \
@@ -4919,11 +4935,30 @@ module Hardfork_finaliser = struct
                    the fork block is missing would send whoever reads the log
                    looking for the wrong thing. *)
                 return (Error (Era_genesis_absent fork_block.protocol_version))
-            | Some oldest ->
-                let%map ancestry =
+            | Some oldest -> (
+                let%bind ancestry =
                   Hardfork_sql.blocks_between_both_inclusive
                     (module Conn)
                     ~latest_block_id:fork_block.id ~oldest_block_id:oldest.id
+                in
+                (* The post-fork chain's genesis block, which has to be here
+                   before any history is rewritten.
+
+                   It corroborates the configuration: its parent hash is the
+                   fork block's, so the chain itself confirms what the daemon
+                   asserted, and the repair stops acting on a single unverified
+                   message.
+
+                   It also bounds the orphaning. blocks_to_orphan takes a
+                   fork_boundary_slot from this block; without one the bound is
+                   NULL and every same-version block off the canonical chain is
+                   orphaned however far above the fork it sits. Mesa bumps the
+                   protocol version, so that filter happens to save us -- but a
+                   fork that kept its version would have no protection at all. *)
+                let%map fork_context =
+                  Hardfork_sql.fork_block_above_height
+                    (module Conn)
+                    ~height:fork_block.height
                 in
                 (* The walk follows parent links, so a short chain means a
                    missing block rather than a shorter history. *)
@@ -4934,36 +4969,55 @@ module Hardfork_finaliser = struct
                   | b :: _ ->
                       b.Hardfork_sql.Block_info.state_hash
                 in
-                if String.equal actual_oldest oldest.state_hash then
-                  Ok (fork_block, ancestry)
-                else
+                if not (String.equal actual_oldest oldest.state_hash) then
                   Error
                     (Chain_incomplete
                        { expected_oldest = oldest.state_hash; actual_oldest } )
-        )
+                else
+                  match fork_context with
+                  | None ->
+                      Error Fork_genesis_absent
+                  | Some fc -> (
+                      match fc.Hardfork_sql.Fork_context.parent_state_hash with
+                      | Some parent
+                        when String.equal parent hardfork_state.fork_state_hash
+                        ->
+                          Ok (fork_block, ancestry, fc)
+                      | Some parent ->
+                          Error
+                            (Fork_genesis_mismatch
+                               { expected_parent =
+                                   hardfork_state.fork_state_hash
+                               ; actual_parent = parent
+                               } )
+                      | None ->
+                          (* A genesis with no parent is the chain's own first
+                             block, not a fork of ours. *)
+                          Error
+                            (Fork_genesis_mismatch
+                               { expected_parent =
+                                   hardfork_state.fork_state_hash
+                               ; actual_parent = "nothing"
+                               } ) ) ) )
 
-  let apply (module Conn : CONNECTION) ~(fork_block : Hardfork_sql.Block_info.t)
-      ~ancestry =
+  let apply (module Conn : CONNECTION) ~ancestry
+      ~(fork_context : Hardfork_sql.Fork_context.t) ~protocol_version =
     let open Deferred.Result.Let_syntax in
     let canonical_block_ids =
       List.map ancestry ~f:(fun b -> b.Hardfork_sql.Block_info.id)
     in
-    (* A fork above the target bounds what may be orphaned: blocks at or beyond
-       it are the post-fork chain and must keep their status. *)
-    let%bind fork_context =
-      Hardfork_sql.fork_block_above_height
-        (module Conn)
-        ~height:fork_block.height
-    in
+    (* The post-fork genesis bounds what may be orphaned: blocks at or beyond
+       it are the new chain and must keep their status. The check has already
+       established that this block forked from ours, so it is not re-queried
+       here -- a second lookup could see a different answer. *)
     let fork_boundary_slot =
-      Option.map fork_context ~f:(fun fc ->
-          fc.Hardfork_sql.Fork_context.fork_slot )
+      Some fork_context.Hardfork_sql.Fork_context.fork_slot
     in
     let%map () =
       Hardfork_sql.mark_pending_blocks_as_canonical_or_orphaned
         (module Conn)
         ~canonical_block_ids ~stop_at_slot:None ~fork_boundary_slot
-        ~protocol_version:fork_block.protocol_version
+        ~protocol_version
     in
     List.length canonical_block_ids
 
@@ -4990,21 +5044,29 @@ module Hardfork_finaliser = struct
                 in
                 match result with
                 | Error reason ->
+                    (* Formatted into the message rather than interpolated from
+                       metadata: plain-text logs drop interpolated values over
+                       50 characters, and every one of these reasons is longer
+                       than that. The reason is the whole point of the line. *)
                     [%log info]
-                      "Not settling the fork boundary yet: $reason. This will \
-                       be retried."
-                      ~metadata:[ ("reason", `String (describe reason)) ] ;
+                      "Not settling the fork boundary yet: %s. This will be \
+                       retried."
+                      (describe reason) ;
                     let%map (_ : bool) = unlock conn in
                     ()
-                | Ok (fork_block, ancestry) ->
-                    let%bind marked = apply conn ~fork_block ~ancestry in
+                | Ok (fork_block, ancestry, fork_context) ->
+                    let%bind marked =
+                      apply conn ~ancestry ~fork_context
+                        ~protocol_version:
+                          fork_block.Hardfork_sql.Block_info.protocol_version
+                    in
                     let%bind () = mark_finalized conn in
                     let%map (_ : bool) = unlock conn in
                     [%log info]
                       "Settled the fork boundary at height $height: $count \
                        blocks marked canonical, the rest of that protocol \
-                       version below the fork orphaned. The fork block's state \
-                       hash is in this message's metadata."
+                       version below the fork orphaned. The fork block is %s."
+                      hardfork_state.fork_state_hash
                       ~metadata:
                         [ ("state_hash", `String hardfork_state.fork_state_hash)
                         ; ( "height"

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4824,6 +4824,7 @@ module Hardfork_finaliser = struct
       principle: the archive keeps its current answer and tries again. *)
   type not_ready =
     | Fork_block_absent
+    | Era_genesis_absent of Hardfork_sql.Protocol_version.t
     | Too_few_confirmations of { have : int; want : int }
     | Chain_incomplete of { expected_oldest : string; actual_oldest : string }
     | Not_on_best_chain
@@ -4831,6 +4832,12 @@ module Hardfork_finaliser = struct
   let describe = function
     | Fork_block_absent ->
         "the fork block is not in this database yet"
+    | Era_genesis_absent v ->
+        sprintf
+          "the fork block is here, but the database holds no genesis block for \
+           protocol version %s -- the repair anchors on it, so the blocks \
+           below the fork cannot be walked"
+          (Hardfork_sql.Protocol_version.to_string v)
     | Too_few_confirmations { have; want } ->
         sprintf
           "the fork block has %d confirmations, fewer than the %d required" have
@@ -4887,9 +4894,12 @@ module Hardfork_finaliser = struct
                 ~v:fork_block.protocol_version
             with
             | None ->
-                (* No block of this protocol version, which cannot happen when
-                   the fork block itself is one. Treat as not ready. *)
-                return (Error Fork_block_absent)
+                (* The era's genesis block -- the one at
+                   global_slot_since_hard_fork = 0 -- is what the repair anchors
+                   on. Without it there is nothing to walk back to, and saying
+                   the fork block is missing would send whoever reads the log
+                   looking for the wrong thing. *)
+                return (Error (Era_genesis_absent fork_block.protocol_version))
             | Some oldest ->
                 let%map ancestry =
                   Hardfork_sql.blocks_between_both_inclusive

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -4730,8 +4730,10 @@ module Hardfork_state = struct
     | None ->
         let%map () = insert (module Conn) t in
         [%log info]
-          "Recorded hard fork at block $state_hash, height $height, from \
-           $source"
+          "Recorded a hard fork at height $height, from $source. The fork \
+           block's state hash is in this message's metadata: plain-text logs \
+           drop interpolated values longer than 50 characters, and a state \
+           hash is 52."
           ~metadata:
             [ ("state_hash", `String t.fork_state_hash)
             ; ("height", `String (Int64.to_string t.fork_blockchain_length))
@@ -4867,12 +4869,29 @@ module Hardfork_finaliser = struct
         return (Error Fork_block_absent)
     | Some fork_block -> (
         let%bind tip = Hardfork_sql.latest_state_hash (module Conn) in
+        (* The block's own slot, not the configuration's. The fork stanza's
+           global_slot_since_genesis is the slot the post-fork chain's genesis
+           is scheduled at, which sits a delta beyond the fork block -- 161
+           slots on devnet's mesa fork. Comparing that against a recorded block
+           slot never matches, and the repair would decline for ever. *)
+        let%bind fork_slot =
+          match%map
+            Hardfork_sql.block_slot_by_state_hash
+              (module Conn)
+              ~state_hash:hardfork_state.fork_state_hash
+          with
+          | Some slot ->
+              slot
+          | None ->
+              (* Cannot happen: the block was just found by the same hash. *)
+              hardfork_state.fork_global_slot
+        in
         let%bind on_best_chain =
           Hardfork_sql.is_in_best_chain
             (module Conn)
             ~tip_hash:tip ~check_hash:hardfork_state.fork_state_hash
             ~check_height:(Int64.to_int_exn fork_block.height)
-            ~check_slot:hardfork_state.fork_global_slot
+            ~check_slot:fork_slot
         in
         if not on_best_chain then return (Error Not_on_best_chain)
         else
@@ -4880,7 +4899,7 @@ module Hardfork_finaliser = struct
             Hardfork_sql.num_of_confirmations
               (module Conn)
               ~latest_state_hash:tip
-              ~fork_slot:(Int64.to_int_exn hardfork_state.fork_global_slot)
+              ~fork_slot:(Int64.to_int_exn fork_slot)
           in
           if confirmations < required_confirmations then
             return
@@ -4982,11 +5001,16 @@ module Hardfork_finaliser = struct
                     let%bind () = mark_finalized conn in
                     let%map (_ : bool) = unlock conn in
                     [%log info]
-                      "Settled the fork boundary at $state_hash: $count blocks \
-                       marked canonical, the rest of that protocol version \
-                       below the fork orphaned."
+                      "Settled the fork boundary at height $height: $count \
+                       blocks marked canonical, the rest of that protocol \
+                       version below the fork orphaned. The fork block's state \
+                       hash is in this message's metadata."
                       ~metadata:
                         [ ("state_hash", `String hardfork_state.fork_state_hash)
+                        ; ( "height"
+                          , `String
+                              (Int64.to_string
+                                 hardfork_state.fork_blockchain_length ) )
                         ; ("count", `Int marked)
                         ] ) ) )
       pool

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2125,6 +2125,78 @@ let archive_blocks =
                    path (Error.to_string_hum err) ;
                  add_to_failure_file path ) ) )
 
+let send_hardfork_config =
+  let params =
+    let open Command.Let_syntax in
+    let%map_open config_file =
+      Command.Param.anon ("config-file" %: Command.Param.string)
+    and archive_process_location = Cli_lib.Flag.Host_and_port.Daemon.archive in
+    (config_file, archive_process_location)
+  in
+  Command.async
+    ~summary:
+      "Send a hard fork runtime configuration to an archive node.\n\n\
+       The archive derives everything it needs about a fork from this one \
+       message: the config's fork stanza is the fork block's identity, and its \
+       ledger stanzas locate and verify the genesis ledger. A daemon sends it \
+       automatically when it generates the config; this does the same thing by \
+       hand, which is what makes the archive's hand-over testable without \
+       running a fork."
+    (Cli_lib.Background_daemon.graphql_init params
+       ~f:(fun _graphql_endpoint (config_file, archive_process_location) ->
+         let logger = Logger.create () in
+         let archive_process_location =
+           match archive_process_location with
+           | Some location ->
+               location
+           | None ->
+               failwith
+                 "An archive address is required: this talks to the archive \
+                  directly rather than through a daemon"
+         in
+         let%bind config_json =
+           match%map
+             Deferred.Or_error.try_with ~here:[%here] (fun () ->
+                 Reader.file_contents config_file )
+           with
+           | Ok contents ->
+               contents
+           | Error e ->
+               failwithf "Could not read %s: %s" config_file
+                 (Error.to_string_hum e) ()
+         in
+         (* Parsed here only to fail early on a file that the archive would
+            reject anyway, with a message naming the file rather than the
+            wire. *)
+         ( match
+             Or_error.try_with (fun () -> Yojson.Safe.from_string config_json)
+             |> Or_error.bind ~f:(fun json ->
+                    Runtime_config.of_yojson json
+                    |> Result.map_error ~f:Error.of_string )
+           with
+         | Error e ->
+             failwithf "%s is not a runtime configuration: %s" config_file
+               (Error.to_string_hum e) ()
+         | Ok runtime_config -> (
+             match Runtime_config.fork runtime_config with
+             | None ->
+                 failwithf
+                   "%s has no fork stanza, so it does not describe a forked \
+                    network and the archive would refuse it"
+                   config_file ()
+             | Some fork ->
+                 printf "Sending the fork at %s (height %d) to the archive\n"
+                   fork.state_hash fork.blockchain_length ) ) ;
+         match%map
+           Mina_lib.Archive_client.dispatch_hardfork_config ~logger
+             archive_process_location ~config_json
+         with
+         | Ok () ->
+             printf "Sent.\n"
+         | Error e ->
+             failwithf "Could not send to the archive: %s"
+               (Error.to_string_hum e) () ) )
+
 let receipt_chain_hash =
   let proof_cache_db = Proof_cache_tag.create_identity_db () in
   let open Command.Let_syntax in
@@ -2519,6 +2591,7 @@ let advanced ~itn_features =
     ; ("add-peers", add_peers_graphql)
     ; ("object-lifetime-statistics", object_lifetime_statistics)
     ; ("archive-blocks", archive_blocks)
+    ; ("send-hardfork-config", send_hardfork_config)
     ; ("compute-receipt-chain-hash", receipt_chain_hash)
     ; ("hash-transaction", hash_transaction)
     ; ("set-coinbase-receiver", set_coinbase_receiver_graphql)

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2187,8 +2187,11 @@ let send_hardfork_config =
              | Some fork ->
                  printf "Sending the fork at %s (height %d) to the archive\n"
                    fork.state_hash fork.blockchain_length ) ) ;
+         (* One attempt. The daemon retries because it is on a heartbeat and
+            nobody is watching; someone running this by hand wants an answer,
+            not the same failure logged five times. *)
          match%map
-           Mina_lib.Archive_client.dispatch_hardfork_config ~logger
+           Mina_lib.Archive_client.dispatch_hardfork_config ~max_tries:1 ~logger
              archive_process_location ~config_json
          with
          | Ok () ->


### PR DESCRIPTION
Part of the archive automode series (#19245). **Stacked on #19266.** Targets `feat/archive_automode`.

## The idea

The archive learns about a fork from exactly one message: the runtime configuration a daemon generated for it. That makes the whole hand-over testable by **sending the same message by hand** — no fork, no daemon, no ledger.

## What

**`mina advanced send-hardfork-config <config.json> --archive-address host:port`**

Sits next to `archive-blocks` and exists for the same reason: talking to an archive directly is how the archive gets exercised. It parses the config before sending, so a file the archive would reject fails here with a message naming *the file* rather than the wire.

**`scripts/tests/archive-automode/`** puts the pieces together, in the order a real fork puts them:

1. a database on the pre-fork schema
2. seeded with the boundary a fork strands — a band of pending blocks canonicalisation can no longer reach, with off-chain siblings at two heights
3. a running archive in automode
4. the configuration, over the archive RPC
5. **the archive records the fork and refuses to repair it** — see below
6. the post-fork genesis block arrives
7. now the band heals, and the assertions check that it healed correctly

The seed is deliberately small. What matters is the **shape**, not the scale.

## The repair now waits for the chain to confirm the fork

Until this PR, the repair acted on the configuration message alone. One message named a block as the fork point and the archive rewrote history around it.

It now waits for the **post-fork chain's genesis block**. That block's parent hash is the fork block's, so the chain itself confirms what the daemon asserted. If a genesis block is present but forked from a different block, the archive says so and does nothing.

That block also **bounds the orphaning**. `blocks_to_orphan` takes its slot as `fork_boundary_slot`; with no genesis the bound is `NULL`, and every same-version block off the canonical chain is orphaned however far above the fork it sits. Mesa bumps the protocol version, so that filter happens to save us today — but a fork that kept its version would have had no protection at all.

This also gives the hand-over the sequence an operator expects: the pre-fork daemon stops, the post-fork daemon starts and feeds its genesis block in, and only then does the archive touch history.

## It passes, end to end, on the synthetic seed

```
phase 1 — config sent, genesis not yet here
  fork on record, finalized_at NULL, 7 blocks still pending, nothing rewritten
  "Not settling the fork boundary yet: the post-fork chain's genesis block
   has not arrived, so the fork block is so far attested only by the
   configuration and nothing has corroborated it. This will be retried."

phase 2 — genesis block inserted
  "Settled the fork boundary at height "10": 10 blocks marked canonical,
   the rest of that protocol version below the fork orphaned."

  before:  canonical 5,  pending 7
  after:   canonical 11, orphaned 2, pending 0
```

Both off-chain siblings ended **orphaned**, not swept into the canonical set — the case a naive repair gets wrong.

## And on the real devnet archive at the mesa fork

The devnet archive as it stood at the mesa fork on 2026-08-19: 681,253 blocks, 401 of them stranded pending, the fork block among them.

```
phase 1 — the real fork config, sent to the archive
  declined for 8 minutes of retries; not one row changed

phase 2 — the mesa genesis block present
  settled in 20s

                            before      after
  canonical                545,203    545,433
  pending at or below fork     332          0
  fork block                pending  canonical
```

545,433 canonical blocks is an unbroken chain from genesis to the fork block.

The 69 berkeley blocks above the fork became `orphaned`. That is correct: they are the empty-block window the mesa chain abandoned, and their slots are below the boundary the genesis block sets, so the guard does not protect them. The one block left `pending` is the mesa genesis itself, which ordinary `update_chain_status` canonicalises once k blocks build on it.

One value in that run is not real. The public mesa archive was unreachable from the test machine, so the genesis block's **own state hash** is synthetic and labelled as such in the fixture. Every value the code reads is real: the parent hash, the height, and the slots.

## What running it caught

**A slot that means something else.** `Fork_config.global_slot_since_genesis` is the **scheduled** hard fork genesis slot, not the fork block's slot. On devnet they are 161 apart (859560 against 859399). Both the best-chain check and the confirmation count compared that number against recorded block slots, so on a real fork neither could ever match and the archive would have declined for ever. The finaliser now asks the block for its slot. The synthetic seed made the two values equal, which is why it passed and devnet did not.

**A diagnostic that lies.** The finaliser anchors the repair on the era's genesis block — the one at `global_slot_since_hard_fork = 0`. When that was absent it reported *"the fork block is not in this database yet"*, with a comment in the code claiming the case could not happen. It can, and when it does **the fork block is right there**. `Era_genesis_absent` now names the protocol version and says what the repair needs it for.

**Logs that drop what matters.** `logproc` discards interpolated values longer than 50 characters. A base58 state hash is 52, and every refusal reason is longer, so an operator saw `Not settling the fork boundary yet: $reason` and no reason at all. Both are formatted into the message now.

None of these was visible to the type checker or to any unit test. Only a real archive against a real database surfaced them.

Two smaller things the harness had to get right and did not at first, both now fixed and commented:

- **`pg_isready` lies too.** The image runs initdb against a temporary server before restarting, so it answers ready while the real server is still coming up. Retrying `createdb` is what proves usability.
- **`epoch_data` has six `NOT NULL` columns** the seed has to fill.

## Scope

This covers the repair path, its refusal paths for the genesis block, and the real devnet boundary. Still uncovered:

- the fork genesis block insert (#19255) and the genesis accounts load (#19257) — both need a real ledger tarball
- the `upgrade_to_mesa.sql` migration path; the devnet run added `hardfork_state` directly
- the remaining refusal paths (confirmations, chain closure, best chain) as seed variants
- CI wiring

