### PR TITLE
Point minaBaseBookworm back at an image that exists

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -6,9 +6,10 @@
 --       MinaProtocol/mina-release-toolkit. Pinned to a released version tag
 --       (not a moving tag like :latest) for reproducible CI; bump it
 --       deliberately when a newer toolkit is wanted.
--- NOTE: the amd64 mina-toolchain images are on b8d9c69 (carries the
---       mina-bench-upload benchmark uploader), while bookworm arm64 stays on
---       ffab0f8.
+-- NOTE: mina-toolchain and mina-base are published by DIFFERENT pipelines and
+--       their hashes move independently. mina-toolchain comes from
+--       mina-toolchains-build; mina-base from mina-docker-base-build
+--       (!ci-docker-base-me). Bumping one is never a reason to bump the other.
 -- NOTE: minaBase* are the published common base-deps images on docker.io. The tag
 --       format matches build.sh's HASHTAG for service=mina-base: <githash>-<codename>-<network>.
 --       These are frozen references, like minaToolchain*: the daemon/archive/hardfork
@@ -34,8 +35,8 @@
 , minaToolchain =
     "docker.io/minaprotocol/mina-toolchain:4e95b64-bullseye-devnet"
 , minaBaseBookworm =
-    { amd64 = "docker.io/minaprotocol/mina-base:4e95b64-bookworm-devnet"
-    , arm64 = "docker.io/minaprotocol/mina-base:4e95b64-bookworm-devnet-arm64"
+    { amd64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet"
+    , arm64 = "docker.io/minaprotocol/mina-base:86b89d0-bookworm-devnet-arm64"
     }
 , minaBaseBullseye.amd64 =
     "docker.io/minaprotocol/mina-base:86b89d0-bullseye-devnet"


### PR DESCRIPTION
Follow-up to `55f9100468 bump toolchains`. Two lines and a comment.

### What happened

That commit bumped the `mina-toolchain` pins to `4e95b64` — correct, build [#426](https://buildkite.com/o-1-labs-2/mina-toolchains-build/builds/426) published all five and they are present. But it carried `minaBaseBookworm` along with them, and **nothing publishes `mina-base` at that hash**:

| Image | On docker.io |
| --- | --- |
| `mina-base:4e95b64-bookworm-devnet` | ❌ missing |
| `mina-base:4e95b64-bookworm-devnet-arm64` | ❌ missing |
| `mina-base:86b89d0-bookworm-devnet` | ✅ present |
| `mina-base:86b89d0-bookworm-devnet-arm64` | ✅ present |

The two families come from different pipelines and their hashes move independently:

- `mina-toolchain` ← `mina-toolchains-build`
- `mina-base` ← `mina-docker-base-build` (`!ci-docker-base-me`)

### Why CI did not catch it

By design. `DockerImage.dhall` calls the cache load as:

```
( ./buildkite/scripts/docker/load_from_cache.sh <image> \
  || echo mina-base-not-in-ci-cache-inlining-base-deps-stage )
```

A miss falls back to inlining the base-deps stage, so the build still succeeds. The only cost is that every bookworm build re-runs base-deps instead of starting `FROM` the published image — slower builds, no failure. Worth fixing precisely because nothing will ever complain about it.

### The comment

Replaced rather than corrected. The old NOTE named the hashes each family happened to be on (`b8d9c69`, `ffab0f8`) — the part most likely to go stale, and it already had. The replacement states the durable fact instead: the two families come from different pipelines, so bumping one is never a reason to bump the other.

`make all` passes: 18 tests, 48 assertions. `mina-toolchain` pins are untouched.