### PR TITLE
Let a release pipeline set the channel it is publishing to

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -362,7 +362,7 @@ let build_artifacts
                             , Network.foldMinaBuildMainnetEnv nets
                             , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                             , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
-                            , "MINA_DEB_RELEASE=${DebianChannel.lowerName
+                            , "MINA_DEB_RELEASE=${DebianChannel.effective
                                                     spec.channel}"
                             ]
                           # BuildFlags.buildEnvs spec.buildFlags
@@ -407,7 +407,7 @@ let commonBuildEnvs =
                 , Network.foldMinaBuildMainnetEnv nets
                 , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                 , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
-                , "MINA_DEB_RELEASE=${DebianChannel.lowerName spec.channel}"
+                , "MINA_DEB_RELEASE=${DebianChannel.effective spec.channel}"
                 ]
               # BuildFlags.buildEnvs spec.buildFlags
               # spec.extraBuildEnvs
@@ -791,7 +791,7 @@ let docker_commands
                   ->  DockerImage.generateStep
                         (     s
                           //  { deb_release =
-                                  DebianChannel.lowerName spec.channel
+                                  DebianChannel.effective spec.channel
                               , docker_repo = spec.docker_repo
                               }
                         )

--- a/buildkite/src/Constants/DebianChannel.dhall
+++ b/buildkite/src/Constants/DebianChannel.dhall
@@ -50,4 +50,38 @@ let lowerName =
             }
             channel
 
-in  { Type = Channel, capitalName = capitalName, lowerName = lowerName }
+let Prelude = ../External/Prelude.dhall
+
+let envOverride
+    : Optional Text
+    =
+      -- The channel a release pipeline is publishing to, if it says.
+      --
+      -- Read here rather than declared per job because the alternative is a
+      -- job file per channel: ten packaging jobs times three channels. The
+      -- env var is absent everywhere except a release pipeline, so every
+      -- other render keeps the channel its job declares.
+      --
+      -- Text, not Channel, on purpose. Dhall cannot turn a string into a
+      -- union alternative -- it has no Text equality at all -- so a typed
+      -- value would have to be spliced into the expression as source, which
+      -- is how the pipeline filters do it and is a code-execution hole when
+      -- the value is not trusted. Passing Text keeps the value inert here;
+      -- scripts/debian/builder-helpers.sh rejects a name that is not a real
+      -- channel, where string comparison actually exists.
+      Some env:MINA_RELEASE_CHANNEL as Text ? None Text
+
+let effective
+    : Channel -> Text
+    =
+      -- The channel to build for: what the pipeline asked for, else what the
+      -- job declares.
+          \(declared : Channel)
+      ->  Prelude.Optional.default Text (lowerName declared) envOverride
+
+in  { Type = Channel
+    , capitalName = capitalName
+    , lowerName = lowerName
+    , envOverride = envOverride
+    , effective = effective
+    }

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -10,6 +10,30 @@ MINA_DEB_VERSION=${MINA_DEB_VERSION:-"0.0.0-experimental"}
 MINA_DEB_RELEASE=${MINA_DEB_RELEASE:-"unstable"}
 ARCHITECTURE=${ARCHITECTURE:-"amd64"}
 
+# MINA_DEB_RELEASE becomes the `Suite:` field of every package built here, and
+# the apt component they are published into. It can now be set by a release
+# pipeline rather than only by the job definition, so it is checked against the
+# channels that actually exist.
+#
+# The check lives here, in bash, because Dhall cannot do it: it has no Text
+# equality, so the value travels from the pipeline as an unvalidated string.
+# Without this a typo does not fail -- deb-s3 would create a component named
+# after it and publish there, and nothing downstream would notice, because the
+# package's own Suite field would agree with the typo.
+#
+# Keep in step with Channel in buildkite/src/Constants/DebianChannel.dhall.
+MINA_DEB_KNOWN_RELEASES=(
+  unstable develop compatible master itn umt umt-mainnet
+  devnet alpha beta experimental stable
+)
+if [[ ! " ${MINA_DEB_KNOWN_RELEASES[*]} " == *" ${MINA_DEB_RELEASE} "* ]]; then
+  echo "❌ MINA_DEB_RELEASE='${MINA_DEB_RELEASE}' is not a known channel." >&2
+  echo "   Known: ${MINA_DEB_KNOWN_RELEASES[*]}" >&2
+  echo "   This becomes the Suite: field and the apt component, so a name" >&2
+  echo "   that is not a real channel would publish somewhere nobody reads." >&2
+  exit 1
+fi
+
 # Helper script to include when building deb archives.
 
 echo "--- Setting up the environment to build debian packages..."


### PR DESCRIPTION
First of two PRs wiring the release pipelines. This one lets a pipeline name its channel; the next adds the publish job.

### Why

`PackagingSpec.channel` is declared per job, so building for `alpha` would mean a job file per channel — ten packaging jobs × three channels. A release pipeline needs to say it once instead.

`DebianChannel.effective` reads `MINA_RELEASE_CHANNEL` and falls back to the channel the job declares:

```
$ dhall-to-yaml <<< '(./src/Jobs/Release/MinaArtifactBullseye.dhall)' | grep MINA_DEB_RELEASE
MINA_DEB_RELEASE=unstable

$ MINA_RELEASE_CHANNEL=alpha dhall-to-yaml <<< '…' | grep -E 'MINA_DEB_RELEASE|deb-release'
MINA_DEB_RELEASE=alpha
--deb-release alpha
```

**Inert by default.** The variable is absent everywhere except a release pipeline. I diffed the full rendered pipeline against `develop` with it unset — byte-identical.

### Why it carries Text, not a `Channel`

Dhall cannot turn a string into a union alternative — it has **no Text equality at all**. A typed value would have to be spliced into the expression as Dhall *source*, which is how `Prepare.dhall` passes the pipeline filters. That is fine for pipeline settings but it is a code-execution path, and it is the same hole #19227 closed for comment input. Text keeps the value inert while it is inside Dhall.

### So the check is in bash

`builder-helpers.sh` rejects a `MINA_DEB_RELEASE` that is not a real channel:

| value | result |
| --- | --- |
| `stable`, `alpha` | builds |
| `stabel` | ❌ `is not a known channel` |
| unset | falls back to `unstable` |

This matters more than it looks. Without it a typo **fails nowhere**: `deb-s3` creates a component named after it and publishes there, the package's own `Suite:` field agrees with the typo so nothing looks inconsistent, and the release quietly lands where nobody is looking. The list is kept next to a comment pointing at `Channel` in `DebianChannel.dhall`.

### Verification

- `make all` — 18 tests, 48 assertions
- `scripts/debian/tests/test_builder_helpers.sh` — 36 tests, 279 assertions
- rendered-pipeline diff vs develop with the variable unset: empty
- `shellcheck` clean at CI's `-S warning` level

### Not in this PR

The `Publish` tag filter and `Jobs/Release/PublishDebians.dhall`. Until those land, a release pipeline can package to the right channel but not publish it.