### PR TITLE
Publish this build's debians to the channel it was packaged for

### DIFF
--- a/buildkite/src/Command/Packages/PublishDebians.dhall
+++ b/buildkite/src/Command/Packages/PublishDebians.dhall
@@ -1,0 +1,156 @@
+-- Publish the .deb files this build produced, exactly as they were built.
+--
+-- The packaging jobs write their output into the CI cache and stop there.
+-- This reads that output back and hands it to `release-manager publish`,
+-- which uploads it and then asks the repository, package by package, whether
+-- each one is really listed at the version and architecture it was built
+-- with.
+--
+-- Nothing is rewritten on the way. The version comes from the git tag the
+-- build was made from and the `Suite:` field was written at packaging time
+-- from the same MINA_RELEASE_CHANNEL this step publishes into, so the package
+-- that reaches the repository is the package that was tested. That is the
+-- whole point of dropping the promotion step: `release-manager
+-- publish-from-cache` still exists for the flows that genuinely need a
+-- rewrite.
+--
+-- Ordering is the pipeline's job, not this file's. A release pipeline uploads
+-- the packaging stage, waits, then uploads this one, so a failed test or a
+-- failed package build means this step is never reached.
+
+let Prelude = ../../External/Prelude.dhall
+
+let List/map = Prelude.List.map
+
+let Text/concatSep = Prelude.Text.concatSep
+
+let Cmd = ../../Lib/Cmds.dhall
+
+let Command = ../Base.dhall
+
+let Size = ../Size.dhall
+
+let FixPermissions = ../FixPermissions.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+let ContainerImages = ../../Constants/ContainerImages.dhall
+
+let DebianChannel = ../../Constants/DebianChannel.dhall
+
+let DebianRepo = ../../Constants/DebianRepo.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Spec =
+      { Type =
+          { codenames : List DebianVersions.DebVersion
+          , channel : DebianChannel.Type
+          , debianRepo : DebianRepo.Type
+          , verify : Bool
+          , label : Text
+          , key : Text
+          }
+      , default =
+          { codenames = [ DebianVersions.DebVersion.Bullseye ]
+          , channel = DebianChannel.Type.Unstable
+          , debianRepo = DebianRepo.Type.Unstable
+          , verify = True
+          , label = "Publish debians"
+          , key = "publish-debians"
+          }
+      }
+
+let debsFolder = "_publish"
+
+let readFromCache
+    : Spec.Type -> List Cmd.Type
+    =
+      -- One read per codename, into its own folder.
+      --
+      -- read_all_from_cache.sh puts the packages of ONE codename flat into
+      -- LOCAL_DEB_FOLDER, and `release-manager publish` wants a
+      -- {codename}/*.deb tree, so the codename is the folder rather than
+      -- something the publish step has to reconstruct from file names.
+          \(spec : Spec.Type)
+      ->  List/map
+            DebianVersions.DebVersion
+            Cmd.Type
+            (     \(codename : DebianVersions.DebVersion)
+              ->  let lower = DebianVersions.lowerName codename
+
+                  in  Cmd.run
+                        (     "MINA_DEB_CODENAME=${lower}"
+                          ++  " ROOT=\\\${BUILDKITE_BUILD_ID}"
+                          ++  " LOCAL_DEB_FOLDER=${debsFolder}/${lower}"
+                          ++  " ./buildkite/scripts/debian/read_all_from_cache.sh"
+                        )
+            )
+            spec.codenames
+
+let publishCmd
+    : Spec.Type -> Cmd.Type
+    =     \(spec : Spec.Type)
+      ->  let codenames =
+                Text/concatSep
+                  ","
+                  ( List/map
+                      DebianVersions.DebVersion
+                      Text
+                      DebianVersions.lowerName
+                      spec.codenames
+                  )
+
+          let verifyArg = if spec.verify then " --verify" else ""
+
+          let signArg =
+                merge
+                  { Some = \(key : Text) -> " --debian-sign-key ${key}"
+                  , None = ""
+                  }
+                  (DebianRepo.keyId spec.debianRepo)
+
+          in  Cmd.runInDocker
+                Cmd.Docker::{
+                , image = ContainerImages.minaReleaseToolkit
+                , extraEnv = [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
+                , privileged = True
+                , useRoot = True
+                }
+                (     "git config --global --add safe.directory /workdir && "
+                  ++  ". ./buildkite/scripts/export-git-env-vars.sh && "
+                  ++  "gpg --import /var/secrets/debian/key.gpg && "
+                  ++  "release-manager publish"
+                  ++  " --source-folder ${debsFolder}"
+                  ++  " --codenames ${codenames}"
+                  ++  " --channel ${DebianChannel.effective spec.channel}"
+                  ++  " --debian-repo ${DebianRepo.bucket_or_default
+                                          spec.debianRepo}"
+                  ++  signArg
+                  ++  verifyArg
+                )
+
+let step
+    -- NOTE: Command.Base prepends automatic retries for infrastructure exit
+    -- codes (255 agent lost, 143 SIGTERM, ...) and a job can only add to that
+    -- list, not remove from it. Uploading is not idempotent: `release-manager
+    -- publish` passes --fail-if-exists, so a retry after a partial upload
+    -- fails with "package already exists" rather than finishing the job. That
+    -- is a loud, safe failure -- nothing is overwritten and nothing is
+    -- silently half-published -- but it needs a human. The real fix is to make
+    -- publish idempotent (an identical package already present is success),
+    -- which belongs in release-manager.
+    : Spec.Type -> Command.Type
+    =     \(spec : Spec.Type)
+      ->  Command.build
+            Command.Config::{
+            , commands =
+                  [ FixPermissions.command Arch.Type.Amd64 ]
+                # readFromCache spec
+                # [ publishCmd spec ]
+            , label = spec.label
+            , key = spec.key
+            , target = Size.Small
+            }
+
+in  { Type = Spec.Type, Spec = Spec, step = step, debsFolder = debsFolder }

--- a/buildkite/src/Command/Packages/PublishDebians.dhall
+++ b/buildkite/src/Command/Packages/PublishDebians.dhall
@@ -133,13 +133,33 @@ let publishCmd
 let step
     -- NOTE: Command.Base prepends automatic retries for infrastructure exit
     -- codes (255 agent lost, 143 SIGTERM, ...) and a job can only add to that
-    -- list, not remove from it. Uploading is not idempotent: `release-manager
-    -- publish` passes --fail-if-exists, so a retry after a partial upload
-    -- fails with "package already exists" rather than finishing the job. That
-    -- is a loud, safe failure -- nothing is overwritten and nothing is
-    -- silently half-published -- but it needs a human. The real fix is to make
-    -- publish idempotent (an identical package already present is success),
-    -- which belongs in release-manager.
+    -- list, not remove from it, so this step has to survive being run twice.
+    -- Mostly it does. `release-manager publish` writes each package to the
+    -- path its name and version already determine, so a second attempt
+    -- rewrites what the first one got through and adds what it never
+    -- reached. Checked against the pinned toolkit: publishing a folder
+    -- holding one already published package and one new one exits 0 with
+    -- both listed. Exit 1 is in the retry list only with a limit of 0
+    -- (flake_retry_limit), so a publish that fails stops rather than looping.
+    --
+    -- The exception is an attempt killed while deb-s3 held the repository
+    -- lock. publish passes --lock and no --arch, so the lock is
+    -- dists/{codename}/{channel}/binary-/lockfile with the architecture
+    -- segment left empty, and nothing collects it afterwards. The next
+    -- attempt waits ten minutes on that lock and then gives up, leaving the
+    -- lock where it was, so every attempt after that costs another ten
+    -- minutes until someone deletes the key. That is the case that needs a
+    -- human, and it is what clear-s3-lockfile.sh exists for on the older
+    -- bash path.
+    --
+    -- What a second attempt does not do is notice that the bytes changed.
+    -- --fail-if-exists is passed, but it refuses only a name and version
+    -- already published under a different pool filename, which a rebuild
+    -- does not produce, and a leftover .deb-s3-temp object whose bytes
+    -- differ, which only a killed attempt leaves. A plain re-publish of
+    -- different bytes at the same version passes both and replaces what is
+    -- published silently. Guarding that belongs to release-manager and is
+    -- tracked in MinaProtocol/mina-release-toolkit#38.
     : Spec.Type -> Command.Type
     =     \(spec : Spec.Type)
       ->  Command.build

--- a/buildkite/src/Jobs/Release/PublishDebians.dhall
+++ b/buildkite/src/Jobs/Release/PublishDebians.dhall
@@ -1,0 +1,49 @@
+-- Publish this build's .deb files to the channel the pipeline named.
+--
+-- Scoped to Release and tagged Publish so it is selected only by a release
+-- pipeline's publish stage. Nothing else runs it: nightly builds packages and
+-- deliberately does not publish them.
+--
+-- dirtyWhen is `everything` because this is not a reaction to a file changing.
+-- It is what the pipeline exists to do, and the scope keeps it out of every
+-- other pipeline.
+--
+-- The channel and the repository are read from the environment via
+-- DebianChannel.effective, so the three release pipelines share this one job
+-- and differ only in what they set.
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let PublishDebians = ../../Command/Packages/PublishDebians.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let DebianRepo = ../../Constants/DebianRepo.dhall
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen = [ S.everything ]
+        , path = "Release"
+        , name = "PublishDebians"
+        , scope = [ PipelineScope.Type.Release ]
+        , tags = [ PipelineTag.Type.Publish, PipelineTag.Type.Release ]
+        }
+      , steps =
+        [ PublishDebians.step
+            PublishDebians.Spec::{
+            , codenames = [ DebianVersions.DebVersion.Bullseye ]
+            , debianRepo = DebianRepo.Type.Unstable
+            , label = "Publish: debians"
+            , key = "publish-debians"
+            }
+        ]
+      }

--- a/buildkite/src/Pipeline/Tag.dhall
+++ b/buildkite/src/Pipeline/Tag.dhall
@@ -36,6 +36,7 @@ let Tag
       | Archive
       | Mesa
       | Packaging
+      | Publish
       >
 
 let capitalName =
@@ -69,6 +70,7 @@ let capitalName =
             , Archive = "Archive"
             , Mesa = "Mesa"
             , Packaging = "Packaging"
+            , Publish = "Publish"
             }
             tag
 
@@ -103,6 +105,7 @@ let lowerName =
             , Archive = "archive"
             , Mesa = "mesa"
             , Packaging = "packaging"
+            , Publish = "publish"
             }
             tag
 

--- a/buildkite/src/Pipeline/TagFilter.dhall
+++ b/buildkite/src/Pipeline/TagFilter.dhall
@@ -18,6 +18,7 @@ let Filter
       | DebianBuild
       | DockerBuild
       | Packaging
+      | Publish
       | Rosetta
       | Hardfork
       | AllDockersAndDebians
@@ -61,6 +62,7 @@ let tags
             , DebianBuild = [ Tag.Type.Debian ]
             , DockerBuild = [ Tag.Type.Docker ]
             , Packaging = [ Tag.Type.Packaging ]
+            , Publish = [ Tag.Type.Publish ]
             , AllTests = [ Tag.Type.Lint, Tag.Type.Release, Tag.Type.Test ]
             , Release = [ Tag.Type.Release ]
             , Promote = [ Tag.Type.Promote ]
@@ -216,6 +218,7 @@ let show
             , DebianBuild = "DebianBuild"
             , DockerBuild = "DockerBuild"
             , Packaging = "Packaging"
+            , Publish = "Publish"
             , Rosetta = "Rosetta"
             , Hardfork = "Hardfork"
             , AllDockersAndDebians = "AllDockersAndDebians"


### PR DESCRIPTION
> **Stacked on [#19270](https://github.com/MinaProtocol/mina/pull/19270)** — retarget to `develop` once that merges.

Second of two. #19270 lets a pipeline name its channel; this adds the step that publishes to it. Together they make a release pipeline possible without the promotion stage.

### What it does

The packaging jobs write their `.deb` files into the CI cache and stop. Nothing in the repo takes them from there to an apt repository — that was the promotion pipeline's job, and it re-versioned them on the way.

`PublishDebians` reads them back and hands them to `release-manager publish`, which uploads them **unchanged** and then asks the repository, package by package, whether each is listed at the version and architecture it was built with.

```
release-manager publish --source-folder _publish --codenames bullseye \
  --channel alpha --debian-repo unstable.apt.packages.minaprotocol.com \
  --debian-sign-key 386E9DAC… --verify
```

That `--channel alpha` is the render with `MINA_RELEASE_CHANNEL=alpha` set — the value flows from the pipeline env through #19270 into both the `Suite:` field at packaging time and the component here, so they cannot disagree.

### One cache read per codename

`read_all_from_cache.sh` puts one codename's packages **flat** into `LOCAL_DEB_FOLDER`, and `publish` wants a `{codename}/*.deb` tree. So the codename becomes the directory rather than something publish has to reconstruct from file names.

### Ordering is not expressed here

Deliberately. A release pipeline uploads the packaging stage, `wait`s, then uploads this one — so a failed test or a failed package build means this step is never reached. Encoding it as `depends_on` instead would either slow nightly down or require a second copy of every packaging job.

### Verification

New `Publish` tag and filter, so a pipeline can select this stage and only this stage. Checked against the real triage:

| Filter | `PublishDebians` |
| --- | --- |
| `Publish` | ✅ selected — and it is the **only** job selected |
| `FastOnly` | absent |
| `LongAndVeryLong` | absent |
| `Packaging` | absent |

Scope is `Release` only, so nightly still packages without publishing. The rendered-pipeline diff against the base branch is exactly two new files and nothing else. `make all` passes: 18 tests, 48 assertions.

### Known limitation, flagged in the file

`Command.Base` prepends automatic retries for infrastructure exit codes (255 agent lost, 143 SIGTERM…) and a job can only *add* to that list, not remove from it. Uploading is not idempotent — `release-manager publish` passes `--fail-if-exists` — so a retry after a partial upload fails with "package already exists" rather than finishing.

That is a **loud, safe failure**: nothing is overwritten, nothing is silently half-published. But it needs a human. The real fix is making `publish` idempotent (an identical package already present counts as success), which belongs in release-manager and is worth doing before this runs unattended.