### PR TITLE
Say what the publish step actually does when it is run twice

### DIFF
--- a/buildkite/src/Command/Packages/PublishDebians.dhall
+++ b/buildkite/src/Command/Packages/PublishDebians.dhall
@@ -133,13 +133,33 @@ let publishCmd
 let step
     -- NOTE: Command.Base prepends automatic retries for infrastructure exit
     -- codes (255 agent lost, 143 SIGTERM, ...) and a job can only add to that
-    -- list, not remove from it. Uploading is not idempotent: `release-manager
-    -- publish` passes --fail-if-exists, so a retry after a partial upload
-    -- fails with "package already exists" rather than finishing the job. That
-    -- is a loud, safe failure -- nothing is overwritten and nothing is
-    -- silently half-published -- but it needs a human. The real fix is to make
-    -- publish idempotent (an identical package already present is success),
-    -- which belongs in release-manager.
+    -- list, not remove from it, so this step has to survive being run twice.
+    -- Mostly it does. `release-manager publish` writes each package to the
+    -- path its name and version already determine, so a second attempt
+    -- rewrites what the first one got through and adds what it never
+    -- reached. Checked against the pinned toolkit: publishing a folder
+    -- holding one already published package and one new one exits 0 with
+    -- both listed. Exit 1 is in the retry list only with a limit of 0
+    -- (flake_retry_limit), so a publish that fails stops rather than looping.
+    --
+    -- The exception is an attempt killed while deb-s3 held the repository
+    -- lock. publish passes --lock and no --arch, so the lock is
+    -- dists/{codename}/{channel}/binary-/lockfile with the architecture
+    -- segment left empty, and nothing collects it afterwards. The next
+    -- attempt waits ten minutes on that lock and then gives up, leaving the
+    -- lock where it was, so every attempt after that costs another ten
+    -- minutes until someone deletes the key. That is the case that needs a
+    -- human, and it is what clear-s3-lockfile.sh exists for on the older
+    -- bash path.
+    --
+    -- What a second attempt does not do is notice that the bytes changed.
+    -- --fail-if-exists is passed, but it refuses only a name and version
+    -- already published under a different pool filename, which a rebuild
+    -- does not produce, and a leftover .deb-s3-temp object whose bytes
+    -- differ, which only a killed attempt leaves. A plain re-publish of
+    -- different bytes at the same version passes both and replaces what is
+    -- published silently. Guarding that belongs to release-manager and is
+    -- tracked in MinaProtocol/mina-release-toolkit#38.
     : Spec.Type -> Command.Type
     =     \(spec : Spec.Type)
       ->  Command.build


### PR DESCRIPTION
Stacked on #19271. Comment only — rendered with the CI toolchain's own `dhall-to-yaml` 1.6.2, `Jobs/Release/PublishDebians.dhall` produces byte-identical YAML before and after (6197 bytes, md5 `efc0ccecd87a52cfe6aa653ba07876e6`).

#19271 flags a known limitation on `PublishDebians`:

> Uploading is not idempotent: `release-manager publish` passes `--fail-if-exists`, so a retry after a partial upload fails with "package already exists" rather than finishing the job. That is a loud, safe failure — nothing is overwritten and nothing is silently half-published — but it needs a human.

The instinct is right — there *is* a case that needs a human — but every specific in that paragraph turns out to be wrong, including the reassuring half. This rewrites it to say what the code does.

### The ordinary retry is fine

`release-manager` here is the Rust binary in `ghcr.io/minaprotocol/mina-release-toolkit:0.0.5`, not this repo's `buildkite/scripts/release/manager.sh`. Run against that binary with a real `deb-s3` talking to MinIO and `.deb` fixtures built by `dpkg-deb`:

| Run | Input | Exit | Repository afterwards |
| --- | --- | --- | --- |
| 1 | fresh package, empty repo | 0 | `SHA256: 6abb3baf…` |
| 2 | byte-identical re-run | **0** | unchanged — no `already exists` |
| 3 | same name+version, **different bytes** | **0** | **`SHA256: 6c0dd772…`** — silently replaced |

And the exact partial-upload case — publish A alone, then re-run over a folder holding an identical A plus a new B:

```
ATTEMPT 1 exit = 0     1 package(s) uploaded
ATTEMPT 2 exit = 0     2 package(s) uploaded, all 2 present
```

Also checked, all exit 0 on the second run: three codenames at once, two architectures in one folder, an `arch=all` package alongside a real arch, only-one-of-two changed, and the signed path with `--debian-sign-key` (`InRelease` and `Release.gpg` regenerated).

### The case that does need a human is the lock

`publish` passes `--lock` and no `--arch`, so `Deb::S3::Lock.lock_path` (`lock.rb:52-55`) resolves the architecture segment to the empty string. Planting a stale lock and re-publishing:

| stale lock at | result |
| --- | --- |
| `dists/bullseye/alpha/binary-amd64/lockfile` | ignored — publish completes, **exit 0 in 3s** |
| `dists/bullseye/alpha/binary-/lockfile` | **still blocked after 45s** |

Measured end to end: **605 seconds, exit 1** — 60 attempts at 10s then an uncaught `throw` (`lock.rb:20-27`). Exit 1 is what `flake_retry_limit = Some 0` does not retry. The lock is held from `cli.rb:173` to `cli.rb:267`, so a SIGTERM or a lost agent inside that window leaves it behind and nothing collects it — including the failure it just caused, so every further attempt costs another ten minutes until someone deletes the key.

I also checked this is the *only* residue that breaks a retry, by `SIGKILL`ing a real publish at six offsets on fresh buckets and re-running plainly: kills at t+3s and t+6s leave the lock and block; kills at t+9s and t+13s leave `.deb-s3-temp` objects and the re-run still **exits 0** (they are consumed); later kills leave nothing. `s3_store` writes each object with a single whole-body `put_object` (`utils.rb:103-106`), so there is no torn `Packages`, `Packages.gz`, `Release` or `InRelease` to trip over.

This is not novel to this repo: `scripts/debian/publish.sh:105-125` wraps its upload in a ten-iteration loop calling `scripts/debian/clear-s3-lockfile.sh` for exactly this shape of problem. Worth noting that script does not actually work on its own path, though — `publish.sh:121` passes `--arch $ARCH` so its lock is arch-qualified, while the script probes the empty-arch key, and `publish.sh:125` passes only `MINA_DEB_BUCKET` so the codename and component fall back to hardcoded `bullseye`/`unstable`. The empty-arch key it probes is the right one for `release-manager` and the wrong one for `publish.sh`. Either way the new step has no equivalent at all.

### `--fail-if-exists` does not guard the overwrite

In the `deb-s3` the toolkit ships (pinned fork 0.11.7) it refuses two things, neither of which is the ordinary case:

* `Manifest#add` raises when the name and version already exist **under a different pool basename** (`manifest.rb:60-71`) — a rebuild produces the identical basename, so it falls through to `preserve_versions`, which deletes the old entry and adds the new one.
* `s3_store` raises when a leftover `<pool>.deb-s3-temp` object has different bytes (`utils.rb:85`) — that key only exists if a previous run died between `cli.rb:274` and `cli.rb:283`.

A plain re-publish of different bytes at the same version passes both. Run 3 above is completely silent: no warning, no stderr line, no exit-code difference from run 1. Guarding it belongs in `release-manager`, so it is filed as **MinaProtocol/mina-release-toolkit#38** with a reproduction, the root cause and a proposed pre-flight identity check.

### One more correction folded in

"A job can only add to that list, not remove from it" is true and worth keeping (`Command/Base.dhall:232` is `# c.retries`). But exit `1` *is* in the list, with `limit = 0` (`Base.dhall:211-214`, `flake_retry_limit` default at `:116`), so a publish that genuinely fails is terminal rather than looping. The old comment implied it would loop; the new one says limit 0.

### Not changed here, but worth a look

`Jobs/Release/PublishDebians.dhall:38` tags the job `[Publish, Release]`, and the header says it is "selected only by a release pipeline's publish stage". `TagFilter.Release` resolves to `[Release]` (`Pipeline/TagFilter.dhall:67`) and the filter mode defaults to `Any` at every layer (`Prepare.dhall:26`, `list_jobs.sh:41`, `monorepo.sh:139`), so running `has_matching_tags` from `buildkite/scripts/monorepo_lib.sh` against this job's rendered tags returns a match for `Release` and for `AllTests`. `ScopeFilter.StableOnly` is `[MainlineNightly, Release]` (`ScopeFilter.dhall:24`), which `scope_matches` also accepts. So `scope` is doing all the work and the tags do not narrow anything. Dropping `PipelineTag.Type.Release` from line 38 would make the header's claim true — your call, I left it alone.

### Verification

Run in `ci-toolchain-base:v4`, i.e. the image the Lint job uses (dhall 1.30.0, dhall-to-yaml 1.6.2) — not local tooling:

* `make check_syntax`, `make check_lint`, `make check_format` — all pass on the whole tree
* `dhall --ascii format --check --inplace` and `lint --check --inplace` on the changed file — no rewrite
* rendered YAML identical before and after
* every added comment line ≤ 78 columns

Every claim here went through two independent adversarial passes. The first refuted two of them — "it survives being run twice" (the lock) and "only raises on a different pool filename" (`utils.rb:85`) — and both are corrected above and in the commit. The second could not break any sentence of the comment, and added the `SIGKILL` sweep and the 605-second measurement quoted above.
