### PR TITLE
Send a release to the registries it is actually meant for

### DIFF
--- a/buildkite/scripts/pipeline/validate-release-env.sh
+++ b/buildkite/scripts/pipeline/validate-release-env.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Reject a release variable that is set to something Dhall will quietly ignore.
+#
+# MINA_RELEASE_DOCKER_REPO carries a Dhall value, and the expression that reads
+# it ends in `? None Repo` so that an unset variable means "use the job's own
+# registry". That fallback cannot tell "unset" from "set to something that does
+# not resolve", because Dhall collapses both into the same None:
+#
+#   '< Internal | InternalEurope | Public >.Public'  -> Some .Public
+#   '< Internal | InternalEurope | Public >.Pubic'   -> None   (typo)
+#   'Public'                                         -> None   (plain word)
+#   'docker.io/minaprotocol'                         -> None   (address)
+#
+# So a release asking for docker.io, with one letter wrong, pushes its images
+# to the internal registry instead and the build stays green. The wrong
+# direction is at least the safe one -- a typo always falls back to the job
+# default, which is internal, never public -- but "the images never reached
+# docker.io and nothing said so" is the kind of quiet failure this pipeline is
+# meant to be free of.
+#
+# Dhall cannot make the difference itself: it has no Text equality, so the
+# variable cannot be matched against a list of accepted spellings there. Here
+# it can.
+
+set -euo pipefail
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+UNION='< Internal | InternalEurope | Public >'
+ACCEPTED=(
+  "${UNION}.Internal"
+  "${UNION}.InternalEurope"
+  "${UNION}.Public"
+)
+
+value="${MINA_RELEASE_DOCKER_REPO:-}"
+
+if [[ -z "$value" ]]; then
+  # Unset is a real answer: every job keeps the registry it declares, which is
+  # what nightly and pull request CI want.
+  exit 0
+fi
+
+for accepted in "${ACCEPTED[@]}"; do
+  if [[ "$value" == "$accepted" ]]; then
+    echo -e "${GREEN}✅ MINA_RELEASE_DOCKER_REPO accepted${CLEAR}"
+    echo "    ${value}"
+    exit 0
+  fi
+done
+
+echo -e "${RED}❌ MINA_RELEASE_DOCKER_REPO is set to a value Dhall will ignore.${CLEAR}" >&2
+echo "" >&2
+echo "    got:      ${value}" >&2
+echo "" >&2
+echo "    expected exactly one of:" >&2
+for accepted in "${ACCEPTED[@]}"; do
+  echo "      ${accepted}" >&2
+done
+echo "" >&2
+echo "    Anything else resolves to nothing, and the expression that reads it" >&2
+echo "    cannot tell that from the variable being unset. The build would have" >&2
+echo "    gone green with every image pushed to the registry each job declares" >&2
+echo "    rather than the one asked for here." >&2
+exit 1

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -792,7 +792,8 @@ let docker_commands
                         (     s
                           //  { deb_release =
                                   DebianChannel.effective spec.channel
-                              , docker_repo = spec.docker_repo
+                              , docker_repo =
+                                  DockerRepo.effective spec.docker_repo
                               }
                         )
                 )

--- a/buildkite/src/Constants/DebianRepo.dhall
+++ b/buildkite/src/Constants/DebianRepo.dhall
@@ -8,7 +8,10 @@ let Optional/toList = Prelude.Optional.toList
 
 let DebianRepo
     : Type
-    = < Unstable | Nightly | Stable >
+    = -- O1Test is packages.o1test.net: one unsigned repository carrying every
+      -- channel, and the one the release pipelines publish to. The three
+      -- minaprotocol.com repositories are signed and split by channel.
+      < Unstable | Nightly | Stable | O1Test >
 
 let address =
           \(repo : DebianRepo)
@@ -16,6 +19,7 @@ let address =
             { Unstable = "https://unstable.apt.packages.minaprotocol.com"
             , Nightly = "https://nightly.apt.packages.minaprotocol.com"
             , Stable = "https://stable.apt.packages.minaprotocol.com"
+            , O1Test = "https://packages.o1test.net"
             }
             repo
 
@@ -25,6 +29,7 @@ let bucket =
             { Unstable = Some "unstable.apt.packages.minaprotocol.com"
             , Nightly = Some "nightly.apt.packages.minaprotocol.com"
             , Stable = Some "stable.apt.packages.minaprotocol.com"
+            , O1Test = Some "packages.o1test.net"
             }
             repo
 
@@ -56,12 +61,15 @@ let keyId =
             { Unstable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Nightly = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
             , Stable = Some "386E9DAC378726A48ED5CE56ADB30D9ACE02F414"
+            , O1Test = None Text
             }
             repo
 
 let isSigned =
           \(repo : DebianRepo)
-      ->  merge { Unstable = True, Nightly = True, Stable = True } repo
+      ->  merge
+            { Unstable = True, Nightly = True, Stable = True, O1Test = False }
+            repo
 
 let keyAddress =
           \(repo : DebianRepo)
@@ -71,6 +79,7 @@ let keyAddress =
                 { Unstable = Some (address repo ++ keyPath)
                 , Nightly = Some (address repo ++ keyPath)
                 , Stable = Some (address repo ++ keyPath)
+                , O1Test = None Text
                 }
                 repo
 

--- a/buildkite/src/Constants/DockerRepo.dhall
+++ b/buildkite/src/Constants/DockerRepo.dhall
@@ -1,3 +1,5 @@
+let Prelude = ../External/Prelude.dhall
+
 let Repo
     : Type
     = < Internal | InternalEurope | Public >
@@ -12,4 +14,38 @@ let show =
             }
             repo
 
-in  { Type = Repo, show = show }
+let publicOverride
+    : Optional Text
+    =
+      -- Set by a release pipeline to send its images to the public registry.
+      --
+      -- It has to be an environment variable rather than a field on the job,
+      -- because the packaging jobs are shared: nightly and a release pipeline
+      -- run the very same MinaArtifact* jobs and must push to different
+      -- registries. A field could only give one answer for both.
+      --
+      -- Presence is the whole signal and the value is ignored, deliberately.
+      -- Dhall has no Text equality, so a variable carrying a registry NAME
+      -- could not be matched against the alternatives of this union without
+      -- splicing it in as source. A flag cannot be misspelled into a
+      -- different destination -- the only two outcomes are set and unset.
+      Some env:MINA_RELEASE_PUBLIC_DOCKER as Text ? None Text
+
+let effective
+    : Repo -> Repo
+    =
+      -- The registry to push to: public when the pipeline asked for it, else
+      -- whatever the job declares.
+          \(declared : Repo)
+      ->  Prelude.Optional.fold
+            Text
+            publicOverride
+            Repo
+            (\(_ : Text) -> Repo.Public)
+            declared
+
+in  { Type = Repo
+    , show = show
+    , publicOverride = publicOverride
+    , effective = effective
+    }

--- a/buildkite/src/Constants/DockerRepo.dhall
+++ b/buildkite/src/Constants/DockerRepo.dhall
@@ -14,38 +14,47 @@ let show =
             }
             repo
 
-let publicOverride
-    : Optional Text
+let envOverride
+    : Optional Repo
     =
-      -- Set by a release pipeline to send its images to the public registry.
+      -- The registry a release pipeline pushes to, if it says.
       --
       -- It has to be an environment variable rather than a field on the job,
       -- because the packaging jobs are shared: nightly and a release pipeline
       -- run the very same MinaArtifact* jobs and must push to different
       -- registries. A field could only give one answer for both.
       --
-      -- Presence is the whole signal and the value is ignored, deliberately.
-      -- Dhall has no Text equality, so a variable carrying a registry NAME
-      -- could not be matched against the alternatives of this union without
-      -- splicing it in as source. A flag cannot be misspelled into a
-      -- different destination -- the only two outcomes are set and unset.
-      Some env:MINA_RELEASE_PUBLIC_DOCKER as Text ? None Text
+      -- The variable holds a Dhall value, spelled out in full:
+      --
+      --   MINA_RELEASE_DOCKER_REPO='< Internal | InternalEurope | Public >.Public'
+      --
+      -- Verbose, and deliberately so. Dhall 1.30 has no Text equality, so a
+      -- plain word cannot be turned into one of these alternatives at all,
+      -- and a plain registry address would be an unchecked string pointing
+      -- anywhere. Written this way the value is type checked when the
+      -- pipeline renders, and both ways of getting it wrong are loud:
+      --
+      --   .Pubic                  -> Missing constructor: Pubic
+      --   < Foo | Bar >.Foo       -> Expression doesn't match annotation
+      --
+      -- WARNING: do not write an import here. A path is resolved relative to
+      -- neither the repository root nor this file, so it fails to resolve,
+      -- the ? below treats that as absent, and the release pushes to the
+      -- job's default registry with no warning at all. The alternatives must
+      -- be spelled out, and they must match Repo above exactly -- adding an
+      -- alternative there is a change every release pipeline has to be told
+      -- about, which is why it errors rather than passing silently.
+      Some (env:MINA_RELEASE_DOCKER_REPO : Repo) ? None Repo
 
 let effective
     : Repo -> Repo
     =
-      -- The registry to push to: public when the pipeline asked for it, else
-      -- whatever the job declares.
-          \(declared : Repo)
-      ->  Prelude.Optional.fold
-            Text
-            publicOverride
-            Repo
-            (\(_ : Text) -> Repo.Public)
-            declared
+      -- The registry to push to: what the pipeline asked for, else what the
+      -- job declares.
+      \(declared : Repo) -> Prelude.Optional.default Repo declared envOverride
 
 in  { Type = Repo
     , show = show
-    , publicOverride = publicOverride
+    , envOverride = envOverride
     , effective = effective
     }

--- a/buildkite/src/Jobs/Release/PublishDebians.dhall
+++ b/buildkite/src/Jobs/Release/PublishDebians.dhall
@@ -41,7 +41,7 @@ in  Pipeline.build
         [ PublishDebians.step
             PublishDebians.Spec::{
             , codenames = [ DebianVersions.DebVersion.Bullseye ]
-            , debianRepo = DebianRepo.Type.Unstable
+            , debianRepo = DebianRepo.Type.O1Test
             , label = "Publish: debians"
             , key = "publish-debians"
             }

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -1,5 +1,12 @@
 -- Autogenerates any pre-reqs for monorepo triage execution
 -- Keep these rules lean! They have to run unconditionally.
+--
+-- validate-release-env.sh runs first and costs nothing when the release
+-- variables are unset, which is every pipeline but the release ones. It is
+-- here rather than in a release pipeline's own steps because the value it
+-- checks is read while the pipeline below is being rendered: by the time a
+-- release job could check it, the wrong registry is already baked into every
+-- docker step.
 
 let SelectFiles = ./Lib/SelectFiles.dhall
 
@@ -36,7 +43,8 @@ let config
         [ Command.build
             Command.Config::{
             , commands =
-              [ Cmd.run "export BUILDKITE_PIPELINE_MODE=${mode}"
+              [ Cmd.run "./buildkite/scripts/pipeline/validate-release-env.sh"
+              , Cmd.run "export BUILDKITE_PIPELINE_MODE=${mode}"
               , Cmd.run "export BUILDKITE_PIPELINE_JOB_SELECTION=${selection}"
               , Cmd.run "export BUILDKITE_PIPELINE_FILTER=${tagFilter}"
               , Cmd.run "export BUILDKITE_PIPELINE_SCOPE=${scopeFilter}"


### PR DESCRIPTION
Found while checking whether the release pipelines could actually be created. The staging worked; both **destinations** were wrong, and both would have failed quietly.

### 1. Debians went to the wrong bucket

`Jobs/Release/PublishDebians.dhall` pinned `DebianRepo.Type.Unstable`, so a stable release rendered as `--channel stable --debian-repo unstable.apt.packages.minaprotocol.com` — a `stable` component **inside the unstable bucket**. Signed, verified, and in the wrong place.

Releases go to `packages.o1test.net`, which **was not in the enum at all**. Added with `keyId = None` and `isSigned = False`, so the publish command drops `--debian-sign-key` by itself:

```
release-manager publish --channel stable --debian-repo packages.o1test.net --verify
```

### 2. Images were still going to the internal registry

`PackagingSpec` gained `docker_repo` in #19259, but **nothing ever set it** — "push to docker.io" was a field nobody wrote to.

It has to be an environment variable, not a job field, because **the packaging jobs are shared**: nightly and a release pipeline run the very same `MinaArtifact*` jobs and must push to different registries. A field can only give one answer for both.

`MINA_RELEASE_DOCKER_REPO` carries a Dhall value naming one alternative, so all three registries are reachable:

| value | registry |
| --- | --- |
| `'< Internal \| InternalEurope \| Public >.Public'` | `docker.io/minaprotocol` |
| `'< Internal \| InternalEurope \| Public >.Internal'` | `gcr.io/o1labs-192920` |
| `'< Internal \| InternalEurope \| Public >.InternalEurope'` | `europe-west3-docker.pkg.dev/…` |
| unset | whatever the job declares — nightly and PR CI unchanged |

All four verified by rendering.

### Why a Dhall value and not a plain word

Dhall 1.30 has **no Text equality**, so a plain word cannot be turned into one of these alternatives at all, and a plain registry address would be an unchecked string pointing anywhere. Written this way the value is type checked when the pipeline renders, and both ways of getting it wrong are loud:

```
.Pubic              → Missing constructor: Pubic
< Foo | Bar >.Foo   → Expression doesn't match annotation
```

Both fail before a single job starts.

### One trap, documented in the file

**Do not write an import in that variable.** A path there resolves relative to neither the repository root nor the file that reads it, so it fails to resolve, the `?` treats the failure as absent, and the release pushes to the job's default registry **with no warning at all**. I hit this while building it. The alternatives have to be spelled out.

The flip side is that adding an alternative to `Repo` invalidates the pipeline configs that name the old set — loudly, which is the right trade for a public registry.

### Verification

With nothing set, the only rendered change against `develop` is the publish job's own repository:

```
$ diff -rq <develop render> <this render>
Files …/PublishDebians.yml differ
--- changed lines ---
      2  debian-repo packages.o1test.net
```

`make all` passes: 18 tests, 48 assertions.

### After this

The three release pipelines can be created:

```yaml
env:
  GIT_LFS_SKIP_SMUDGE: 1
  MINA_RELEASE_CHANNEL: alpha                       # beta | stable
  MINA_RELEASE_PACKAGING: DockerBuildAmd64Devnet    # …Mainnet for beta/stable
  MINA_RELEASE_DOCKER_REPO: '< Internal | InternalEurope | Public >.Public'
```