### PR TITLE
Select packaging for one network without rebuilding the apps

### DIFF
--- a/buildkite/src/Pipeline/TagFilter.dhall
+++ b/buildkite/src/Pipeline/TagFilter.dhall
@@ -19,6 +19,8 @@ let Filter
       | DockerBuild
       | Packaging
       | Publish
+      | PackagingAmd64Devnet
+      | PackagingAmd64Mainnet
       | Rosetta
       | Hardfork
       | AllDockersAndDebians
@@ -63,6 +65,10 @@ let tags
             , DockerBuild = [ Tag.Type.Docker ]
             , Packaging = [ Tag.Type.Packaging ]
             , Publish = [ Tag.Type.Publish ]
+            , PackagingAmd64Devnet =
+              [ Tag.Type.Packaging, Tag.Type.Devnet, Tag.Type.Amd64 ]
+            , PackagingAmd64Mainnet =
+              [ Tag.Type.Packaging, Tag.Type.Mainnet, Tag.Type.Amd64 ]
             , AllTests = [ Tag.Type.Lint, Tag.Type.Release, Tag.Type.Test ]
             , Release = [ Tag.Type.Release ]
             , Promote = [ Tag.Type.Promote ]
@@ -219,6 +225,8 @@ let show
             , DockerBuild = "DockerBuild"
             , Packaging = "Packaging"
             , Publish = "Publish"
+            , PackagingAmd64Devnet = "PackagingAmd64Devnet"
+            , PackagingAmd64Mainnet = "PackagingAmd64Mainnet"
             , Rosetta = "Rosetta"
             , Hardfork = "Hardfork"
             , AllDockersAndDebians = "AllDockersAndDebians"


### PR DESCRIPTION
> **Stacked on [#19275](https://github.com/MinaProtocol/mina/pull/19275)** — retarget to `develop` once that merges.

Found while writing the three release pipeline configs: there was no filter that selects *just* the packaging jobs of one network.

### What the existing filters do wrong

`DockerBuildAmd64Mainnet` is tagged `Docker`, and the app builds carry `Docker` too:

```
DockerBuildAmd64Mainnet (All) → 2 jobs
  MinaArtifactBullseyeApps        ← rebuilds the whole tree
  MinaArtifactMainnetBullseye
```

The packaging stage runs *after* the test stage, which already built that tree. So the release would compile everything twice — the longest part of the build.

**For devnet it is worse than slow:**

```
DockerBuildAmd64Devnet (All) → 12 jobs
  …Apps × 6, plus every devnet packaging job
```

and it also drags in the mainnet packaging job, so an alpha release would write mainnet debians into the same cache directory. `PublishDebians` reads that directory by codename, so those mainnet packages would be published to **alpha**.

### The fix

Two filters naming `Packaging` with the network instead of `Docker`:

| filter | selects |
| --- | --- |
| `PackagingAmd64Devnet` | 6 jobs — Bookworm, Bullseye, BullseyeInstrumented, Focal, Jammy, Noble |
| `PackagingAmd64Mainnet` | 1 job — MinaArtifactMainnetBullseye |

No app build in either, and no network mixing. Both verified against the real triage.

`make all` passes: 18 tests, 48 assertions. Additive — no existing filter changes, so nothing else moves.

### Still open, not fixed here

`PackagingAmd64Devnet` builds **six** codenames while `PublishDebians` is configured for **bullseye only**. Whichever set a release should actually ship, those two want to agree — otherwise five codenames are built and thrown away.