### PR TITLE
Fix three things that stop a release pipeline running

### DIFF
--- a/buildkite/src/Jobs/Release/ReleaseCommit.dhall
+++ b/buildkite/src/Jobs/Release/ReleaseCommit.dhall
@@ -1,7 +1,7 @@
 -- Refuse to release a commit that is not tagged.
 --
--- A release version is read from the repository, never asserted. The check
--- is a job of its own, and scoped to Release, for three reasons:
+-- A release version is read from the repository, never asserted. The check is
+-- a job of its own, and scoped to Release, for three reasons:
 --
 --  * It fails in seconds. Discovering an untagged commit inside a packaging
 --    job means discovering it forty minutes in, after the apps build.
@@ -15,6 +15,12 @@
 -- dirtyWhen is deliberately `everything`: this is not a reaction to a change
 -- in some file, it is a precondition of the pipeline it belongs to. Scope
 -- keeps it out of every other pipeline.
+
+let B = ../../External/Buildkite.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
+let Prelude = ../../External/Prelude.dhall
 
 let S = ../../Lib/SelectFiles.dhall
 
@@ -32,6 +38,32 @@ let Command = ../../Command/Base.dhall
 
 let Size = ../../Command/Size.dhall
 
+let allowUntagged
+    : Optional Text
+    =
+      -- Set while a release pipeline is being rehearsed on a branch, which by
+      -- definition carries no release tag.
+      --
+      -- It makes the STEP soft fail; the script is not told and does not
+      -- change. The check still runs, still reports exactly what is wrong,
+      -- and still goes red -- the pipeline simply carries on past it. A
+      -- switch inside the script would have made it exit 0 and go green,
+      -- which is the same as not running it, and the one thing a rehearsal
+      -- must not do is look like a release that passed.
+      --
+      -- Presence is the whole signal: there are only two outcomes, so there
+      -- is no value to misspell.
+      Some env:MINA_RELEASE_ALLOW_UNTAGGED as Text ? None Text
+
+let softFail
+    : Optional B/SoftFail
+    = Prelude.Optional.fold
+        Text
+        allowUntagged
+        (Optional B/SoftFail)
+        (\(_ : Text) -> Some (B/SoftFail.Boolean True))
+        (None B/SoftFail)
+
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -47,6 +79,7 @@ in  Pipeline.build
             , commands = [ Cmd.run "./scripts/verify/release-commit.sh" ]
             , label = "Release: verify the commit is tagged"
             , key = "verify-release-commit"
+            , soft_fail = softFail
             , target = Size.Small
             }
         ]

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -208,6 +208,7 @@ run_build() {
       STUB_TAG_IN_REGISTRY="${STUB_TAG_IN_REGISTRY:-}" \
       FORCE_DOCKER_OVERWRITE="${FORCE_DOCKER_OVERWRITE:-}" \
       CI="" BUILDKITE="" GITHUB_ACTIONS="" \
+      SKIP_GITBRANCH="" \
       ./scripts/docker/build.sh "$@" ) > "${args_file}.log" 2>&1
     LAST_EXIT=$?
     set -e

--- a/scripts/export-git-env-vars.sh
+++ b/scripts/export-git-env-vars.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Defaulted here rather than further down, where it used to be, because
+# MINA_DOCKER_TAG is built from it well before that point. Under `set -u` a
+# caller that had not set it aborted on the unbound variable instead of
+# getting the default the script clearly intends to provide. Every caller
+# reached this script through buildkite/scripts/export-git-env-vars.sh, which
+# sets it first, so nothing ever ran into it until a script sourced this one
+# directly.
+MINA_DEB_CODENAME=${MINA_DEB_CODENAME:-bullseye}
+
 # If enabled, keep my tags intact, it won't run git fetch --prune
 KEEP_MY_TAGS_INTACT=${KEEP_MY_TAGS_INTACT:-1}
 

--- a/scripts/verify/release-commit.sh
+++ b/scripts/verify/release-commit.sh
@@ -27,6 +27,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 CLEAR='\033[0m'
 RED='\033[0;31m'
+YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 
 # Sourced for GITTAG / GITHASH / GITHASH_CONFIG, so the tag logic and the
@@ -34,6 +35,27 @@ GREEN='\033[0;32m'
 # recomputes them.
 # shellcheck disable=SC1090,SC1091
 source "${SCRIPTPATH}/../export-git-env-vars.sh"
+
+# Rehearsal escape hatch.
+#
+# A pipeline being tried out on a branch has no release tag on it, and this
+# check is the first thing that runs, so nothing downstream can be exercised
+# until it passes. MINA_RELEASE_ALLOW_UNTAGGED=1 turns the refusal into a
+# warning so the rest of the pipeline can be rehearsed.
+#
+# It says loudly what it costs, because the cost is easy to forget: the
+# version still falls back to the most recent tag reachable from HEAD, so the
+# packages this build produces claim a release they are not. That is tolerable
+# in a throwaway channel and is exactly the mislabelling this check exists to
+# stop everywhere else. It must never be set on a pipeline that publishes to
+# alpha, beta or stable.
+if [[ "${MINA_RELEASE_ALLOW_UNTAGGED:-0}" == "1" ]]; then
+    echo -e "${YELLOW}⚠️  MINA_RELEASE_ALLOW_UNTAGGED is set: the tag check is a warning.${CLEAR}" >&2
+    echo "    Version would be ${GITTAG}-${GITHASH}, taken from the most recent" >&2
+    echo "    tag reachable from HEAD rather than from a tag on this commit." >&2
+    echo "    Packages built here claim a release they are not. Rehearsal only." >&2
+    exit 0
+fi
 
 if [[ -n "${OVERRIDE_TAG:-}" ]]; then
     echo -e "${RED}❌ ERROR: OVERRIDE_TAG is set (${OVERRIDE_TAG}).${CLEAR}" >&2

--- a/scripts/verify/release-commit.sh
+++ b/scripts/verify/release-commit.sh
@@ -27,7 +27,6 @@ SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 CLEAR='\033[0m'
 RED='\033[0;31m'
-YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 
 # Sourced for GITTAG / GITHASH / GITHASH_CONFIG, so the tag logic and the
@@ -35,27 +34,6 @@ GREEN='\033[0;32m'
 # recomputes them.
 # shellcheck disable=SC1090,SC1091
 source "${SCRIPTPATH}/../export-git-env-vars.sh"
-
-# Rehearsal escape hatch.
-#
-# A pipeline being tried out on a branch has no release tag on it, and this
-# check is the first thing that runs, so nothing downstream can be exercised
-# until it passes. MINA_RELEASE_ALLOW_UNTAGGED=1 turns the refusal into a
-# warning so the rest of the pipeline can be rehearsed.
-#
-# It says loudly what it costs, because the cost is easy to forget: the
-# version still falls back to the most recent tag reachable from HEAD, so the
-# packages this build produces claim a release they are not. That is tolerable
-# in a throwaway channel and is exactly the mislabelling this check exists to
-# stop everywhere else. It must never be set on a pipeline that publishes to
-# alpha, beta or stable.
-if [[ "${MINA_RELEASE_ALLOW_UNTAGGED:-0}" == "1" ]]; then
-    echo -e "${YELLOW}⚠️  MINA_RELEASE_ALLOW_UNTAGGED is set: the tag check is a warning.${CLEAR}" >&2
-    echo "    Version would be ${GITTAG}-${GITHASH}, taken from the most recent" >&2
-    echo "    tag reachable from HEAD rather than from a tag on this commit." >&2
-    echo "    Packages built here claim a release they are not. Rehearsal only." >&2
-    exit 0
-fi
 
 if [[ -n "${OVERRIDE_TAG:-}" ]]; then
     echo -e "${RED}❌ ERROR: OVERRIDE_TAG is set (${OVERRIDE_TAG}).${CLEAR}" >&2


### PR DESCRIPTION
All three found by running the alpha release pipeline on a branch: [mina-alpha](https://buildkite.com/o-1-labs-2/mina-alpha/builds/2).

### 1. `MINA_DEB_CODENAME: unbound variable` — the real blocker

```
scripts/verify/../export-git-env-vars.sh: line 58: MINA_DEB_CODENAME: unbound variable
```

`export-git-env-vars.sh` builds `MINA_DOCKER_TAG` from `MINA_DEB_CODENAME` at **line 58** and defaults it at **line 69** — eleven lines too late. Under `set -u` a caller that had not set it aborts instead of getting the default the script plainly intends to provide.

Nothing ran into it because every caller reached the script through `buildkite/scripts/export-git-env-vars.sh`, which sets the codename before sourcing. `release-commit.sh` sources it directly, so it became the first caller to find the ordering.

The default moves above first use. Callers that set the variable are unaffected — verified the docker tag still comes out per codename (`…-bullseye`, `…-noble`).

### 2. `Docker build script tests` failed, and the pipeline caused it

Five assertions failed on tags like `mina-daemon:3.0.0-`**`test-branch`**`-abcdefg-bullseye-devnet`.

The test pins `OVERRIDE_TAG`, `OVERRIDE_GITHASH` and `BRANCH_NAME`, then asserts the branch appears in the tag. A release pipeline sets `SKIP_GITBRANCH` globally — a release version carries no branch segment — and `propagate-environment: true` carries that into **every** job, stripping the segment the fixtures expect.

```
without SKIP_GITBRANCH -> 26 tests, 102 passed, 0 failed
with SKIP_GITBRANCH=1  -> 26 tests,  97 passed, 5 failed
```

It is now neutralised in the same call that already clears `CI`, `BUILDKITE` and `GITHUB_ACTIONS`, for the same reason — the test builds its own world and should not inherit one. **102 pass either way.**

### 3. A rehearsal cannot get past the tag check

`ReleaseCommit` runs first, so a pipeline being tried out on an untagged branch cannot exercise anything downstream.

`MINA_RELEASE_ALLOW_UNTAGGED` makes the **Buildkite step** soft fail. The script is not told about it and does not change: it still runs, still refuses, still prints exactly what is wrong, and still goes red. The pipeline simply carries on past it.

I first wrote this as a switch *inside* the script, which then exited 0. That was wrong — a green "verify the commit is tagged" is indistinguishable from a release whose commit really was tagged, and looking like a release that passed is the one thing a rehearsal must not do. It also puts the decision where the others already are: the script says what is true, the pipeline decides what to do about it.

| | script exit | rendered step |
| --- | --- | --- |
| unset | 1 on an untagged commit | no `soft_fail` key — blocks |
| `MINA_RELEASE_ALLOW_UNTAGGED=1` | still 1 | `soft_fail: true` — visible, does not block |

### Verification

| | |
| --- | --- |
| `scripts/docker/tests/test_build.sh` | 26 tests, 102 passed — with and without `SKIP_GITBRANCH` |
| `scripts/debian/tests/test_builder_helpers.sh` | 36 tests, 279 passed |
| `release-commit.sh` with no `MINA_DEB_CODENAME` | passes — was the CI crash |
| script still exits 1 with the flag set | confirmed |
| `make all` | 18 tests, 48 assertions |
| `shellcheck -S warning` | clean |

### Not fixed here

`Perf: Archive` and `Perf: Snark Profiler` also failed in that build, but both are **soft-failed** already and do not block.