### PR TITLE
Publish every codename that was packaged, by looking

### DIFF
--- a/buildkite/scripts/debian/read_all_codenames_from_cache.sh
+++ b/buildkite/scripts/debian/read_all_codenames_from_cache.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Read every codename's debian packages out of this build's cache.
+#
+# The codenames are discovered, not declared. The packaging stage decides which
+# ones exist -- a devnet release builds five, a mainnet release builds one --
+# and a list written here would be a second statement of that, free to drift
+# from the first. Drift would be quiet in the worst direction: a codename
+# missing from the list is built, cached, and never published, and nothing
+# reports it.
+#
+# The destination gets one folder per codename, because that is the layout
+# `release-manager publish` reads: it takes {codename}/*.deb and uses the
+# directory name as the codename, rather than parsing it back out of file
+# names.
+
+set -euo pipefail
+
+CACHE_BASE_URL="${CACHE_BASE_URL:-/var/storagebox}"
+ROOT="${MINA_READ_CACHE_ROOT:-${BUILDKITE_BUILD_ID:?BUILDKITE_BUILD_ID is not set}}"
+DEST="${1:?usage: $0 <destination-folder>}"
+
+SRC="${CACHE_BASE_URL}/${ROOT}/debians"
+
+if [[ ! -d "$SRC" ]]; then
+  echo "❌ No debians in the cache at ${SRC}." >&2
+  echo "   The packaging stage writes them there, so either it did not run or" >&2
+  echo "   it ran against a different build id." >&2
+  exit 1
+fi
+
+CODENAMES=()
+for dir in "${SRC}"/*/; do
+  [[ -d "$dir" ]] || continue
+  CODENAMES+=("$(basename "$dir")")
+done
+
+if [[ ${#CODENAMES[@]} -eq 0 ]]; then
+  echo "❌ ${SRC} holds no codename folders." >&2
+  echo "   Refusing to report a successful read of nothing." >&2
+  exit 1
+fi
+
+echo "--- Codenames found in the cache: ${CODENAMES[*]}"
+
+for codename in "${CODENAMES[@]}"; do
+  echo "--- Reading ${codename}"
+  MINA_DEB_CODENAME="$codename" \
+  ROOT="$ROOT" \
+  LOCAL_DEB_FOLDER="${DEST}/${codename}" \
+    ./buildkite/scripts/debian/read_all_from_cache.sh
+done
+
+echo "--- Read ${#CODENAMES[@]} codename(s) into ${DEST}"

--- a/buildkite/src/Command/Packages/PublishDebians.dhall
+++ b/buildkite/src/Command/Packages/PublishDebians.dhall
@@ -18,12 +18,6 @@
 -- the packaging stage, waits, then uploads this one, so a failed test or a
 -- failed package build means this step is never reached.
 
-let Prelude = ../../External/Prelude.dhall
-
-let List/map = Prelude.List.map
-
-let Text/concatSep = Prelude.Text.concatSep
-
 let Cmd = ../../Lib/Cmds.dhall
 
 let Command = ../Base.dhall
@@ -40,20 +34,16 @@ let DebianChannel = ../../Constants/DebianChannel.dhall
 
 let DebianRepo = ../../Constants/DebianRepo.dhall
 
-let DebianVersions = ../../Constants/DebianVersions.dhall
-
 let Spec =
       { Type =
-          { codenames : List DebianVersions.DebVersion
-          , channel : DebianChannel.Type
+          { channel : DebianChannel.Type
           , debianRepo : DebianRepo.Type
           , verify : Bool
           , label : Text
           , key : Text
           }
       , default =
-          { codenames = [ DebianVersions.DebVersion.Bullseye ]
-          , channel = DebianChannel.Type.Unstable
+          { channel = DebianChannel.Type.Unstable
           , debianRepo = DebianRepo.Type.Unstable
           , verify = True
           , label = "Publish debians"
@@ -64,44 +54,21 @@ let Spec =
 let debsFolder = "_publish"
 
 let readFromCache
-    : Spec.Type -> List Cmd.Type
+    : Cmd.Type
     =
-      -- One read per codename, into its own folder.
-      --
-      -- read_all_from_cache.sh puts the packages of ONE codename flat into
-      -- LOCAL_DEB_FOLDER, and `release-manager publish` wants a
-      -- {codename}/*.deb tree, so the codename is the folder rather than
-      -- something the publish step has to reconstruct from file names.
-          \(spec : Spec.Type)
-      ->  List/map
-            DebianVersions.DebVersion
-            Cmd.Type
-            (     \(codename : DebianVersions.DebVersion)
-              ->  let lower = DebianVersions.lowerName codename
-
-                  in  Cmd.run
-                        (     "MINA_DEB_CODENAME=${lower}"
-                          ++  " ROOT=\\\${BUILDKITE_BUILD_ID}"
-                          ++  " LOCAL_DEB_FOLDER=${debsFolder}/${lower}"
-                          ++  " ./buildkite/scripts/debian/read_all_from_cache.sh"
-                        )
-            )
-            spec.codenames
+      -- The codenames are discovered from the cache, not listed here. The
+      -- packaging stage decides which exist -- five for a devnet release, one
+      -- for mainnet -- and a list in this file would be a second statement of
+      -- that, free to drift. Drift would be quiet in the worst direction: a
+      -- codename missing from the list is built, cached, and never published,
+      -- with nothing to report it.
+      Cmd.run
+        "./buildkite/scripts/debian/read_all_codenames_from_cache.sh ${debsFolder}"
 
 let publishCmd
     : Spec.Type -> Cmd.Type
     =     \(spec : Spec.Type)
-      ->  let codenames =
-                Text/concatSep
-                  ","
-                  ( List/map
-                      DebianVersions.DebVersion
-                      Text
-                      DebianVersions.lowerName
-                      spec.codenames
-                  )
-
-          let verifyArg = if spec.verify then " --verify" else ""
+      ->  let verifyArg = if spec.verify then " --verify" else ""
 
           let signArg =
                 merge
@@ -122,7 +89,6 @@ let publishCmd
                   ++  "gpg --import /var/secrets/debian/key.gpg && "
                   ++  "release-manager publish"
                   ++  " --source-folder ${debsFolder}"
-                  ++  " --codenames ${codenames}"
                   ++  " --channel ${DebianChannel.effective spec.channel}"
                   ++  " --debian-repo ${DebianRepo.bucket_or_default
                                           spec.debianRepo}"
@@ -165,9 +131,10 @@ let step
       ->  Command.build
             Command.Config::{
             , commands =
-                  [ FixPermissions.command Arch.Type.Amd64 ]
-                # readFromCache spec
-                # [ publishCmd spec ]
+              [ FixPermissions.command Arch.Type.Amd64
+              , readFromCache
+              , publishCmd spec
+              ]
             , label = spec.label
             , key = spec.key
             , target = Size.Small

--- a/buildkite/src/Jobs/Release/PublishDebians.dhall
+++ b/buildkite/src/Jobs/Release/PublishDebians.dhall
@@ -8,9 +8,10 @@
 -- It is what the pipeline exists to do, and the scope keeps it out of every
 -- other pipeline.
 --
--- The channel and the repository are read from the environment via
--- DebianChannel.effective, so the three release pipelines share this one job
--- and differ only in what they set.
+-- The channel is read from the environment via DebianChannel.effective, and
+-- the codenames are discovered from the cache by the read script, so the three
+-- release pipelines share this one job and differ only in the channel they
+-- set. Nothing here has to be kept in step with the packaging stage.
 
 let S = ../../Lib/SelectFiles.dhall
 
@@ -23,8 +24,6 @@ let PipelineScope = ../../Pipeline/Scope.dhall
 let JobSpec = ../../Pipeline/JobSpec.dhall
 
 let PublishDebians = ../../Command/Packages/PublishDebians.dhall
-
-let DebianVersions = ../../Constants/DebianVersions.dhall
 
 let DebianRepo = ../../Constants/DebianRepo.dhall
 
@@ -40,7 +39,6 @@ in  Pipeline.build
       , steps =
         [ PublishDebians.step
             PublishDebians.Spec::{
-            , codenames = [ DebianVersions.DebVersion.Bullseye ]
             , debianRepo = DebianRepo.Type.O1Test
             , label = "Publish: debians"
             , key = "publish-debians"


### PR DESCRIPTION
> **Stacked on [#19276](https://github.com/MinaProtocol/mina/pull/19276)** → which is stacked on [#19275](https://github.com/MinaProtocol/mina/pull/19275). Retarget as those merge.

The publish job named `bullseye` and nothing else, while a devnet release packages **five** codenames. Four were built, cached, and never published — and nothing said so.

### Why not just list all five

Listing them would fix today and break later. The packaging stage decides which codenames exist — five for devnet, one for mainnet — so a list in the publish job is a *second statement of the same fact*, free to drift from the first.

Drift is quiet in the worst direction: a codename missing from the list is still built and cached, and its absence downstream looks exactly like success. That is the same failure this work has been removing everywhere else.

### So it looks instead

The cache is a mounted directory. `read_all_codenames_from_cache.sh` lists the codename folders the packaging stage wrote and reads each into its own folder — which is the layout `release-manager publish` already expects, since it takes the codename from the directory name. The publish command no longer passes `--codenames` at all: it publishes what it was given.

The same job is now correct for all three pipelines with nothing to keep in step:

```
devnet cache   → Codenames found in the cache: bookworm bullseye focal jammy noble
mainnet cache  → Codenames found in the cache: bullseye
empty cache    → ❌ holds no codename folders.
                    Refusing to report a successful read of nothing.   (exit 1)
```

All three verified against a constructed cache tree.

### Note on the six jobs

`PackagingAmd64Devnet` selects **six jobs** but they are **five codenames** — `MinaArtifactBullseyeInstrumented` is bullseye with a build flag, and its packages land in the bullseye folder alongside the others. Discovery gets this right without anyone having to remember it; a hand-written list of six would have been wrong.

### Verification

`make all` passes: 18 tests, 48 assertions. `shellcheck -S warning` clean.

The per-codename read itself needs the real cache manager, so it is exercised in CI rather than locally — the discovery and the guard are what I could test here.