### PR TITLE
Let a packaging job take its apps from an earlier build

### DIFF
--- a/buildkite/scripts/apps/restore_build_tree.sh
+++ b/buildkite/scripts/apps/restore_build_tree.sh
@@ -46,8 +46,24 @@ fail_missing() {
   exit 1
 }
 
+# MINA_APPS_CACHE_ROOT reads the app build's output from a different build's
+# cache, which is what a packaging-only pipeline needs: the apps were compiled
+# by an earlier build and this one only turns them into packages.
+#
+# It is a name of its own rather than MINA_READ_CACHE_ROOT, which the cache
+# manager already honours, because a packaging job reads from two roots at
+# once. The apps come from the earlier build; the debians this job then writes
+# are read back by its own docker steps out of ITS root. One variable covering
+# both would send those docker steps looking for debians in a build that never
+# produced any.
+APPS_ROOT_ARGS=()
+if [[ -n "${MINA_APPS_CACHE_ROOT:-}" ]]; then
+  echo "--- Reading the app build from cache root ${MINA_APPS_CACHE_ROOT}"
+  APPS_ROOT_ARGS=(--root "${MINA_APPS_CACHE_ROOT}")
+fi
+
 echo "--- Restoring build manifest for ${CODENAME}/${BUILD_VARIANT}"
-if ! ./buildkite/scripts/cache/manager.sh read \
+if ! ./buildkite/scripts/cache/manager.sh read "${APPS_ROOT_ARGS[@]}" \
   "build-manifest/${CODENAME}/${BUILD_VARIANT}/build-manifest.txt" "$TMP_DIR"; then
   fail_missing "manifest for ${CODENAME}/${BUILD_VARIANT} not found in cache"
 fi
@@ -58,7 +74,7 @@ while IFS= read -r relpath; do
   base="$(basename "$relpath")"
   fetch_dir="${TMP_DIR}/fetch"
   mkdir -p "$fetch_dir"
-  if ! ./buildkite/scripts/cache/manager.sh read \
+  if ! ./buildkite/scripts/cache/manager.sh read "${APPS_ROOT_ARGS[@]}" \
     "${APPS_DIR}/${base}" "$fetch_dir" >/dev/null; then
     fail_missing "${base} not found in ${APPS_DIR}"
   fi

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -408,6 +408,7 @@ let commonBuildEnvs =
                 , "PREFORK_LEGACY_VERSION=${spec.deb_legacy_version}"
                 , "PREFORK_GITHASH_CONFIG=${spec.deb_legacy_githash_config}"
                 , "MINA_DEB_RELEASE=${DebianChannel.effective spec.channel}"
+                , "MINA_APPS_CACHE_ROOT"
                 ]
               # BuildFlags.buildEnvs spec.buildFlags
               # spec.extraBuildEnvs

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -491,6 +491,30 @@ let buildDebianFromApps
                               spec} ./buildkite/scripts/debian/build-from-cache.sh ${treeVariant
                                                                                        spec} ${tokens}"
 
+let appsFromAnotherBuild
+    : Optional Text
+    =
+      -- Set when MINA_APPS_CACHE_ROOT names an earlier build, which is what a
+      -- packaging-only pipeline does. See restore_build_tree.sh.
+      Some env:MINA_APPS_CACHE_ROOT as Text ? None Text
+
+let dependsOnApps
+    : PackagingSpec.Type -> List Command.TaggedKey.Type
+    =
+      -- Nothing to wait for when the apps came from an earlier build.
+      --
+      -- The dependency names a job by key, and a packaging-only pipeline does
+      -- not select the app build at all, so the key is absent and Buildkite
+      -- leaves every packaging step in waiting_failed: no job runs, no job
+      -- fails, and the build reports failure with nothing in it to look at.
+          \(spec : PackagingSpec.Type)
+      ->  Prelude.Optional.fold
+            Text
+            appsFromAnotherBuild
+            (List Command.TaggedKey.Type)
+            (\(_ : Text) -> [] : List Command.TaggedKey.Type)
+            [ { name = appsJobName spec, key = "build-apps" } ]
+
 let build_debian
     : PackagingSpec.Type -> Command.Type
     =     \(spec : PackagingSpec.Type)
@@ -506,7 +530,7 @@ let build_debian
                   ]
             , label = "Debian: Build ${labelSuffix spec}"
             , key = "build-deb-pkg${Optional/default Text "" spec.suffix}"
-            , depends_on = [ { name = appsJobName spec, key = "build-apps" } ]
+            , depends_on = dependsOnApps spec
             , target = Size.Multi
             , if_ = spec.if_
             , retries =


### PR DESCRIPTION
Needed for a packaging-only pipeline: turn an earlier build's apps into packages without recompiling them.

### Why it did not work

`restore_build_tree.sh` reconstructs the dune tree from the apps cache, and the packaging job's container had no way to say *which build's* cache to read. It always read its own, which in a packaging-only pipeline is empty.

### Why a new variable and not `MINA_READ_CACHE_ROOT`

The cache manager already honours `MINA_READ_CACHE_ROOT`, so reaching for it is the obvious move. It does not work, because **a packaging job reads two roots at once**:

| read | runs in | wants |
| --- | --- | --- |
| `restore_build_tree.sh` — the apps | the toolchain container | the **earlier** build |
| `read_all_from_cache.sh` — the debians it just built | the host, in **16** docker steps | **this** build |

And `read_all_from_cache.sh` lets `MINA_READ_CACHE_ROOT` override even the explicit `ROOT=$BUILDKITE_BUILD_ID` those steps pass. So one variable covering both would send every docker step looking for debians in a build that never produced any.

`MINA_APPS_CACHE_ROOT` names only the first.

### Behaviour

```
unset -> cache reads carry no --root, fall back to this build   (every existing pipeline)
set   -> cache reads carry --root <that build>                  (packaging-only pipeline)
```

The rendered diff against `develop` is **13 lines, all of them the new name in a packaging job's environment, none anywhere else.** Nothing changes for any pipeline that builds its own apps.

`make all` passes: 18 tests, 48 assertions. `shellcheck -S warning` clean.

### What this unlocks

A packaging pipeline that reads apps from a build/test pipeline, and a publish pipeline that reads debians from the packaging one — each hop naming its source, each separately re-runnable when the one before it went green and something later did not.