### PR TITLE
Rosetta client library and rosetta-client CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-mina: ocaml_checks reformat-diff libp2p_helper build ## Build mina apps
 		src/app/cli/src/mina.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		&& echo "✅ Build complete"
 
 .PHONY: build-archive
@@ -295,6 +296,7 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"
 

--- a/changes/19284.md
+++ b/changes/19284.md
@@ -1,0 +1,21 @@
+- New `rosetta-client` CLI: one subcommand per Rosetta endpoint, for debugging
+  and scripting against a running Rosetta server. It fills in the
+  `network_identifier`, prints the response as JSON (`--compact` for one line),
+  and exits non-zero with a short diagnostic on failure. A `--*-json` payload is
+  checked against the Rosetta model its endpoint expects before it is sent, so a
+  malformed request is reported with the name of the offending flag instead of
+  as a server error. See `src/app/rosetta/client/README.md`.
+
+- `rosetta-client` reads `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
+  `MINA_ROSETTA_NETWORK`, so an operator working against one server can export
+  them once instead of repeating `--rosetta-uri`, `--blockchain` and `--network`
+  on every call. A flag always wins over the matching environment variable.
+
+- Error messages are short and human-readable: a Rosetta error envelope is
+  rendered as `HTTP <code>: <message>`, a connection failure as
+  `connection refused to <url>`. Raw OCaml exception text no longer reaches the
+  terminal, an HTTP body is never dumped verbatim, and a message is never split
+  over several lines.
+
+- `rosetta-client` ships in the `mina-rosetta` Debian package as
+  `/usr/local/bin/rosetta-client`.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -504,6 +504,8 @@ build_rosetta_generic_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-client"
 
   mkdir -p "${BUILDDIR}/etc/mina/rosetta/"{rosetta-cli-config,scripts}
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,7 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
 }
@@ -354,6 +355,7 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/rosetta.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"
     create_mock_exe "default/src/app/validate_keypair/validate_keypair.exe"

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -1,0 +1,110 @@
+# rosetta-client
+
+Generic CLI wrapper for the [Rosetta API](https://www.rosetta-api.org/) as
+implemented by Mina Rosetta.  Think of it as "curl on steroids": every
+subcommand maps to a single endpoint, auto-injects
+`{"blockchain": "mina", "network": "testnet"}` into the request's
+`network_identifier`, and prints the response as JSON (pretty by default,
+`--compact` for one-line output).
+
+For readiness probes, a sibling `rosetta-healthcheck` binary built on the
+same library follows in a separate change.
+
+## Subcommand tree
+
+```
+rosetta-client
+├── network
+│   ├── list
+│   ├── status
+│   └── options
+├── block
+│   └── get            --index N | --hash H
+├── account
+│   ├── balance        --address B62q... [--token-id T] [--index N]
+│   └── coins          --address B62q... [--include-mempool]
+├── mempool
+│   ├── list
+│   └── transaction    --tx-hash H
+├── search
+│   └── transactions   [--address B62q...] [--tx-hash H] [--limit N]
+├── construction
+│   ├── derive         --public-key-json JSON [--metadata-json JSON]
+│   ├── preprocess     --operations-json JSON [--metadata-json JSON]
+│   ├── metadata       --options-json JSON [--public-keys-json JSON]
+│   ├── payloads       --operations-json JSON [--metadata-json JSON] [--public-keys-json JSON]
+│   ├── parse          --signed|--unsigned --transaction STR
+│   ├── combine        --unsigned-transaction STR --signatures-json JSON
+│   ├── hash           --signed-transaction STR
+│   └── submit         --signed-transaction STR
+```
+
+`block transaction` is deliberately absent: Mina's Rosetta server returns
+every transaction inline in `/block`, does not implement
+`/block/transaction`, and would answer 404.  Use `block get` and filter
+the returned transactions by hash.
+
+## Global flags
+
+Every leaf command accepts:
+
+| Flag | Default | Environment override | Notes |
+|------|---------|----------------------|-------|
+| `--rosetta-uri` | `http://localhost:3087` | `MINA_ROSETTA_URI` | Base URL of the Rosetta server. |
+| `--blockchain` | `mina` | `MINA_ROSETTA_BLOCKCHAIN` | Injected into `network_identifier.blockchain`. |
+| `--network` | `testnet` | `MINA_ROSETTA_NETWORK` | Injected into `network_identifier.network`. |
+| `--timeout` | `30` | | Seconds allowed for one request/response exchange, from sending the request to reading the last byte of the response body. |
+| `--compact` | off | | Emit compact JSON instead of indented. |
+
+A flag always wins over its environment variable.  Export the variables
+to talk to the same server repeatedly without repeating the flags; the
+same three variables are read by every binary built on
+`Rosetta_client`.  Their fallback values live in
+`Rosetta_client.Defaults`, so those binaries cannot drift apart.
+
+## Examples
+
+```bash
+# Readable JSON on a local Rosetta:
+rosetta-client network status
+rosetta-client block get --index 100
+rosetta-client account balance --address B62q...
+
+# Point at a non-default host and override network:
+rosetta-client network options \
+  --rosetta-uri http://rosetta.example.com:3087 \
+  --network mainnet
+
+# The same, for a whole session, without repeating the flags:
+export MINA_ROSETTA_URI=http://rosetta.example.com:3087
+export MINA_ROSETTA_NETWORK=mainnet
+rosetta-client network options
+
+# Construction flow:
+rosetta-client construction derive \
+  --public-key-json '{"hex_bytes":"abcd","curve_type":"pallas"}'
+```
+
+## Output contract
+
+On success, the response body is printed as pretty JSON on stdout (or
+compact JSON with `--compact`), followed by a single newline.  Exit 0.
+
+On failure — HTTP non-2xx, transport error, invalid JSON input, or a
+`--*-json` payload that does not match the Rosetta model the endpoint
+expects — the tool prints a short diagnostic on stderr and exits 1.  The diagnostic is
+produced by the `Rosetta_client.Errors` module and is guaranteed to:
+
+- Never leak raw OCaml exception syntax (no `Unix_error`, no `(Unix. ...)`).
+- Never dump multi-kilobyte HTTP bodies verbatim; Rosetta error envelopes
+  are parsed and rendered as `HTTP <code>: <message>`.
+
+## Layout
+
+The HTTP client, the typed Rosetta API surface and the shared defaults
+live in the `rosetta_client` library (`src/lib/rosetta_client/`), so any
+other binary can reuse them.
+
+Inside this binary, `rosetta_client_cli.ml` holds the flags, the
+subcommand tree and the output; `payload.ml` holds the decoding of the
+JSON-valued flags into Rosetta models, and neither prints nor exits.

--- a/src/app/rosetta/client/dune
+++ b/src/app/rosetta/client/dune
@@ -1,0 +1,24 @@
+(executable
+ (package rosetta)
+ (name rosetta_client_cli)
+ (public_name rosetta-client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  core_unix
+  async
+  async.async_command
+  async_kernel
+  async_unix
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here ppx_deriving_yojson)))

--- a/src/app/rosetta/client/payload.ml
+++ b/src/app/rosetta/client/payload.ml
@@ -1,0 +1,27 @@
+(* Decoding of the JSON-valued command-line flags.  See [payload.mli]. *)
+
+open Core_kernel
+
+let json ~label s =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string s) with
+  | Ok parsed ->
+      Ok parsed
+  | Error _ ->
+      Or_error.errorf "%s: invalid JSON" label
+
+let model ~label of_yojson s =
+  let open Or_error.Let_syntax in
+  let%bind parsed = json ~label s in
+  match of_yojson parsed with
+  | Ok value ->
+      Ok value
+  | Error message ->
+      Or_error.errorf "%s: does not match the Rosetta schema: %s" label message
+
+let model_opt ~label of_yojson s =
+  Option.value_map s ~default:(Ok None) ~f:(fun s ->
+      Or_error.map (model ~label of_yojson s) ~f:Option.some )
+
+let json_opt ~label s =
+  Option.value_map s ~default:(Ok None) ~f:(fun s ->
+      Or_error.map (json ~label s) ~f:Option.some )

--- a/src/app/rosetta/client/payload.mli
+++ b/src/app/rosetta/client/payload.mli
@@ -1,0 +1,41 @@
+(** Decoding of the JSON-valued flags ([--public-key-json],
+    [--operations-json], [--signatures-json], ...) into the Rosetta
+    models the endpoints expect.
+
+    This is the part of [rosetta-client] that is not command-line
+    plumbing: it turns one flag's string into a typed value, or into an
+    error that names the flag.  Nothing here prints or exits — the CLI in
+    [rosetta_client_cli.ml] decides what to do with a failure.
+
+    Validating here rather than at the server means a malformed payload
+    is reported against the flag that carried it, before a request is
+    sent. *)
+
+open Core_kernel
+
+(** [json ~label s] parses [s] as JSON.  [label] is the flag name, and
+    appears in the error. *)
+val json : label:string -> string -> Yojson.Safe.t Or_error.t
+
+(** [model ~label of_yojson s] parses [s] as JSON and then decodes it
+    through a generated Rosetta model's [of_yojson].  The error
+    distinguishes "not JSON at all" from "JSON that does not match the
+    schema". *)
+val model :
+     label:string
+  -> (Yojson.Safe.t -> ('a, string) Result.t)
+  -> string
+  -> 'a Or_error.t
+
+(** [model_opt] is {!model} over an optional flag: [None] in, [None]
+    out. *)
+val model_opt :
+     label:string
+  -> (Yojson.Safe.t -> ('a, string) Result.t)
+  -> string option
+  -> 'a option Or_error.t
+
+(** [json_opt] is {!json} over an optional flag.  Used for the two fields
+    the Rosetta schema itself leaves free-form, [metadata] and
+    [options], which have no model to decode into. *)
+val json_opt : label:string -> string option -> Yojson.Safe.t option Or_error.t

--- a/src/app/rosetta/client/rosetta_client_cli.ml
+++ b/src/app/rosetta/client/rosetta_client_cli.ml
@@ -1,0 +1,428 @@
+(* rosetta_client CLI — a curl-on-steroids for the Rosetta API.
+
+   This file owns the command-line surface: the flags, the subcommand
+   tree, and how a result or an error reaches the terminal.  Decoding a
+   JSON-valued flag into the model an endpoint expects is in
+   [payload.ml], which neither prints nor exits.
+
+   Every subcommand POSTs to a single Rosetta endpoint through the
+   [Rosetta_client] library, auto-injects the network_identifier
+   ({"blockchain":"mina","network":"testnet"} by default), and prints
+   the response as JSON (pretty by default).  On HTTP or transport
+   failure, prints a short human-readable diagnostic on stderr and exits
+   non-zero; the diagnostic never leaks raw OCaml exception syntax.
+
+   Environment variables (each one is overridden by the matching flag,
+   and all three are shared with [rosetta-healthcheck]):
+
+   - [MINA_ROSETTA_URI] — default for [--rosetta-uri].
+   - [MINA_ROSETTA_BLOCKCHAIN] — default for [--blockchain].
+   - [MINA_ROSETTA_NETWORK] — default for [--network].
+
+   The values they fall back to when unset live in
+   [Rosetta_client.Defaults]. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+(* Seconds allowed for one request/response exchange with the Rosetta
+   server, from sending the request to reading the last byte of the
+   response body.  This is deliberately longer than
+   [MRC.Defaults.http_timeout]: a healthcheck probe wants a quick verdict,
+   whereas this CLI is used interactively for queries such as a
+   /search/transactions sweep that legitimately take much longer than a
+   probe would wait. *)
+let default_timeout = 30.0
+
+(* ---------- Global flags shared by every leaf command ---------- *)
+
+(* A record that every subcommand's [let%map_open] can pull in with a
+   single line.  Keeps per-command preludes short. *)
+type global_flags =
+  { base_uri : string
+  ; blockchain : string
+  ; network : string
+  ; timeout : float
+  ; compact : bool
+  }
+
+let global_flags_param =
+  let open Command.Let_syntax in
+  let open Command.Param in
+  let%map base_uri =
+    flag "--rosetta-uri"
+      ~doc:
+        (sprintf "URI Rosetta base URL (default: %s, overridable via $%s)"
+           (MRC.Defaults.base_uri_from_env ())
+           MRC.Defaults.uri_env_var )
+      (optional_with_default (MRC.Defaults.base_uri_from_env ()) string)
+  and blockchain =
+    flag "--blockchain"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.blockchain (default: %s, overridable via \
+            $%s)"
+           (MRC.Defaults.blockchain_from_env ())
+           MRC.Defaults.blockchain_env_var )
+      (optional_with_default (MRC.Defaults.blockchain_from_env ()) string)
+  and network =
+    flag "--network"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.network (default: %s, overridable via $%s)"
+           (MRC.Defaults.network_from_env ())
+           MRC.Defaults.network_env_var )
+      (optional_with_default (MRC.Defaults.network_from_env ()) string)
+  and timeout =
+    flag "--timeout"
+      ~doc:
+        (sprintf "SECONDS HTTP request timeout (default: %.0f)" default_timeout)
+      (optional_with_default default_timeout float)
+  and compact =
+    flag "--compact" ~doc:" Emit compact JSON instead of indented (pretty)"
+      no_arg
+  in
+  { base_uri; blockchain; network; timeout; compact }
+
+let client_of_globals g =
+  MRC.Http.create ~base_uri:(Uri.of_string g.base_uri) ~blockchain:g.blockchain
+    ~network:g.network ~timeout:g.timeout ()
+
+(* Single JSON record on stdout, with a trailing newline.  Bypasses
+   Async's [print_*] wrappers so the output flushes even when we take
+   the [Stdlib.exit] fast path. *)
+let emit_json g json =
+  let s = if g.compact then MRC.Http.compact json else MRC.Http.pretty json in
+  Stdlib.print_string s ; Stdlib.print_newline () ; Stdlib.flush Stdlib.stdout
+
+let emit_error msg =
+  (* No raw OCaml exception text leaks: [msg] is produced by
+     [MRC.Errors] formatters or by the CLI itself. *)
+  Stdlib.prerr_string (msg ^ "\n") ;
+  Stdlib.flush Stdlib.stderr
+
+(* Run a client call, emit the result as JSON (or the error on stderr
+   and exit 1).  Wraps the "happy path" so each leaf command stays a
+   one-liner. *)
+let run g ~(call : MRC.Http.t -> Yojson.Safe.t Deferred.Or_error.t) =
+  let client = client_of_globals g in
+  match%map call client with
+  | Ok j ->
+      emit_json g j
+  | Error e ->
+      emit_error (Error.to_string_hum e) ;
+      Stdlib.exit 1
+
+(* ---------- Flags reused by more than one subcommand ---------- *)
+
+(* Defined once here so a flag that means the same thing in two
+   subcommands also spells and documents itself the same way. *)
+
+let address_flag =
+  Command.Param.(
+    flag "--address" ~doc:"B62q... Account address" (required string))
+
+let address_filter_flag =
+  Command.Param.(
+    flag "--address" ~doc:"B62q... Filter by account" (optional string))
+
+let tx_hash_flag =
+  Command.Param.(flag "--tx-hash" ~doc:"H Transaction hash" (required string))
+
+let tx_hash_filter_flag =
+  Command.Param.(flag "--tx-hash" ~doc:"H Filter by tx hash" (optional string))
+
+let block_index_flag ~doc = Command.Param.(flag "--index" ~doc (optional int))
+
+let metadata_json_flag =
+  Command.Param.(
+    flag "--metadata-json" ~doc:"JSON Optional metadata object"
+      (optional string))
+
+let operations_json_flag =
+  Command.Param.(
+    flag "--operations-json" ~doc:"JSON Operations array" (required string))
+
+let public_keys_json_flag =
+  Command.Param.(
+    flag "--public-keys-json" ~doc:"JSON PublicKey array" (optional string))
+
+let signed_transaction_flag =
+  Command.Param.(
+    flag "--signed-transaction" ~doc:"STR Signed tx blob" (required string))
+
+(* ---------- Data API subcommands ---------- *)
+
+let cmd_network_list =
+  Command.async ~summary:"POST /network/list"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_list )
+
+let cmd_network_status =
+  Command.async ~summary:"POST /network/status"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_status )
+
+let cmd_network_options =
+  Command.async ~summary:"POST /network/options"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.network_options )
+
+let network_group =
+  Command.group ~summary:"Rosetta /network/* endpoints"
+    [ ("list", cmd_network_list)
+    ; ("status", cmd_network_status)
+    ; ("options", cmd_network_options)
+    ]
+
+let cmd_block_get =
+  Command.async ~summary:"POST /block (by --index or --hash)"
+    (let%map_open.Command g = global_flags_param
+     and index = block_index_flag ~doc:"N Block height"
+     and hash = flag "--hash" ~doc:"H Block state hash" (optional string) in
+     fun () ->
+       match (index, hash) with
+       | None, None ->
+           emit_error "block get: one of --index or --hash is required" ;
+           Stdlib.exit 1
+       | _ ->
+           run g ~call:(fun c -> MRC.Data.block c ?index ?hash ()) )
+
+(* Note: there is no [block transaction] subcommand. Mina's Rosetta server
+   does not implement /block/transaction (it returns every transaction inline
+   in /block, so "other_transactions" is always empty) and would 404 on it.
+   Use [block get] and filter the returned transactions by hash instead. *)
+
+let block_group =
+  Command.group ~summary:"Rosetta /block endpoints" [ ("get", cmd_block_get) ]
+
+let cmd_account_balance =
+  Command.async ~summary:"POST /account/balance"
+    (let%map_open.Command g = global_flags_param
+     and address = address_flag
+     and token_id = flag "--token-id" ~doc:"ID Token id" (optional string)
+     and block_index =
+       block_index_flag ~doc:"N Block height (default: latest)"
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_balance c ~address ?token_id ?block_index () ) )
+
+let cmd_account_coins =
+  Command.async ~summary:"POST /account/coins"
+    (let%map_open.Command g = global_flags_param
+     and address = address_flag
+     and include_mempool =
+       flag "--include-mempool" ~doc:" Include mempool transactions" no_arg
+     in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.account_coins c ~address ~include_mempool () ) )
+
+let account_group =
+  Command.group ~summary:"Rosetta /account/* endpoints"
+    [ ("balance", cmd_account_balance); ("coins", cmd_account_coins) ]
+
+let cmd_mempool_list =
+  Command.async ~summary:"POST /mempool"
+    (let%map_open.Command g = global_flags_param in
+     fun () -> run g ~call:MRC.Data.mempool )
+
+let cmd_mempool_transaction =
+  Command.async ~summary:"POST /mempool/transaction"
+    (let%map_open.Command g = global_flags_param and tx_hash = tx_hash_flag in
+     fun () -> run g ~call:(fun c -> MRC.Data.mempool_transaction c ~tx_hash) )
+
+let mempool_group =
+  Command.group ~summary:"Rosetta /mempool endpoints"
+    [ ("list", cmd_mempool_list); ("transaction", cmd_mempool_transaction) ]
+
+let cmd_search_transactions =
+  Command.async ~summary:"POST /search/transactions"
+    (let%map_open.Command g = global_flags_param
+     and address = address_filter_flag
+     and tx_hash = tx_hash_filter_flag
+     and limit = flag "--limit" ~doc:"N Max results" (optional int) in
+     fun () ->
+       run g ~call:(fun c ->
+           MRC.Data.search_transactions c ?address ?tx_hash ?limit () ) )
+
+let search_group =
+  Command.group ~summary:"Rosetta /search/* endpoints"
+    [ ("transactions", cmd_search_transactions) ]
+
+(* ---------- Construction API subcommands ---------- *)
+
+(* [Payload] reports a bad flag as an error; this is where that error
+   becomes a diagnostic on stderr and a non-zero exit. *)
+let or_exit = function
+  | Ok value ->
+      value
+  | Error e ->
+      emit_error (Error.to_string_hum e) ;
+      Stdlib.exit 1
+
+let required_flag label of_yojson s = or_exit (Payload.model ~label of_yojson s)
+
+let optional_flag label of_yojson s =
+  or_exit (Payload.model_opt ~label of_yojson s)
+
+(* [metadata] and [options] stay raw JSON: the Rosetta schema leaves both
+   free-form, so there is no model to decode them into. *)
+let raw_json_flag label s = or_exit (Payload.json ~label s)
+
+let optional_raw_json_flag label s = or_exit (Payload.json_opt ~label s)
+
+let cmd_construction_derive =
+  Command.async ~summary:"POST /construction/derive"
+    (let%map_open.Command g = global_flags_param
+     and public_key =
+       flag "--public-key-json"
+         ~doc:
+           "JSON Rosetta PublicKey object (e.g. \
+            '{\"hex_bytes\":\"...\",\"curve_type\":\"pallas\"}')"
+         (required string)
+     and metadata = metadata_json_flag in
+     fun () ->
+       let pk =
+         required_flag "--public-key-json" [%of_yojson: RM.Public_key.t]
+           public_key
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       run g ~call:(fun c ->
+           MRC.Construction.derive c ~public_key:pk ?metadata:md () ) )
+
+let cmd_construction_preprocess =
+  Command.async ~summary:"POST /construction/preprocess"
+    (let%map_open.Command g = global_flags_param
+     and operations = operations_json_flag
+     and metadata = metadata_json_flag in
+     fun () ->
+       let ops =
+         required_flag "--operations-json" [%of_yojson: RM.Operation.t list]
+           operations
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       run g ~call:(fun c ->
+           MRC.Construction.preprocess c ~operations:ops ?metadata:md () ) )
+
+let cmd_construction_metadata =
+  Command.async ~summary:"POST /construction/metadata"
+    (let%map_open.Command g = global_flags_param
+     and options =
+       flag "--options-json" ~doc:"JSON Options object" (required string)
+     and public_keys = public_keys_json_flag in
+     fun () ->
+       let opts = raw_json_flag "--options-json" options in
+       let pks =
+         optional_flag "--public-keys-json" [%of_yojson: RM.Public_key.t list]
+           public_keys
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.metadata c ~options:opts ?public_keys:pks () ) )
+
+let cmd_construction_payloads =
+  Command.async ~summary:"POST /construction/payloads"
+    (let%map_open.Command g = global_flags_param
+     and operations = operations_json_flag
+     and metadata = metadata_json_flag
+     and public_keys = public_keys_json_flag in
+     fun () ->
+       let ops =
+         required_flag "--operations-json" [%of_yojson: RM.Operation.t list]
+           operations
+       in
+       let md = optional_raw_json_flag "--metadata-json" metadata in
+       let pks =
+         optional_flag "--public-keys-json" [%of_yojson: RM.Public_key.t list]
+           public_keys
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.payloads c ~operations:ops ?metadata:md
+             ?public_keys:pks () ) )
+
+let cmd_construction_parse =
+  Command.async ~summary:"POST /construction/parse"
+    (let%map_open.Command g = global_flags_param
+     and signed = flag "--signed" ~doc:" Transaction is signed" no_arg
+     and unsigned = flag "--unsigned" ~doc:" Transaction is unsigned" no_arg
+     and transaction =
+       flag "--transaction" ~doc:"STR Transaction blob" (required string)
+     in
+     fun () ->
+       let signed =
+         match (signed, unsigned) with
+         | true, true ->
+             emit_error "--signed and --unsigned are mutually exclusive" ;
+             Stdlib.exit 1
+         | false, false ->
+             emit_error "parse: one of --signed or --unsigned is required" ;
+             Stdlib.exit 1
+         | true, false ->
+             true
+         | false, true ->
+             false
+       in
+       run g ~call:(fun c -> MRC.Construction.parse c ~signed ~transaction) )
+
+let cmd_construction_combine =
+  Command.async ~summary:"POST /construction/combine"
+    (let%map_open.Command g = global_flags_param
+     and unsigned_transaction =
+       flag "--unsigned-transaction" ~doc:"STR Unsigned tx blob"
+         (required string)
+     and signatures =
+       flag "--signatures-json" ~doc:"JSON Signatures array" (required string)
+     in
+     fun () ->
+       let sigs =
+         required_flag "--signatures-json" [%of_yojson: RM.Signature.t list]
+           signatures
+       in
+       run g ~call:(fun c ->
+           MRC.Construction.combine c ~unsigned_transaction ~signatures:sigs )
+    )
+
+let cmd_construction_hash =
+  Command.async ~summary:"POST /construction/hash"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction = signed_transaction_flag in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.hash c ~signed_transaction) )
+
+let cmd_construction_submit =
+  Command.async ~summary:"POST /construction/submit"
+    (let%map_open.Command g = global_flags_param
+     and signed_transaction = signed_transaction_flag in
+     fun () ->
+       run g ~call:(fun c -> MRC.Construction.submit c ~signed_transaction) )
+
+let construction_group =
+  Command.group ~summary:"Rosetta /construction/* endpoints"
+    [ ("derive", cmd_construction_derive)
+    ; ("preprocess", cmd_construction_preprocess)
+    ; ("metadata", cmd_construction_metadata)
+    ; ("payloads", cmd_construction_payloads)
+    ; ("parse", cmd_construction_parse)
+    ; ("combine", cmd_construction_combine)
+    ; ("hash", cmd_construction_hash)
+    ; ("submit", cmd_construction_submit)
+    ]
+
+(* ---------- Top-level ---------- *)
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta client CLI — curl-on-steroids for a running Rosetta \
+          server"
+       [ ("network", network_group)
+       ; ("block", block_group)
+       ; ("account", account_group)
+       ; ("mempool", mempool_group)
+       ; ("search", search_group)
+       ; ("construction", construction_group)
+       ] )

--- a/src/app/rosetta/client/tests/dune
+++ b/src/app/rosetta/client/tests/dune
@@ -1,0 +1,25 @@
+;; Hermetic alcotest smoke tests for rosetta-client.
+;;
+;; These exercise only subcommands that don't need a running Rosetta
+;; server: --help for each subgroup and the clean error paths of the
+;; HTTP and JSON-validation code.
+
+(test
+ (name test_rosetta_client)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_kernel
+  core_unix
+  core_unix.filename_unix
+  core_unix.sys_unix
+  stdio
+  yojson
+  ;; mina libraries
+  rosetta_client)
+ (deps ../rosetta_client_cli.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/client/tests/test_rosetta_client.ml
+++ b/src/app/rosetta/client/tests/test_rosetta_client.ml
@@ -1,0 +1,202 @@
+(* Hermetic alcotest smoke tests for rosetta-client.
+
+   These exercise only the subcommands that don't need a running
+   Rosetta server: --help for each subgroup and the clean error paths of
+   the HTTP and JSON-validation code.
+
+   The regression guard we care most about is that user-visible error
+   output never leaks raw OCaml exception syntax (e.g. Unix_error,
+   Core.Unix.Unix_error, etc.).  See [assert_no_ocaml_exn_leak]. *)
+
+open Core
+
+(* Path to the binary under test.  dune places the test executable in
+   the same directory as its deps, so [../rosetta_client_cli.exe] is reachable from
+   wherever dune chooses to [chdir] into.  We resolve it once relative
+   to [Sys.get_argv ().(0)] so the tests survive dune sandboxing. *)
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../rosetta_client_cli.exe"
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args] and an optional env extension, capture
+   stdout and stderr, return [(exit_code, stdout, stderr)]. *)
+let run_cli ?(env = []) args =
+  let pi = Core_unix.create_process_env ~prog:bin ~args ~env:(`Extend env) () in
+  (* Close stdin immediately so the child gets EOF if it ever tried to
+     read. *)
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: no user-facing output must contain raw OCaml
+   exception syntax.  The triggering bug for this whole cleanup was
+   connection-refused paths leaking [Unix_error] through to stderr. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains ?(case_insensitive = false) s ~sub =
+  if case_insensitive then
+    String.is_substring (String.lowercase s) ~substring:(String.lowercase sub)
+  else String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  check_contains ~label:"--help root lists network" out ~sub:"network" ;
+  check_contains ~label:"--help root lists construction" out ~sub:"construction" ;
+  assert_no_ocaml_exn_leak "--help root stderr" err
+
+let test_help_network () =
+  let code, out, err = run_cli [ "network"; "--help" ] in
+  Alcotest.(check int) "network --help exit" 0 code ;
+  check_contains ~label:"network --help lists list" out ~sub:"list" ;
+  check_contains ~label:"network --help lists status" out ~sub:"status" ;
+  check_contains ~label:"network --help lists options" out ~sub:"options" ;
+  assert_no_ocaml_exn_leak "network --help stderr" err
+
+let test_help_construction () =
+  let code, out, err = run_cli [ "construction"; "--help" ] in
+  Alcotest.(check int) "construction --help exit" 0 code ;
+  check_contains ~label:"construction --help lists derive" out ~sub:"derive" ;
+  check_contains ~label:"construction --help lists submit" out ~sub:"submit" ;
+  assert_no_ocaml_exn_leak "construction --help stderr" err
+
+let test_connection_refused_clean_error () =
+  (* Port 1 is privileged and reliably refuses on loopback. *)
+  let code, out, err =
+    run_cli [ "network"; "status"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  Alcotest.(check int) "network status (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "network status stdout" out ;
+  assert_no_ocaml_exn_leak "network status stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  let has_signal =
+    contains ~case_insensitive:true combined ~sub:"refused"
+    || contains ~case_insensitive:true combined ~sub:"unreachable"
+    || contains combined ~sub:"127.0.0.1:1"
+  in
+  if not has_signal then
+    Alcotest.failf
+      "network status (dead port): stderr should signal refusal / URI, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+let test_block_get_missing_args () =
+  let code, out, err =
+    run_cli [ "block"; "get"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then
+    Alcotest.failf "block get (no --index/--hash): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "block get stdout" out ;
+  assert_no_ocaml_exn_leak "block get stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if String.is_empty (String.strip combined) then
+    Alcotest.failf "block get (no --index/--hash): expected a diagnostic"
+
+let test_construction_derive_invalid_json () =
+  let code, out, err =
+    run_cli
+      [ "construction"
+      ; "derive"
+      ; "--public-key-json"
+      ; "{not valid"
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ]
+  in
+  if code = 0 then
+    Alcotest.failf "construction derive (bad JSON): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "construction derive stdout" out ;
+  assert_no_ocaml_exn_leak "construction derive stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if
+    not
+      ( contains ~case_insensitive:true combined ~sub:"json"
+      || contains combined ~sub:"public-key-json" )
+  then
+    Alcotest.failf
+      "construction derive (bad JSON): stderr should mention JSON, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+(* Valid JSON that is not a Rosetta PublicKey: the CLI decodes flag
+   payloads into the endpoint's model, so this must be rejected locally
+   with the flag name rather than sent to the server. *)
+let test_construction_derive_schema_mismatch () =
+  let code, out, err =
+    run_cli
+      [ "construction"
+      ; "derive"
+      ; "--public-key-json"
+      ; {|{"hex_bytes":"aabb"}|}
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ]
+  in
+  if code = 0 then
+    Alcotest.failf "construction derive (bad schema): expected non-zero exit" ;
+  assert_no_ocaml_exn_leak "construction derive stdout" out ;
+  assert_no_ocaml_exn_leak "construction derive stderr" err ;
+  let combined = out ^ "\n" ^ err in
+  if
+    not
+      ( contains ~case_insensitive:true combined ~sub:"schema"
+      || contains combined ~sub:"public-key-json" )
+  then
+    Alcotest.failf
+      "construction derive (bad schema): stderr should name the flag or the \n\
+       schema, got:\n\
+       stdout=%s\n\
+       stderr=%s"
+      out err
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-client CLI smoke tests"
+    [ ( "help"
+      , [ ("root", `Quick, test_help_root)
+        ; ("network", `Quick, test_help_network)
+        ; ("construction", `Quick, test_help_construction)
+        ] )
+    ; ( "error paths"
+      , [ ( "connection refused is clean"
+          , `Quick
+          , test_connection_refused_clean_error )
+        ; ("block get missing args", `Quick, test_block_get_missing_args)
+        ; ( "construction derive invalid JSON"
+          , `Quick
+          , test_construction_derive_invalid_json )
+        ; ( "construction derive schema mismatch"
+          , `Quick
+          , test_construction_derive_schema_mismatch )
+        ] )
+    ]

--- a/src/dune-project
+++ b/src/dune-project
@@ -124,6 +124,7 @@
 (package (name mina_node_config))
 (package (name mina_numbers))
 (package (name mina_plugins))
+(package (name rosetta_client))
 (package (name mina_runtime_config))
 (package (name mina_signature_kind))
 (package (name mina_snark_worker))

--- a/src/lib/rosetta_client/construction.ml
+++ b/src/lib/rosetta_client/construction.ml
@@ -1,0 +1,87 @@
+(* Rosetta Construction API wrappers.  See [construction.mli].
+
+   As in [Data], each request is the generated Rosetta request model for
+   the endpoint, serialised with its own [to_yojson]. *)
+
+module RM = Rosetta_models
+
+let derive t ~public_key ?metadata () =
+  let request =
+    { RM.Construction_derive_request.network_identifier =
+        Http.network_identifier t
+    ; public_key
+    ; metadata
+    }
+  in
+  Http.post_json t ~path:"/construction/derive"
+    ~body:(RM.Construction_derive_request.to_yojson request)
+
+let preprocess t ~operations ?metadata () =
+  let request =
+    { RM.Construction_preprocess_request.network_identifier =
+        Http.network_identifier t
+    ; operations
+    ; metadata
+    }
+  in
+  Http.post_json t ~path:"/construction/preprocess"
+    ~body:(RM.Construction_preprocess_request.to_yojson request)
+
+let metadata t ?options ?(public_keys = []) () =
+  let request =
+    { RM.Construction_metadata_request.network_identifier =
+        Http.network_identifier t
+    ; options
+    ; public_keys
+    }
+  in
+  Http.post_json t ~path:"/construction/metadata"
+    ~body:(RM.Construction_metadata_request.to_yojson request)
+
+let payloads t ~operations ?metadata ?(public_keys = []) () =
+  let request =
+    { RM.Construction_payloads_request.network_identifier =
+        Http.network_identifier t
+    ; operations
+    ; metadata
+    ; public_keys
+    }
+  in
+  Http.post_json t ~path:"/construction/payloads"
+    ~body:(RM.Construction_payloads_request.to_yojson request)
+
+let parse t ~signed ~transaction =
+  let request =
+    RM.Construction_parse_request.create
+      (Http.network_identifier t)
+      signed transaction
+  in
+  Http.post_json t ~path:"/construction/parse"
+    ~body:(RM.Construction_parse_request.to_yojson request)
+
+let combine t ~unsigned_transaction ~signatures =
+  let request =
+    RM.Construction_combine_request.create
+      (Http.network_identifier t)
+      unsigned_transaction signatures
+  in
+  Http.post_json t ~path:"/construction/combine"
+    ~body:(RM.Construction_combine_request.to_yojson request)
+
+let hash t ~signed_transaction =
+  let request =
+    RM.Construction_hash_request.create
+      (Http.network_identifier t)
+      signed_transaction
+  in
+  Http.post_json t ~path:"/construction/hash"
+    ~body:(RM.Construction_hash_request.to_yojson request)
+
+let submit t ~signed_transaction =
+  let request =
+    RM.Construction_submit_request.create
+      (Http.network_identifier t)
+      signed_transaction
+  in
+  Http.post_json t ~path:"/construction/submit"
+    ~body:(RM.Construction_submit_request.to_yojson request)

--- a/src/lib/rosetta_client/construction.mli
+++ b/src/lib/rosetta_client/construction.mli
@@ -1,0 +1,58 @@
+(** Rosetta Construction API wrappers.
+
+    Every function builds the generated Rosetta request model for its
+    endpoint (with [network_identifier] injected automatically), POSTs
+    it, and returns the decoded response.  Arguments are the typed
+    models rather than raw JSON, so a malformed payload is rejected
+    while it is still being decoded from the caller's input instead of
+    by the server.
+
+    [metadata] and [options] stay [Yojson.Safe.t] because the Rosetta
+    schema itself leaves those two fields free-form. *)
+
+val derive :
+     Http.t
+  -> public_key:Rosetta_models.Public_key.t
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val preprocess :
+     Http.t
+  -> operations:Rosetta_models.Operation.t list
+  -> ?metadata:Yojson.Safe.t
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val metadata :
+     Http.t
+  -> ?options:Yojson.Safe.t
+  -> ?public_keys:Rosetta_models.Public_key.t list
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val payloads :
+     Http.t
+  -> operations:Rosetta_models.Operation.t list
+  -> ?metadata:Yojson.Safe.t
+  -> ?public_keys:Rosetta_models.Public_key.t list
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val parse :
+     Http.t
+  -> signed:bool
+  -> transaction:string
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val combine :
+     Http.t
+  -> unsigned_transaction:string
+  -> signatures:Rosetta_models.Signature.t list
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val hash :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val submit :
+  Http.t -> signed_transaction:string -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/data.ml
+++ b/src/lib/rosetta_client/data.ml
@@ -1,0 +1,131 @@
+(* Rosetta Data API wrappers.  See [data.mli].
+
+   Every request is built as the generated Rosetta request model for the
+   endpoint and serialised with its own [to_yojson], so the field names,
+   the required/optional split and the nesting all come from the schema
+   rather than from hand-written JSON objects. *)
+
+open Core_kernel
+module RM = Rosetta_models
+
+(* A Mina token id travels in [account_identifier.metadata], which the
+   Rosetta schema leaves free-form.  Give the one shape we send a type
+   of its own so the endpoint wrappers below never assemble JSON. *)
+module Token_metadata = struct
+  type t = { token_id : string } [@@deriving to_yojson]
+end
+
+let account_identifier ?token_id address =
+  { RM.Account_identifier.address
+  ; sub_account = None
+  ; metadata =
+      Option.map token_id ~f:(fun token_id ->
+          Token_metadata.to_yojson { Token_metadata.token_id } )
+  }
+
+let partial_block_identifier ?index ?hash () =
+  { RM.Partial_block_identifier.index = Option.map index ~f:Int64.of_int; hash }
+
+let decode_response response ~endpoint of_yojson =
+  Async.Deferred.Or_error.bind response ~f:(fun json ->
+      match of_yojson json with
+      | Ok response ->
+          Async.Deferred.Or_error.return response
+      | Error msg ->
+          Async.Deferred.Or_error.errorf
+            "%s response did not match Rosetta schema: %s" endpoint msg )
+
+(* A request whose only content is the network_identifier: /network/status,
+   /network/options and /mempool all take this shape. *)
+let network_request t =
+  RM.Network_request.to_yojson
+    (RM.Network_request.create (Http.network_identifier t))
+
+let network_list t =
+  Http.post_json t ~path:"/network/list"
+    ~body:(RM.Metadata_request.to_yojson (RM.Metadata_request.create ()))
+
+let network_list_response t =
+  decode_response (network_list t) ~endpoint:"/network/list"
+    RM.Network_list_response.of_yojson
+
+let network_status t =
+  Http.post_json t ~path:"/network/status" ~body:(network_request t)
+
+let network_status_response t =
+  decode_response (network_status t) ~endpoint:"/network/status"
+    RM.Network_status_response.of_yojson
+
+let network_options t =
+  Http.post_json t ~path:"/network/options" ~body:(network_request t)
+
+let network_options_response t =
+  decode_response (network_options t) ~endpoint:"/network/options"
+    RM.Network_options_response.of_yojson
+
+let block t ?index ?hash () =
+  let request =
+    RM.Block_request.create
+      (Http.network_identifier t)
+      (partial_block_identifier ?index ?hash ())
+  in
+  Http.post_json t ~path:"/block" ~body:(RM.Block_request.to_yojson request)
+
+let account_balance t ~address ?token_id ?block_index () =
+  let request =
+    { RM.Account_balance_request.network_identifier = Http.network_identifier t
+    ; account_identifier = account_identifier ?token_id address
+    ; block_identifier =
+        Option.map block_index ~f:(fun index ->
+            partial_block_identifier ~index () )
+    ; currencies = []
+    }
+  in
+  Http.post_json t ~path:"/account/balance"
+    ~body:(RM.Account_balance_request.to_yojson request)
+
+let account_coins t ~address ?(include_mempool = false) () =
+  let request =
+    RM.Account_coins_request.create
+      (Http.network_identifier t)
+      (account_identifier address)
+      include_mempool
+  in
+  Http.post_json t ~path:"/account/coins"
+    ~body:(RM.Account_coins_request.to_yojson request)
+
+let mempool t = Http.post_json t ~path:"/mempool" ~body:(network_request t)
+
+let mempool_transaction t ~tx_hash =
+  let request =
+    RM.Mempool_transaction_request.create
+      (Http.network_identifier t)
+      (RM.Transaction_identifier.create tx_hash)
+  in
+  Http.post_json t ~path:"/mempool/transaction"
+    ~body:(RM.Mempool_transaction_request.to_yojson request)
+
+let search_transactions_request t ?address ?tx_hash ?limit () =
+  { (RM.Search_transactions_request.create (Http.network_identifier t)) with
+    RM.Search_transactions_request.address
+  ; transaction_identifier =
+      Option.map tx_hash ~f:RM.Transaction_identifier.create
+  ; limit = Option.map limit ~f:Int64.of_int
+  }
+
+(* [address] is the top-level filter that matches an account regardless
+   of its sub-account; [account_identifier] would additionally require
+   the sub-account to match, so an address-only search must not set it. *)
+let%test_unit "search_transactions uses the top-level address filter" =
+  let client = Http.create ~base_uri:(Uri.of_string "http://localhost") () in
+  let request = search_transactions_request client ~address:"B62qaddress" () in
+  [%test_eq: string option] request.RM.Search_transactions_request.address
+    (Some "B62qaddress") ;
+  if Option.is_some request.RM.Search_transactions_request.account_identifier
+  then failwith "address-only search should not emit account_identifier"
+
+let search_transactions t ?address ?tx_hash ?limit () =
+  Http.post_json t ~path:"/search/transactions"
+    ~body:
+      (RM.Search_transactions_request.to_yojson
+         (search_transactions_request t ?address ?tx_hash ?limit ()) )

--- a/src/lib/rosetta_client/data.mli
+++ b/src/lib/rosetta_client/data.mli
@@ -1,0 +1,59 @@
+(** Rosetta Data API: read-only endpoints.
+
+    The raw endpoint functions POST to the appropriate path and return
+    the decoded response as a [Yojson.Safe.t].  The client's
+    [network_identifier] is injected automatically; callers pass in only
+    the endpoint-specific payload.
+
+    The [*_response] helpers decode selected endpoint responses through
+    the generated Rosetta model Yojson bindings. *)
+
+val network_list : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_list_response :
+  Http.t -> Rosetta_models.Network_list_response.t Async.Deferred.Or_error.t
+
+val network_status : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_status_response :
+  Http.t -> Rosetta_models.Network_status_response.t Async.Deferred.Or_error.t
+
+val network_options : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val network_options_response :
+  Http.t -> Rosetta_models.Network_options_response.t Async.Deferred.Or_error.t
+
+val block :
+     Http.t
+  -> ?index:int
+  -> ?hash:string
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val account_balance :
+     Http.t
+  -> address:string
+  -> ?token_id:string
+  -> ?block_index:int
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val account_coins :
+     Http.t
+  -> address:string
+  -> ?include_mempool:bool
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val mempool : Http.t -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val mempool_transaction :
+  Http.t -> tx_hash:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+val search_transactions :
+     Http.t
+  -> ?address:string
+  -> ?tx_hash:string
+  -> ?limit:int
+  -> unit
+  -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/defaults.ml
+++ b/src/lib/rosetta_client/defaults.ml
@@ -1,0 +1,51 @@
+(* Fallback values and environment-variable names shared by every
+   Rosetta CLI.  See [defaults.mli]. *)
+
+open Core_kernel
+
+let uri_env_var = "MINA_ROSETTA_URI"
+
+let blockchain_env_var = "MINA_ROSETTA_BLOCKCHAIN"
+
+let network_env_var = "MINA_ROSETTA_NETWORK"
+
+let base_uri = "http://localhost:3087"
+
+let blockchain = "mina"
+
+let network = "testnet"
+
+(* Seconds allowed for one request/response exchange with the Rosetta
+   server, measured from sending the request to reading the last byte of
+   the response body. *)
+let http_timeout = 5.0
+
+(* A variable that is declared but blank -- [MINA_ROSETTA_URI=], or a
+   Kubernetes [env:] entry with an empty [value:] -- means "not
+   configured", not "configure this to the empty string".  Taking it
+   literally would build a request against an empty base URI, or send an
+   empty network_identifier.network that every server rejects. *)
+let env_value value ~default =
+  match value with
+  | Some value when not (String.is_empty (String.strip value)) ->
+      value
+  | _ ->
+      default
+
+let%test_unit "a blank environment variable falls back to the default" =
+  let check value = [%test_eq: string] (env_value value ~default:"d") "d" in
+  check None ;
+  check (Some "") ;
+  check (Some "   ") ;
+  [%test_eq: string] (env_value (Some "v") ~default:"d") "v"
+
+(* [Stdlib.Sys] rather than [Core_kernel.Sys]: the latter's [getenv]
+   raises on an unset variable, and an unset variable is the normal case
+   here. *)
+let from_env var ~default = env_value (Stdlib.Sys.getenv_opt var) ~default
+
+let base_uri_from_env () = from_env uri_env_var ~default:base_uri
+
+let blockchain_from_env () = from_env blockchain_env_var ~default:blockchain
+
+let network_from_env () = from_env network_env_var ~default:network

--- a/src/lib/rosetta_client/defaults.mli
+++ b/src/lib/rosetta_client/defaults.mli
@@ -1,0 +1,53 @@
+(** Fallback values shared by every Rosetta CLI.
+
+    Both [rosetta-client] and [rosetta-healthcheck] connect to the same
+    server with the same network_identifier, so the values they fall back
+    to when a flag is omitted are defined once, here, rather than once per
+    binary.  {!Http.create} uses the same values as its optional-argument
+    defaults.
+
+    Each value has an environment-variable override, so an operator who
+    always talks to the same server can export it once instead of
+    repeating flags on every invocation.  A flag, when given, always wins
+    over the environment variable.
+
+    {ul
+    {- [MINA_ROSETTA_URI] — base URL of the Rosetta server.}
+    {- [MINA_ROSETTA_BLOCKCHAIN] — [network_identifier.blockchain].}
+    {- [MINA_ROSETTA_NETWORK] — [network_identifier.network].}} *)
+
+(** Name of the environment variable that overrides {!base_uri}. *)
+val uri_env_var : string
+
+(** Name of the environment variable that overrides {!blockchain}. *)
+val blockchain_env_var : string
+
+(** Name of the environment variable that overrides {!network}. *)
+val network_env_var : string
+
+(** Base URL of a Rosetta server running next to the daemon
+    ([http://localhost:3087]). *)
+val base_uri : string
+
+(** [network_identifier.blockchain] for every Mina network ([mina]). *)
+val blockchain : string
+
+(** [network_identifier.network] ([testnet]). *)
+val network : string
+
+(** Seconds allowed for one request/response exchange with the Rosetta
+    server, from sending the request to reading the last byte of the
+    response body. *)
+val http_timeout : float
+
+(** [base_uri_from_env ()] is [$MINA_ROSETTA_URI] when that variable is
+    set, and {!base_uri} otherwise. *)
+val base_uri_from_env : unit -> string
+
+(** [blockchain_from_env ()] is [$MINA_ROSETTA_BLOCKCHAIN] when that
+    variable is set, and {!blockchain} otherwise. *)
+val blockchain_from_env : unit -> string
+
+(** [network_from_env ()] is [$MINA_ROSETTA_NETWORK] when that variable
+    is set, and {!network} otherwise. *)
+val network_from_env : unit -> string

--- a/src/lib/rosetta_client/dune
+++ b/src/lib/rosetta_client/dune
@@ -1,0 +1,27 @@
+(library
+ (name rosetta_client)
+ (public_name rosetta_client)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  async
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_models)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps
+   ppx_version
+   ppx_let
+   ppx_here
+   ppx_inline_test
+   ppx_assert
+   ppx_deriving_yojson)))

--- a/src/lib/rosetta_client/errors.ml
+++ b/src/lib/rosetta_client/errors.ml
@@ -1,0 +1,142 @@
+(* Rosetta error-envelope and transport-exception formatting.  See
+   [errors.mli] for contract.  The goal is to produce one-line human
+   messages that are safe to splat into a [{"error": "..."}] JSON field:
+   no raw OCaml exception syntax, no giant HTTP bodies. *)
+
+open Core_kernel
+
+(* Use [Core.Unix] for the [Unix.Unix_error] constructor (Core_kernel
+   shadows Unix).  Aliased locally so the pattern-match syntax stays
+   natural. *)
+module Unix = Core.Unix
+
+let max_body_chars = 500
+
+(* Collapse every run of whitespace, newlines included, into one space.
+   A reverse proxy answers with a multi-line HTML page, and [errors.mli]
+   promises a message that is safe to put on one log line or in a JSON
+   [error] field. *)
+let single_line s =
+  String.split_on_chars s ~on:[ ' '; '\t'; '\n'; '\r' ]
+  |> List.filter ~f:(fun part -> not (String.is_empty part))
+  |> String.concat ~sep:" "
+
+let truncate s =
+  let s = single_line s in
+  if String.length s <= max_body_chars then s
+  else String.sub s ~pos:0 ~len:max_body_chars ^ "... (truncated)"
+
+(* The [message] of a Rosetta error envelope
+   ({"code":_,"message":_,"retriable":_,...}).  We decode only that one
+   field, and tolerate an envelope that omits the other required fields,
+   because the sole purpose here is to recover a readable message from
+   whatever the server sent -- a strict decode would throw the message
+   away over an unrelated missing field. *)
+module Envelope = struct
+  type t = { message : string } [@@deriving of_yojson { strict = false }]
+end
+
+let try_parse_envelope body =
+  match Or_error.try_with (fun () -> Yojson.Safe.from_string body) with
+  | Error _ ->
+      None
+  | Ok json -> (
+      match Envelope.of_yojson json with
+      | Ok envelope ->
+          Some envelope.Envelope.message
+      | Error _ ->
+          None )
+
+let format_http_body ~status ~body =
+  match try_parse_envelope body with
+  | Some msg ->
+      (* [truncate], not just [single_line]: Mina's Rosetta propagates
+         Postgres and GraphQL errors into [message], so the envelope can
+         carry as much text as a raw body. *)
+      sprintf "HTTP %d: %s" status (truncate msg)
+  | None ->
+      if String.is_empty (String.strip body) then sprintf "HTTP %d" status
+      else sprintf "HTTP %d: %s" status (truncate body)
+
+let format_exn ~url exn =
+  let url_s = Uri.to_string url in
+  match exn with
+  | Unix.Unix_error (Unix.ECONNREFUSED, _, _) ->
+      sprintf "connection refused to %s" url_s
+  | Unix.Unix_error (Unix.ETIMEDOUT, _, _) ->
+      sprintf "timeout connecting to %s" url_s
+  | Unix.Unix_error (Unix.ENETUNREACH, _, _) ->
+      sprintf "network unreachable to %s" url_s
+  | Unix.Unix_error (Unix.EHOSTUNREACH, _, _) ->
+      sprintf "host unreachable to %s" url_s
+  | Unix.Unix_error (Unix.ECONNRESET, _, _) ->
+      sprintf "connection reset by %s" url_s
+  | Unix.Unix_error (err, _, _) ->
+      sprintf "request to %s failed: %s" url_s (Unix.Error.message err)
+  | Failure m ->
+      sprintf "request to %s failed: %s" url_s m
+  | _ ->
+      (* Last-resort fallback for exceptions we haven't pattern-matched
+         above. Keep the message generic so user-visible output never
+         leaks raw OCaml exception constructor syntax. *)
+      sprintf "request to %s failed" url_s
+
+let%test_unit "format_http_body parses Rosetta envelope" =
+  let body =
+    {|{"code":4,"message":"Network doesn't exist","details":{"x":1}}|}
+  in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Network doesn't exist"
+
+let%test_unit "format_http_body falls back to truncated body on non-envelope" =
+  let body = "Internal Server Error" in
+  [%test_eq: string]
+    (format_http_body ~status:500 ~body)
+    "HTTP 500: Internal Server Error"
+
+let%test_unit "format_http_body truncates very long bodies" =
+  let body = String.make (max_body_chars + 100) 'x' in
+  let rendered = format_http_body ~status:502 ~body in
+  [%test_pred: string] (String.is_substring ~substring:"truncated") rendered
+
+let%test_unit "format_http_body truncates a long envelope message" =
+  let message = String.make (max_body_chars + 100) 'x' in
+  let body = Yojson.Safe.to_string (`Assoc [ ("message", `String message) ]) in
+  [%test_pred: string]
+    (String.is_substring ~substring:"truncated")
+    (format_http_body ~status:500 ~body)
+
+let%test_unit "format_http_body renders a multi-line body on one line" =
+  let body = "<html>\n<head><title>502 Bad Gateway</title></head>\n</html>" in
+  let rendered = format_http_body ~status:502 ~body in
+  [%test_pred: string] (fun s -> not (String.contains s '\n')) rendered ;
+  [%test_pred: string]
+    (String.is_substring ~substring:"502 Bad Gateway")
+    rendered
+
+let%test_unit "format_http_body handles empty body" =
+  [%test_eq: string] (format_http_body ~status:504 ~body:"") "HTTP 504"
+
+let%test_unit "format_exn ECONNREFUSED is readable" =
+  let url = Uri.of_string "http://localhost:9999" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "127.0.0.1:9999") in
+  [%test_eq: string] (format_exn ~url exn)
+    "connection refused to http://localhost:9999"
+
+let%test_unit "format_exn never leaks OCaml Unix_error syntax" =
+  let url = Uri.of_string "http://example.invalid" in
+  let exn = Unix.Unix_error (Unix.ECONNREFUSED, "connect", "x") in
+  let s = format_exn ~url exn in
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix_error"))
+    s ;
+  [%test_pred: string]
+    (fun s -> not (String.is_substring s ~substring:"Unix."))
+    s
+
+let%test_unit "format_exn handles ETIMEDOUT" =
+  let url = Uri.of_string "http://slow.example" in
+  let exn = Unix.Unix_error (Unix.ETIMEDOUT, "connect", "x") in
+  [%test_eq: string] (format_exn ~url exn)
+    "timeout connecting to http://slow.example"

--- a/src/lib/rosetta_client/errors.mli
+++ b/src/lib/rosetta_client/errors.mli
@@ -1,0 +1,24 @@
+(** Rosetta-friendly formatting for HTTP errors and transport exceptions.
+
+    These helpers produce short, human-readable strings that are safe to
+    splat into a JSON [error] field or print on stderr.  They MUST NOT
+    leak raw OCaml exception syntax (e.g. [(Unix_error ...)]) or dump
+    multi-kilobyte HTTP bodies verbatim. *)
+
+(** [format_http_body ~status ~body] renders a non-2xx HTTP response as
+    a short diagnostic like ["HTTP 500: Network doesn't exist"]. If
+    [body] is a Rosetta error envelope ({"code":_,"message":_,...}), the
+    [message] field is used; otherwise the body is included truncated to
+    [max_body_chars] characters. *)
+val format_http_body : status:int -> body:string -> string
+
+(** [format_exn ~url e] renders a transport exception (typically from
+    Cohttp_async or Async_unix) as a short diagnostic like
+    ["connection refused to http://localhost:9999"].  No raw OCaml
+    exception syntax leaks through. *)
+val format_exn : url:Uri.t -> exn -> string
+
+(** Character cap used by [format_http_body] when falling back to the
+    raw body.  Exposed so callers can reference the same bound in tests
+    and documentation. *)
+val max_body_chars : int

--- a/src/lib/rosetta_client/http.ml
+++ b/src/lib/rosetta_client/http.ml
@@ -1,0 +1,175 @@
+(* HTTP core for the Rosetta client library.  See [http.mli]. *)
+
+open Core_kernel
+open Async
+
+type t =
+  { base_uri : Uri.t; blockchain : string; network : string; timeout : float }
+
+(* Normalise the base URI once, here, rather than on every request: drop
+   any trailing slash from its path so that appending an endpoint path
+   (which always starts with "/") cannot produce a double slash.  Every
+   other part of the URI -- scheme, userinfo, host, port, query,
+   fragment, percent-encoding -- is left to [Uri]. *)
+let normalize_base base_uri =
+  Uri.with_path base_uri
+    (String.rstrip ~drop:(Char.equal '/') (Uri.path base_uri))
+
+let create ~base_uri ?(blockchain = Defaults.blockchain)
+    ?(network = Defaults.network) ?(timeout = Defaults.http_timeout) () =
+  { base_uri = normalize_base base_uri; blockchain; network; timeout }
+
+let base_uri t = t.base_uri
+
+let blockchain t = t.blockchain
+
+let network t = t.network
+
+let timeout t = t.timeout
+
+let network_identifier t =
+  Rosetta_models.Network_identifier.create t.blockchain t.network
+
+(* Append an endpoint path to the (already normalised) base path.  A
+   base URI may carry a path of its own -- a Rosetta server behind a
+   reverse proxy at http://host/rosetta -- so the endpoint is appended to
+   [Uri.path base] instead of replacing it. *)
+let join_uri base path =
+  let path = if String.is_prefix path ~prefix:"/" then path else "/" ^ path in
+  Uri.with_path base (Uri.path base ^ path)
+
+let pretty j = Yojson.Safe.pretty_to_string j
+
+let compact j = Yojson.Safe.to_string j
+
+(* One request/response exchange: enforces [t.timeout], folds all
+   transport/decode failures into the error channel, and renders any
+   error via [Errors] so callers never see raw OCaml exception text.
+
+   Racing the deferred against [with_timeout] is not enough on its own:
+   it stops us waiting, but leaves the socket open until the far end
+   closes it, and [rosetta-healthcheck wait] is a probe loop, so one
+   invocation against a sick server would pile up file descriptors.  Two
+   levers close it instead:
+
+   - [interrupt], which Cohttp passes to the TCP connect, so a connect
+     that never completes is abandoned with its socket;
+   - closing the response body's pipe, which is what Cohttp itself waits
+     on before it closes the reader and writer (see [Pipe.closed] in
+     cohttp-async's [Client.request]), so a response whose body stalls
+     is torn down too.
+
+   One case is left: a server that completes the TCP connect and then
+   never sends a response line.  Cohttp-async 5.0.0 exposes no handle on
+   that connection -- [Client.Connection.close] cannot preempt its own
+   in-flight request either, because the throttle runs its [at_kill]
+   only once the blocked job finishes -- so closing it would mean owning
+   the transport here rather than using [Cohttp_async.Client].  The leak
+   that remains is bounded by one run of a short-lived CLI and cannot
+   reach the default descriptor limit at any usable --timeout/--interval
+   pair. *)
+let with_request t ~uri ~make_req ~describe =
+  let timed_out = Ivar.create () in
+  let body_pipe = Ivar.create () in
+  let exchange () =
+    let%bind response, body = make_req ~interrupt:(Ivar.read timed_out) in
+    let pipe = Cohttp_async.Body.to_pipe body in
+    Ivar.fill body_pipe pipe ;
+    let%map chunks = Pipe.to_list pipe in
+    (response, String.concat chunks)
+  in
+  let result =
+    Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true exchange
+  in
+  match%bind Async.with_timeout (Time.Span.of_sec t.timeout) result with
+  | `Timeout ->
+      Ivar.fill_if_empty timed_out () ;
+      Option.iter (Ivar.peek body_pipe) ~f:Pipe.close_read ;
+      Deferred.Or_error.errorf "timeout after %.1fs: %s %s" t.timeout describe
+        (Uri.to_string uri)
+  | `Result (Error e) ->
+      let msg =
+        match Error.to_exn e with exn -> Errors.format_exn ~url:uri exn
+      in
+      Deferred.Or_error.error_string msg
+  | `Result (Ok (response, body_str)) -> (
+      let status = Cohttp_async.Response.status response in
+      let code = Cohttp.Code.code_of_status status in
+      if code < 200 || code >= 300 then
+        Deferred.Or_error.error_string
+          (Errors.format_http_body ~status:code ~body:body_str)
+      else
+        match
+          Or_error.try_with (fun () -> Yojson.Safe.from_string body_str)
+        with
+        | Ok j ->
+            Deferred.Or_error.return j
+        | Error _ ->
+            Deferred.Or_error.errorf
+              "invalid JSON response from %s (first 200 chars: %s)"
+              (Uri.to_string uri)
+              ( if String.length body_str > 200 then
+                String.sub body_str ~pos:0 ~len:200
+              else body_str ) )
+
+(* Every Rosetta endpoint answers JSON; only the ones we send a body to
+   also need to declare the request's own content type.  [request_headers]
+   is derived from [response_headers] so the shared Accept is stated once. *)
+let response_headers = Cohttp.Header.init_with "Accept" "application/json"
+
+let request_headers =
+  Cohttp.Header.add response_headers "Content-Type" "application/json"
+
+let post_json t ~path ~body =
+  let uri = join_uri t.base_uri path in
+  let body_str = Yojson.Safe.to_string body in
+  with_request t ~uri ~describe:"POST" ~make_req:(fun ~interrupt ->
+      Cohttp_async.Client.post ~interrupt ~headers:request_headers
+        ~body:(Cohttp_async.Body.of_string body_str)
+        uri )
+
+let get_json t ~path =
+  let uri = join_uri t.base_uri path in
+  with_request t ~uri ~describe:"GET" ~make_req:(fun ~interrupt ->
+      Cohttp_async.Client.get ~interrupt ~headers:response_headers uri )
+
+(* Regression guard: when a response's body stalls, the timeout must
+   close the connection, not merely stop waiting on it.  The server here
+   sends a complete set of response headers promising 100 bytes and then
+   sends nothing, so the only way its reader reaches EOF is if the client
+   hangs up. *)
+let%test_unit "a timed-out response body closes its connection" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let hung_up = Ivar.create () in
+      let%bind server =
+        Tcp.Server.create ~on_handler_error:`Ignore
+          Tcp.Where_to_listen.of_port_chosen_by_os (fun _addr reader writer ->
+            Writer.write writer "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n" ;
+            let%bind () = Writer.flushed writer in
+            let%map (_ : string) = Reader.contents reader in
+            Ivar.fill_if_empty hung_up () )
+      in
+      let port = Tcp.Server.listening_on server in
+      let t =
+        create
+          ~base_uri:(Uri.of_string (sprintf "http://127.0.0.1:%d" port))
+          ~timeout:0.2 ()
+      in
+      let%bind result = post_json t ~path:"/stalled-body" ~body:(`Assoc []) in
+      [%test_pred: string]
+        (String.is_substring ~substring:"timeout after")
+        ( match result with
+        | Ok json ->
+            "expected a timeout, got " ^ Yojson.Safe.to_string json
+        | Error e ->
+            Error.to_string_hum e ) ;
+      let%bind () =
+        match%map
+          Async.with_timeout (Time.Span.of_sec 5.0) (Ivar.read hung_up)
+        with
+        | `Timeout ->
+            failwith "the timed-out request left its connection open"
+        | `Result () ->
+            ()
+      in
+      Tcp.Server.close server )

--- a/src/lib/rosetta_client/http.mli
+++ b/src/lib/rosetta_client/http.mli
@@ -1,0 +1,54 @@
+(** Thin HTTP wrapper around Cohttp_async for talking to a Rosetta
+    server.
+
+    A value of type {!t} bundles a base URI with the
+    [network_identifier] to splice into outgoing request bodies.  The
+    identifier and the timeout default to the shared values in
+    {!Defaults}; override them via the optional arguments to
+    {!create}. *)
+
+type t
+
+(** [create ~base_uri ?blockchain ?network ?timeout ()] builds a client.
+    Defaults: {!Defaults.blockchain}, {!Defaults.network} and
+    {!Defaults.http_timeout}. *)
+val create :
+     base_uri:Uri.t
+  -> ?blockchain:string
+  -> ?network:string
+  -> ?timeout:float
+  -> unit
+  -> t
+
+val base_uri : t -> Uri.t
+
+val blockchain : t -> string
+
+val network : t -> string
+
+val timeout : t -> float
+
+(** The network_identifier injected into every request body that needs
+    one. *)
+val network_identifier : t -> Rosetta_models.Network_identifier.t
+
+(** [post_json t ~path ~body] POSTs [body] to [base_uri ^ path] with a
+    JSON content type and [timeout] enforcement.  Non-2xx responses and
+    decode failures are folded into the error channel via
+    {!Errors.format_http_body} and {!Errors.format_exn}; the resulting
+    strings never contain raw OCaml exception syntax. *)
+val post_json :
+     t
+  -> path:string
+  -> body:Yojson.Safe.t
+  -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** GET variant of {!post_json}.  Rosetta endpoints are POST-only in
+    practice, but this is useful for sidecar endpoints and tests. *)
+val get_json : t -> path:string -> Yojson.Safe.t Async.Deferred.Or_error.t
+
+(** Pretty-print (indented) a JSON value to a string. *)
+val pretty : Yojson.Safe.t -> string
+
+(** Compact-print a JSON value to a string. *)
+val compact : Yojson.Safe.t -> string

--- a/src/lib/rosetta_client/rosetta_client.ml
+++ b/src/lib/rosetta_client/rosetta_client.ml
@@ -1,0 +1,14 @@
+(* Public surface of the [rosetta_client] library.  Callers use
+   the nested module names:
+
+   {[
+     let client = Rosetta_client.Http.create ~base_uri () in
+     Rosetta_client.Data.network_status client
+   ]} *)
+
+module Defaults = Defaults
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Errors = Errors
+module Models = Rosetta_models

--- a/src/lib/rosetta_client/rosetta_client.mli
+++ b/src/lib/rosetta_client/rosetta_client.mli
@@ -1,0 +1,22 @@
+(** Mina Rosetta client library.
+
+    Thin HTTP client and typed Rosetta API surface, shared by
+    [rosetta-client] (the generic CLI) and [rosetta-healthcheck] (which
+    only exposes readiness probes).
+
+    {[
+      open Async
+
+      let client =
+        Rosetta_client.Http.create
+          ~base_uri:(Uri.of_string "http://localhost:3087") ()
+
+      let%bind status = Rosetta_client.Data.network_status client
+    ]} *)
+
+module Defaults = Defaults
+module Http = Http
+module Data = Data
+module Construction = Construction
+module Errors = Errors
+module Models = Rosetta_models


### PR DESCRIPTION
Adds a shared Rosetta client library and the first binary built on it.

**1 of 3.** This PR is the base of a stack:

1. **this PR** — `rosetta_client` library + `rosetta-client` CLI
2. #18796 — `rosetta-healthcheck` CLI (readiness probes)
3. the Rosetta test helpers move from `curl` to `rosetta-client`

## `src/lib/rosetta_client/`

A thin HTTP client for a running Rosetta server, so the binaries above do
not each grow their own copy of network_identifier handling, timeout
enforcement and error formatting.

- `Http` — one request/response exchange with a per-request timeout. The
  base URI is normalised once at creation, so a trailing slash or a
  reverse-proxy path prefix (`http://host/rosetta`) both work.
- `Data` / `Construction` — one function per Rosetta endpoint. Requests are
  built as the generated models in `src/lib/rosetta_models/` and serialised
  with their own `to_yojson`, so field names, the required/optional split
  and the nesting all come from the schema rather than from hand-written
  JSON objects.
- `Errors` — renders a failure as one short line. A Rosetta error envelope
  becomes `HTTP <code>: <message>`; a transport failure becomes
  `connection refused to <url>`. Raw OCaml exception text never reaches the
  terminal, and a body is never dumped verbatim.
- `Defaults` — the values both CLIs fall back to, defined once, with an
  environment override each.

## `rosetta-client`

One subcommand per endpoint, for debugging and scripting — curl on
steroids. It fills in the `network_identifier`, prints the response as JSON
(`--compact` for one line), and exits non-zero with a short diagnostic on
failure.

```bash
rosetta-client network status
rosetta-client block get --index 100
rosetta-client account balance --address B62q...
```

A `--*-json` payload is decoded into the model its endpoint expects before
anything is sent, so a malformed request is reported against the flag that
carried it:

```
$ rosetta-client construction derive --public-key-json '{"hex_bytes":"aabb"}'
--public-key-json: does not match the Rosetta schema: Public_key.t.curve_type
```

`MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and `MINA_ROSETTA_NETWORK`
supply the defaults, so an operator working against one server exports them
once instead of repeating flags. A flag always wins over its variable.

Inside the binary, `rosetta_client_cli.ml` holds the flags, the subcommand
tree and the output; `payload.ml` holds the flag decoding and neither
prints nor exits.

## Packaging

Ships in `mina-rosetta` as `/usr/local/bin/rosetta-client`, built by
`make build-mina` and `make build-rosetta`.

## Testing

- Library inline tests: URI joining, the request-shape guard for
  `/search/transactions`, error rendering (envelope, truncation,
  single-line, no `Unix_error` leakage), and a timeout regression test
  against a real TCP server that stalls a response body, asserting the
  client hangs up rather than leaking the connection.
- `rosetta-client` alcotest suite: `--help` per subgroup and the clean
  error paths (connection refused, missing arguments, invalid JSON, schema
  mismatch).

See `src/app/rosetta/client/README.md`.
