### PR TITLE
Use rosetta-client in the Rosetta test helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-mina: ocaml_checks reformat-diff libp2p_helper build ## Build mina apps
 		src/app/cli/src/mina.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		&& echo "✅ Build complete"
 
@@ -296,6 +297,7 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -246,6 +246,28 @@ psql -f ./src/test/archive/sample_db/archive_db.sql "${INDEXER_PG_CONN}"
 mina-rosetta-indexer-test --archive_uri "${INDEXER_PG_CONN}"
 sudo -u postgres dropdb "${INDEXER_DBNAME}"
 
+echo "=========================== NEGATIVE TEST: healthcheck against not-yet-running Rosetta ==========================="
+# Sanity check: before Rosetta is up, `rosetta-healthcheck ready` must
+# fail cleanly.  Catches regressions in error formatting and exit codes
+# (e.g. raw OCaml [Unix_error] leaking through to stderr on ECONNREFUSED).
+set +e
+NEGATIVE_OUTPUT=$(rosetta-healthcheck ready \
+  --online-uri "http://127.0.0.1:${MINA_ROSETTA_ONLINE_PORT}" \
+  --json 2>&1)
+NEGATIVE_EXIT=$?
+set -e
+if [ "$NEGATIVE_EXIT" -eq 0 ]; then
+  echo "ERROR: healthcheck reported READY before Rosetta was started" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+if echo "$NEGATIVE_OUTPUT" | grep -q "Unix_error\|Unix\.\|Core\.Unix"; then
+  echo "ERROR: healthcheck leaked raw OCaml exception syntax" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+echo "   ✅  healthcheck correctly reported not-ready with a clean error"
+
 # Mina Rosetta
 echo "=========================== STARTING ROSETTA API ONLINE AND OFFLINE INSTANCES ==========================="
 ports=("$MINA_ROSETTA_ONLINE_PORT" "$MINA_ROSETTA_OFFLINE_PORT")
@@ -255,7 +277,27 @@ for port in "${ports[@]}"; do
     --graphql-uri http://127.0.0.1:${MINA_GRAPHQL_PORT}/graphql \
     --log-level ${LOG_LEVEL} \
     --port ${port} &
-  sleep 5
+  # Wait for the HTTP listener to bind.  We intentionally do NOT probe a
+  # functional Rosetta endpoint here: at this point the Mina daemon isn't
+  # running yet, and any Rosetta route that calls the daemon (e.g.
+  # /network/list) would fail for the full timeout.  Functional readiness
+  # is exercised later by `rosetta-cli configuration:validate` and the
+  # subsequent sweeps, once the daemon is up.
+  echo "Waiting for Rosetta on port ${port} to bind..."
+  for i in $(seq 1 60); do
+    # ":" opens the connection and closes it; "echo" would also write a
+    # newline, which Rosetta logs as a malformed request line on every
+    # attempt.
+    if (: > "/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+      echo "Rosetta on port ${port} is listening"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Rosetta on port ${port} did not bind within 60s"
+      exit 1
+    fi
+    sleep 1
+  done
 done
 
 # Mina Archive

--- a/buildkite/src/Command/Rosetta/Connectivity.dhall
+++ b/buildkite/src/Command/Rosetta/Connectivity.dhall
@@ -65,9 +65,14 @@ let Spec =
       }
 
 let bareBinaries =
+    -- rosetta-client is required by scripts/tests/rosetta-helper.sh, which
+    -- both the sanity and the load test source.  Restoring every binary
+    -- here makes restore-or-install.sh skip the deb install, so anything
+    -- the tests call must be listed.
           "mina.exe:mina"
       ++  ",archive.exe:mina-archive"
       ++  ",rosetta.exe:mina-rosetta"
+      ++  ",rosetta_client_cli.exe:rosetta-client"
       ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -41,6 +41,7 @@ let bareBinaries =
       ++  ",signer.exe:mina-ocaml-signer"
       ++  ",zkapp_test_transaction.exe:mina-zkapp-test-transaction"
       ++  ",indexer_test.exe:mina-rosetta-indexer-test"
+      ++  ",rosetta_healthcheck.exe:rosetta-healthcheck"
       ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =

--- a/changes/18796.md
+++ b/changes/18796.md
@@ -1,0 +1,18 @@
+- New `rosetta-healthcheck` CLI: readiness probes for a running Mina Rosetta
+  server. Subcommands are `connectivity` (does `/network/list` advertise the
+  expected network?), `tip-recency` (is the tip returned by `/network/status`
+  newer than `--max-age`?), `ready` (both of those plus `/network/options`), and
+  `wait` (poll `ready` until it passes or `--timeout` expires). Each prints
+  exactly one result — one JSON object with `--json`, one line without it — so
+  it can be used directly as a Kubernetes exec probe or a Docker `HEALTHCHECK`.
+  See `src/app/rosetta/healthcheck/README.md`.
+
+- In JSON mode a field with no value is left out rather than emitted as `null`,
+  so a probe that could not reach the server prints
+  `{"healthy": false, "error": "..."}` instead of a record padded with nulls.
+
+- `ready` and `wait` run every check even after an earlier one has failed, and
+  report all the problems they found, rather than stopping at the first.
+
+- `rosetta-healthcheck` ships in the `mina-rosetta` Debian package as
+  `/usr/local/bin/rosetta-healthcheck`.

--- a/changes/19284.md
+++ b/changes/19284.md
@@ -1,0 +1,21 @@
+- New `rosetta-client` CLI: one subcommand per Rosetta endpoint, for debugging
+  and scripting against a running Rosetta server. It fills in the
+  `network_identifier`, prints the response as JSON (`--compact` for one line),
+  and exits non-zero with a short diagnostic on failure. A `--*-json` payload is
+  checked against the Rosetta model its endpoint expects before it is sent, so a
+  malformed request is reported with the name of the offending flag instead of
+  as a server error. See `src/app/rosetta/client/README.md`.
+
+- `rosetta-client` reads `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
+  `MINA_ROSETTA_NETWORK`, so an operator working against one server can export
+  them once instead of repeating `--rosetta-uri`, `--blockchain` and `--network`
+  on every call. A flag always wins over the matching environment variable.
+
+- Error messages are short and human-readable: a Rosetta error envelope is
+  rendered as `HTTP <code>: <message>`, a connection failure as
+  `connection refused to <url>`. Raw OCaml exception text no longer reaches the
+  terminal, an HTTP body is never dumped verbatim, and a message is never split
+  over several lines.
+
+- `rosetta-client` ships in the `mina-rosetta` Debian package as
+  `/usr/local/bin/rosetta-client`.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -504,6 +504,8 @@ build_rosetta_generic_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-healthcheck"
   cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
     "${BUILDDIR}/usr/local/bin/rosetta-client"
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,7 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-healthcheck"
     assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
@@ -355,6 +356,7 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/rosetta.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe"
     create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"

--- a/scripts/tests/rosetta-helper.sh
+++ b/scripts/tests/rosetta-helper.sh
@@ -1,10 +1,34 @@
 #!/usr/bin/env bash
 
-# Helper functions for Rosetta API sanity and load tests
+# Helper functions for Rosetta API sanity and load tests.
 
+# network_identifier.blockchain, for the raw curl calls below.  It is
+# "mina" on every Mina network, which is also what rosetta-client
+# defaults to, so rosetta-client calls do not pass it at all.
 readonly BLOCKCHAIN="mina"
 
 readonly DEFAULT_HEADERS=(--header "Accept: application/json" --header "Content-Type: application/json")
+
+# Seconds allowed for one rosetta-client request.  The curl calls these
+# tests used before had no timeout at all, and rosetta-load.sh exists to
+# put the server under load, where a /search/transactions sweep can take
+# minutes; the CLI's own 30s default would turn that load into a test
+# failure.  300s is the http_timeout the rosetta-cli audit config uses
+# against the same server.
+readonly ROSETTA_CLIENT_TIMEOUT="${ROSETTA_CLIENT_TIMEOUT:-300}"
+
+# Every test below shells out to rosetta-client, so check for it once,
+# here, while this file is being sourced.  It cannot be checked inside
+# the test functions: those run inside a command substitution, where an
+# exit leaves only the subshell and the message would be captured as the
+# response rather than shown.
+if ! command -v rosetta-client > /dev/null 2>&1; then
+    echo "❌  rosetta-client is not on PATH." >&2
+    echo "    It ships in the mina-rosetta Debian package as" >&2
+    echo "    /usr/local/bin/rosetta-client, or build it with:" >&2
+    echo "        dune build src/app/rosetta/client/rosetta_client_cli.exe" >&2
+    exit 1
+fi
 
 function assert() {
     local __response=$1
@@ -116,17 +140,33 @@ function wait_for_sync() {
     done
 }
 
-function test_network_status() {
+# Runs rosetta-client against the Rosetta instance named by the test data
+# array.  rosetta-client reads the connection details from the
+# environment, so no call site below repeats --rosetta-uri or --network.
+# The blockchain is left unset: rosetta-client already defaults it to
+# "mina".
+#
+# Arguments:
+#   $1 - test data array name (passed by reference)
+#   $@ - rosetta-client subcommand and its flags
+function rosetta_client() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/status" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    shift
+
+    MINA_ROSETTA_URI="${__test_data[address]}" \
+    MINA_ROSETTA_NETWORK="${__test_data[id]}" \
+        rosetta-client --timeout "${ROSETTA_CLIENT_TIMEOUT}" "$@"
+}
+
+function test_network_status() {
+    assert "$(rosetta_client "$1" network status --compact)" \
         '.sync_status.stage == "Synced"' \
         "   ✅  Rosetta is synced" \
         "   ❌  Rosetta is not synced"
 }
 
 function test_network_options() {
-    declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/network/options" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" network options --compact)" \
         '.version.rosetta_version == "1.4.9"' \
         "   ✅  Rosetta Version is correct" \
         "   ❌  Invalid Rosetta Version (expected 1.4.9)"
@@ -134,7 +174,9 @@ function test_network_options() {
 
 function test_block() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/block" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"block_identifier\":{\"hash\":\"${__test_data[block]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" block get \
+        --hash "${__test_data[block]}" \
+        --compact)" \
         ".block.block_identifier.hash == \"${__test_data[block]}\" " \
         "   ✅  Block hash correct" \
         "   ❌  Block hash incorrect or not found (expected ${__test_data[block]})"
@@ -142,7 +184,9 @@ function test_block() {
 
 function test_account_balance() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --request POST "${__test_data[address]}/account/balance" "${DEFAULT_HEADERS[@]}" --data-raw "{\"network_identifier\":{\"blockchain\":\"$BLOCKCHAIN\",\"network\":\"${__test_data[id]}\"},\"account_identifier\":{\"address\":\"${__test_data[account]}\"}}" | jq)" \
+    assert "$(rosetta_client "$1" account balance \
+        --address "${__test_data[account]}" \
+        --compact)" \
         '.balances[0].currency.symbol == "MINA"' \
         "   ✅  Account: Balance ok" \
         "   ❌  Account: Invalid balance structure or balance not found"
@@ -150,15 +194,9 @@ function test_account_balance() {
 
 function test_payment_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[payment_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta_client "$1" search transactions \
+        --tx-hash "${__test_data[payment_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[payment_transaction]}\" " \
         "   ✅  Payment transaction found" \
         "   ❌  Payment transaction not found (expected ${__test_data[payment_transaction]})"
@@ -166,15 +204,9 @@ function test_payment_transaction() {
 
 function test_zkapp_transaction() {
     declare -n __test_data=$1
-    assert "$(curl --no-progress-meter --location "${__test_data[address]}/search/transactions" --header 'Content-Type: application/json' --data "{
-        \"network_identifier\": {
-            \"blockchain\": \"$BLOCKCHAIN\",
-            \"network\": \"${__test_data[id]}\"
-        },
-        \"transaction_identifier\": {
-            \"hash\": \"${__test_data[zkapp_transaction]}\"
-        }
-    }" | jq)" \
+    assert "$(rosetta_client "$1" search transactions \
+        --tx-hash "${__test_data[zkapp_transaction]}" \
+        --compact)" \
         ".transactions[0].transaction.transaction_identifier.hash == \"${__test_data[zkapp_transaction]}\" " \
         "   ✅  Zkapp transaction found" \
         "   ❌  Zkapp transaction not found (expected ${__test_data[zkapp_transaction]})"

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -7,8 +7,8 @@ subcommand maps to a single endpoint, auto-injects
 `network_identifier`, and prints the response as JSON (pretty by default,
 `--compact` for one-line output).
 
-For readiness probes, a sibling `rosetta-healthcheck` binary built on the
-same library follows in a separate change.
+For readiness probes, see the sibling
+[`rosetta-healthcheck`](../healthcheck/README.md) binary.
 
 ## Subcommand tree
 
@@ -58,9 +58,9 @@ Every leaf command accepts:
 
 A flag always wins over its environment variable.  Export the variables
 to talk to the same server repeatedly without repeating the flags; the
-same three variables are read by every binary built on
-`Rosetta_client`.  Their fallback values live in
-`Rosetta_client.Defaults`, so those binaries cannot drift apart.
+same three variables are read by `rosetta-healthcheck`.  Their fallback
+values live in `Rosetta_client.Defaults`, so the two binaries cannot
+drift apart.
 
 ## Examples
 
@@ -99,11 +99,15 @@ produced by the `Rosetta_client.Errors` module and is guaranteed to:
 - Never dump multi-kilobyte HTTP bodies verbatim; Rosetta error envelopes
   are parsed and rendered as `HTTP <code>: <message>`.
 
-## Layout
+## Relationship to `rosetta-healthcheck`
 
-The HTTP client, the typed Rosetta API surface and the shared defaults
-live in the `rosetta_client` library (`src/lib/rosetta_client/`), so any
-other binary can reuse them.
+- **This tool** — Arbitrary Rosetta API calls for debugging, scripting, and
+  day-to-day operations.
+- **`rosetta-healthcheck`** — Composite readiness (`ready` / `wait`),
+  tip-recency / connectivity probes.
+
+Both binaries share the same underlying HTTP library
+(`src/lib/rosetta_client/`).
 
 Inside this binary, `rosetta_client_cli.ml` holds the flags, the
 subcommand tree and the output; `payload.ml` holds the decoding of the

--- a/src/app/rosetta/healthcheck/README.md
+++ b/src/app/rosetta/healthcheck/README.md
@@ -1,0 +1,149 @@
+# rosetta-healthcheck
+
+Slim CLI focused on answering **"is the Rosetta server healthy right now?"**
+Designed for Kubernetes exec probes, Docker `HEALTHCHECK`, CI gates, and
+CI pre-flight checks.
+
+For arbitrary Rosetta API calls — `/block`, `/account/*`, `/mempool`,
+`/search/*`, `/construction/*` — use the sibling
+[`rosetta-client`](../client/README.md) binary.  Both share the same
+underlying HTTP library (`src/lib/rosetta_client/`).
+
+## Commands
+
+### Probes
+
+| Command | Endpoint(s) | Exit 0 when |
+|---------|-------------|-------------|
+| `ready` | composite | `connectivity` + `tip-recency` + `/network/options` all pass |
+| `wait` | poll `ready` | passes before `--timeout` expires |
+| `tip-recency` | POST `/network/status` | tip returned AND its timestamp is within `--max-age` |
+| `connectivity` | POST `/network/list` | `network_identifier` list advertises the expected network (lists the advertised set on mismatch) |
+
+## Usage
+
+```bash
+# Is the server reachable and advertising our network?
+rosetta-healthcheck connectivity --network testnet
+
+# Is the tip fresh? (default tolerance: 360s)
+rosetta-healthcheck tip-recency --max-age 360
+
+# Composite readiness suitable for k8s readiness probes:
+rosetta-healthcheck ready --max-age 360 --json
+
+# Block until ready (CI / init containers):
+rosetta-healthcheck wait --timeout 600 --interval 10 --json
+```
+
+The rosetta-cli audit configuration (`config.json` and the Construction
+DSL files it names) is not handled by this binary.  It ships in the
+`mina-rosetta` Debian package at
+`/etc/mina/rosetta/rosetta-cli-config/`, and
+`buildkite/scripts/tests/rosetta/integration-tests.sh` copies it to a
+writable directory and fills in its `PLACEHOLDER_*` fields before
+invoking rosetta-cli.
+
+To make a single Rosetta API call for debugging, use
+`rosetta-client network status` / `rosetta-client block get` /
+etc.
+
+## Flags
+
+| Flag | Alias | Default | Environment override | Applies to |
+|------|-------|---------|----------------------|------------|
+| `--online-uri` | `-o` | `http://localhost:3087` | `MINA_ROSETTA_URI` | all probes |
+| `--network` | `-n` | `testnet` | `MINA_ROSETTA_NETWORK` | all probes |
+| `--blockchain` | | `mina` | `MINA_ROSETTA_BLOCKCHAIN` | all probes |
+| `--json` | `-j` | off | | every subcommand |
+| `--max-age` | | 360 | | `tip-recency`, `ready`, `wait` |
+| `--timeout` | `-t` | 600 | | `wait` |
+| `--interval` | `-i` | 10 | | `wait` |
+
+A flag always wins over its environment variable.  The three variables
+are the same ones `rosetta-client` reads, and their fallback values live
+in `Rosetta_client.Defaults`, so the two binaries cannot drift apart.
+`--timeout` bounds the whole `wait` loop; the per-request HTTP timeout is
+fixed at `Rosetta_client.Defaults.http_timeout` (5s), because a probe
+wants a quick verdict.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed |
+| 1 | Check failed (one line on stdout, or one JSON record on stdout with `--json`) |
+
+## JSON output contract
+
+When `--json` is set, every probe emits exactly one JSON record on stdout
+and exits. On success:
+
+```json
+{ "healthy": true, ... }
+{ "ready":   true, ... }
+```
+
+On failure the same record includes `"error": "<msg>"` and any metrics
+gathered up to the point of failure; the process exits with code 1.
+
+The records are typed (`health_output.ml`), and a field that has no value
+is left out rather than emitted as `null`.  The probes that produce them
+are in `health_probes.ml` and never print or exit; `rosetta_healthcheck.ml`
+owns the flags, the text/JSON choice and the exit code.  A probe that could not reach
+the server therefore prints:
+
+```json
+{ "healthy": false, "error": "connection refused to http://localhost:3087/network/list" }
+```
+
+All error messages are produced by `Rosetta_client.Errors` and are
+guaranteed to be short, human-readable, and free of raw OCaml exception
+syntax.
+
+## Known limitation
+
+A probe that times out closes its connection in every case except one: a
+server that completes the TCP connect and then never sends a response
+line at all. cohttp-async 5.0.0 exposes no handle on that connection, so
+`wait` against such a server holds one socket per attempt until the
+process exits. It is bounded by a single run of a short-lived CLI, and no
+usable `--timeout` / `--interval` pair reaches the default descriptor
+limit. See the comment on `with_request` in
+`src/lib/rosetta_client/http.ml`.
+
+## Kubernetes integration
+
+```yaml
+# Liveness: is the Rosetta server answering at all?
+livenessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "connectivity",
+              "--online-uri", "http://localhost:3087",
+              "--network", "testnet"]
+  initialDelaySeconds: 30
+  periodSeconds: 30
+
+# Readiness: are all discovery endpoints healthy and the tip fresh?
+readinessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "ready",
+              "--online-uri", "http://localhost:3087",
+              "--max-age", "360"]
+  initialDelaySeconds: 60
+  periodSeconds: 30
+```
+
+## Docker integration
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD ["rosetta-healthcheck", "connectivity", \
+       "--online-uri", "http://localhost:3087"]
+```
+
+## Building
+
+```bash
+dune build src/app/rosetta/healthcheck/rosetta_healthcheck.exe
+```

--- a/src/app/rosetta/healthcheck/dune
+++ b/src/app/rosetta/healthcheck/dune
@@ -1,0 +1,21 @@
+(executable
+ (package rosetta)
+ (name rosetta_healthcheck)
+ (public_name rosetta-healthcheck)
+ (libraries
+  ;; opam libraries
+  core_kernel
+  async
+  async_kernel
+  async.async_command
+  cohttp
+  cohttp-async
+  ppx_deriving_yojson.runtime
+  uri
+  yojson
+  ;; local libraries
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_here ppx_deriving_yojson)))

--- a/src/app/rosetta/healthcheck/health_output.ml
+++ b/src/app/rosetta/healthcheck/health_output.ml
@@ -1,0 +1,69 @@
+(* The JSON records [rosetta-healthcheck ... --json] prints.
+
+   These are the binary's machine-readable contract: an orchestrator
+   reads them to decide whether a Rosetta instance is usable.  Each
+   record therefore has a type here rather than being assembled field by
+   field at the call site, so a probe cannot silently drop a field or
+   rename one.
+
+   Every optional field carries [@default None] (and every list
+   [@default []]), which makes [to_yojson] omit it when it is absent.
+   A probe that could not reach the server therefore emits
+   [{"healthy":false,"error":"..."}] rather than a record padded with
+   nulls. *)
+
+(* One entry of /network/list's advertised set. *)
+type network_id = { blockchain : string; network : string }
+[@@deriving to_yojson]
+
+(* [connectivity]: does /network/list answer, and does it advertise the
+   network we were asked about? *)
+type connectivity =
+  { healthy : bool
+  ; expected_network : string option [@default None]
+  ; advertised : network_id list [@default []]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [tip-recency]: how old is the tip /network/status reports?
+   [max_age] is echoed back only when the tip failed the check, so the
+   reader can see the bound that was applied. *)
+type tip_recency =
+  { healthy : bool
+  ; block_height : int64 option [@default None]
+  ; block_hash : string option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; max_age : int option [@default None]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [ready] and [wait].  [timed_out] distinguishes "wait gave up" from
+   "ready reported not-ready once"; [problems] lists one line per failed
+   probe. *)
+type readiness =
+  { ready : bool
+  ; timed_out : bool option [@default None]
+  ; block_height : int64 option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; problems : string list [@default []]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+let connectivity_failed error =
+  { healthy = false
+  ; expected_network = None
+  ; advertised = []
+  ; error = Some error
+  }
+
+let tip_recency_failed error =
+  { healthy = false
+  ; block_height = None
+  ; block_hash = None
+  ; age_seconds = None
+  ; max_age = None
+  ; error = Some error
+  }

--- a/src/app/rosetta/healthcheck/health_probes.ml
+++ b/src/app/rosetta/healthcheck/health_probes.ml
@@ -1,0 +1,106 @@
+(* The health probes.  See [health_probes.mli] for the contract, and
+   [rosetta_healthcheck.ml] for the CLI that presents these verdicts. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+type tip = { height : int64; hash : string; age_seconds : int64; fresh : bool }
+
+type readiness = { ready : bool; tip : tip option; problems : string list }
+
+(* Now-time as epoch seconds. *)
+let now_secs () = Time.now () |> Time.to_span_since_epoch |> Time.Span.to_sec
+
+let age_seconds_from_timestamp_ms ts =
+  let now_ms = Int64.of_float (now_secs () *. 1000.0) in
+  let age_ms = Int64.( - ) now_ms ts in
+  let age_secs = Int64.( / ) age_ms 1000L in
+  if Int64.( < ) age_secs 0L then 0L else age_secs
+
+let describe (network_identifier : RM.Network_identifier.t) =
+  sprintf "%s:%s" network_identifier.RM.Network_identifier.blockchain
+    network_identifier.RM.Network_identifier.network
+
+let connectivity client ~expected_blockchain ~expected_network =
+  match%map MRC.Data.network_list_response client with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let advertised = response.RM.Network_list_response.network_identifiers in
+      if List.is_empty advertised then
+        Or_error.error_string "/network/list returned no network_identifiers"
+      else
+        let match_found =
+          List.exists advertised ~f:(fun n ->
+              String.equal n.RM.Network_identifier.blockchain
+                expected_blockchain
+              && String.equal n.RM.Network_identifier.network expected_network )
+        in
+        if match_found then Ok advertised
+        else
+          Or_error.errorf "expected network %s:%s not advertised (got: %s)"
+            expected_blockchain expected_network
+            (String.concat ~sep:", " (List.map advertised ~f:describe))
+
+let tip_recency client ~max_age =
+  match%map MRC.Data.network_status_response client with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let block =
+        response.RM.Network_status_response.current_block_identifier
+      in
+      let age_seconds =
+        age_seconds_from_timestamp_ms
+          response.RM.Network_status_response.current_block_timestamp
+      in
+      Ok
+        { height = block.RM.Block_identifier.index
+        ; hash = block.RM.Block_identifier.hash
+        ; age_seconds
+        ; fresh = Int64.( <= ) age_seconds (Int64.of_int max_age)
+        }
+
+(* [/network/options] is the third readiness signal: a server that
+   answers it with a version and a non-empty operation_types list has
+   finished wiring up its Data API. *)
+let network_options_ok client =
+  match%map MRC.Data.network_options_response client with
+  | Error e ->
+      Error (sprintf "network-options: %s" (Error.to_string_hum e))
+  | Ok response ->
+      let version = response.RM.Network_options_response.version in
+      let allow = response.RM.Network_options_response.allow in
+      if
+        String.is_empty version.RM.Version.rosetta_version
+        || List.is_empty allow.RM.Allow.operation_types
+      then Error "network-options: missing rosetta_version or operation_types"
+      else Ok ()
+
+let readiness client ~expected_blockchain ~expected_network ~max_age =
+  let%bind connectivity_result =
+    connectivity client ~expected_blockchain ~expected_network
+  in
+  let%bind tip_result = tip_recency client ~max_age in
+  let%map options_result = network_options_ok client in
+  let problem_of_error label e =
+    sprintf "%s: %s" label (Error.to_string_hum e)
+  in
+  let problems =
+    List.filter_opt
+      [ Result.error connectivity_result
+        |> Option.map ~f:(problem_of_error "connectivity")
+      ; ( match tip_result with
+        | Error e ->
+            Some (problem_of_error "tip-recency" e)
+        | Ok tip when not tip.fresh ->
+            Some
+              (sprintf "tip-recency: tip age %Lds > %ds" tip.age_seconds max_age)
+        | Ok _ ->
+            None )
+      ; Result.error options_result
+      ]
+  in
+  { ready = List.is_empty problems; tip = Result.ok tip_result; problems }

--- a/src/app/rosetta/healthcheck/health_probes.mli
+++ b/src/app/rosetta/healthcheck/health_probes.mli
@@ -1,0 +1,65 @@
+(** The health probes themselves: what [rosetta-healthcheck] asks a
+    Rosetta server, and how it decides whether the answer is healthy.
+
+    Nothing here touches [Command], prints, or exits.  A probe returns a
+    typed verdict and leaves the presentation of it — text or JSON, which
+    exit code — to {!Rosetta_healthcheck}.  That split is what makes the
+    decisions testable without spawning the binary. *)
+
+(** The chain tip as [/network/status] reported it. *)
+type tip =
+  { height : int64
+  ; hash : string
+  ; age_seconds : int64
+        (** Age of [timestamp] at the moment of the probe, never
+            negative: a server whose clock runs ahead of ours reports 0
+            rather than a negative age. *)
+  ; fresh : bool  (** Whether [age_seconds] is within the caller's bound. *)
+  }
+
+(** Verdict of the composite readiness check. *)
+type readiness =
+  { ready : bool  (** True only when [problems] is empty. *)
+  ; tip : tip option
+        (** The tip, when [/network/status] answered — present even when
+            the tip was too old, so a caller can report how far behind
+            the server is. *)
+  ; problems : string list  (** One line per failed check, in probe order. *)
+  }
+
+(** [connectivity client ~expected_blockchain ~expected_network] asks
+    [/network/list] and returns everything the server advertises.
+
+    It is an error when the server answers with an empty list, or when
+    the expected pair is absent — the error message then names the
+    advertised set, because "wrong network" and "server not up" need
+    different fixes. *)
+val connectivity :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> Rosetta_client.Models.Network_identifier.t list Async.Deferred.Or_error.t
+
+(** [tip_recency client ~max_age] asks [/network/status] and reports the
+    tip with its age.  A tip older than [max_age] seconds is returned
+    with [fresh = false] rather than as an error: the caller still wants
+    the height and the age in order to report them. *)
+val tip_recency :
+  Rosetta_client.Http.t -> max_age:int -> tip Async.Deferred.Or_error.t
+
+(** [readiness client ~expected_blockchain ~expected_network ~max_age]
+    runs {!connectivity}, {!tip_recency} and a [/network/options] sanity
+    check.
+
+    Every check runs even after an earlier one failed, so one invocation
+    reports every problem instead of only the first — an operator
+    debugging a sick server wants the whole picture at once.  For that
+    reason this returns a plain [Deferred.t]: a transport failure is an
+    entry in [problems], not an error channel that would short-circuit
+    the remaining checks. *)
+val readiness :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> max_age:int
+  -> readiness Async.Deferred.t

--- a/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
@@ -1,0 +1,332 @@
+(* rosetta_healthcheck.ml — the CLI surface of the Rosetta health probes.
+
+   This file owns everything the operator sees: the flags, the choice
+   between text and JSON, and the exit code.  The probes themselves live
+   in [health_probes.ml] and the JSON records they are rendered into in
+   [health_output.ml]; neither of those prints or exits.
+
+   This binary focuses exclusively on readiness and recency checks.
+   Generic Rosetta API calls live in the sibling [rosetta-client] binary
+   so operators don't have to choose between two overlapping CLIs for
+   debugging.  HTTP calls go through [Rosetta_client] so
+   network_identifier handling, timeout enforcement, and error formatting
+   stay in one place.
+
+   Environment variables (each one is overridden by the matching flag,
+   and all three are shared with [rosetta-client]):
+
+   - [MINA_ROSETTA_URI] — base URL of the Rosetta server, i.e. the
+     default for [--online-uri].
+   - [MINA_ROSETTA_BLOCKCHAIN] — default for [--blockchain].
+   - [MINA_ROSETTA_NETWORK] — default for [--network].
+
+   The values they fall back to when unset live in
+   [Rosetta_client.Defaults], which is also where [rosetta-client] reads
+   them from, so the two binaries cannot drift apart. *)
+
+open Core_kernel
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+module Out = Health_output
+module Probes = Health_probes
+
+(* Probe bounds specific to this binary.  Connection details (URI,
+   blockchain, network) and the per-request HTTP timeout come from
+   [MRC.Defaults] instead. *)
+
+(* Oldest tip, in seconds, that [tip-recency] and [ready] still call
+   healthy.  360s is two 3-minute slots. *)
+let default_max_age = 360
+
+(* How long [wait] keeps polling before it gives up, in seconds. *)
+let default_timeout = 600
+
+(* Seconds [wait] sleeps between two readiness attempts. *)
+let default_interval = 10
+
+(* ---------- Flags ---------- *)
+
+let online_uri_flag =
+  Command.Param.(
+    flag "--online-uri" ~aliases:[ "-o" ]
+      ~doc:
+        (sprintf
+           "URI Rosetta online base URL (default: %s, overridable via $%s)"
+           (MRC.Defaults.base_uri_from_env ())
+           MRC.Defaults.uri_env_var )
+      (optional_with_default (MRC.Defaults.base_uri_from_env ()) string))
+
+let network_flag =
+  Command.Param.(
+    flag "--network" ~aliases:[ "-n" ]
+      ~doc:
+        (sprintf
+           "NAME network_identifier.network (default: %s, overridable via $%s)"
+           (MRC.Defaults.network_from_env ())
+           MRC.Defaults.network_env_var )
+      (optional_with_default (MRC.Defaults.network_from_env ()) string))
+
+let blockchain_flag =
+  Command.Param.(
+    flag "--blockchain"
+      ~doc:
+        (sprintf
+           "NAME network_identifier.blockchain (default: %s, overridable via \
+            $%s)"
+           (MRC.Defaults.blockchain_from_env ())
+           MRC.Defaults.blockchain_env_var )
+      (optional_with_default (MRC.Defaults.blockchain_from_env ()) string))
+
+let json_flag =
+  Command.Param.(
+    flag "--json" ~aliases:[ "-j" ] ~doc:" Output as JSON instead of text"
+      no_arg)
+
+let max_age_flag =
+  Command.Param.(
+    flag "--max-age"
+      ~doc:
+        (sprintf "SECONDS Maximum acceptable age of current tip (default: %d)"
+           default_max_age )
+      (optional_with_default default_max_age int))
+
+let timeout_flag ~default =
+  Command.Param.(
+    flag "--timeout" ~aliases:[ "-t" ]
+      ~doc:(sprintf "SECONDS Max seconds to wait (default: %d)" default)
+      (optional_with_default default int))
+
+let interval_flag =
+  Command.Param.(
+    flag "--interval" ~aliases:[ "-i" ]
+      ~doc:(sprintf "SECONDS Polling interval (default: %d)" default_interval)
+      (optional_with_default default_interval int))
+
+let make_client ~online_uri ~blockchain ~network =
+  MRC.Http.create ~base_uri:(Uri.of_string online_uri) ~blockchain ~network
+    ~timeout:MRC.Defaults.http_timeout ()
+
+(* ---------- Output ---------- *)
+
+(* Emit a JSON record to stdout.  We bypass Async's own [print_*]
+   wrappers (which use non-blocking writers that may not flush before
+   a subsequent [Stdlib.exit]) by going straight to [Stdlib.stdout],
+   and flush explicitly so the record appears even when we exit without
+   going through Async's shutdown path. *)
+let output json =
+  Stdlib.print_string (Yojson.Safe.pretty_to_string json) ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+(* The text-mode counterpart of [output], for the same reason: Async's
+   [printf] buffers, and that buffer is not flushed by [Stdlib.exit]. *)
+let output_line line =
+  Stdlib.print_string line ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+(* Exactly one result per invocation, then exit 1.  Mirrors the contract
+   in [mina_archive_healthcheck]: never double-print -- in JSON mode emit
+   one record, in text mode one line, and in neither case also hand the
+   message back to a [Command] wrapper that would print it again.  The
+   two renderings are lazy so only the one that is asked for is built. *)
+let fail ~json ~record ~line =
+  if json then output (Lazy.force record) else output_line (Lazy.force line) ;
+  Stdlib.exit 1
+
+(* A probe that could not reach the server at all.  Both modes say the
+   same thing, so each command states it once. *)
+let fail_unreachable ~json ~record error =
+  let message = Error.to_string_hum error in
+  fail ~json ~record:(lazy (record message)) ~line:(lazy message)
+
+let advertised_network_id (network_identifier : RM.Network_identifier.t) =
+  { Out.blockchain = network_identifier.RM.Network_identifier.blockchain
+  ; network = network_identifier.RM.Network_identifier.network
+  }
+
+let readiness_json ?timed_out (result : Probes.readiness) =
+  Out.readiness_to_yojson
+    { Out.ready = result.Probes.ready
+    ; timed_out
+    ; block_height =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.height)
+    ; age_seconds =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.age_seconds)
+    ; problems = result.Probes.problems
+    ; error =
+        ( if result.Probes.ready then None
+        else
+          Some
+            (sprintf "not ready: %s"
+               (String.concat ~sep:", " result.Probes.problems) ) )
+    }
+
+(* ---------- connectivity ---------- *)
+
+let connectivity_command =
+  Command.async
+    ~summary:
+      "Verify Rosetta's /network/list advertises the expected network.  Lists \
+       the advertised set when the expected network is absent."
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       match%map
+         Probes.connectivity client ~expected_blockchain:blockchain
+           ~expected_network:network
+       with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.connectivity_to_yojson (Out.connectivity_failed message) )
+       | Ok advertised ->
+           if json then
+             output
+               (Out.connectivity_to_yojson
+                  { Out.healthy = true
+                  ; expected_network = Some network
+                  ; advertised = List.map advertised ~f:advertised_network_id
+                  ; error = None
+                  } )
+           else
+             output_line
+               (sprintf "advertises %d networks (contains %s)"
+                  (List.length advertised) network ) )
+
+(* ---------- tip-recency ---------- *)
+
+let tip_recency_command =
+  Command.async
+    ~summary:
+      "POST /network/status — exit 0 if tip is returned and its timestamp is \
+       within --max-age"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       match%map Probes.tip_recency client ~max_age with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.tip_recency_to_yojson (Out.tip_recency_failed message) )
+       | Ok tip ->
+           let record ~healthy ~max_age_field ~error =
+             Out.tip_recency_to_yojson
+               { Out.healthy
+               ; block_height = Some tip.Probes.height
+               ; block_hash = Some tip.Probes.hash
+               ; age_seconds = Some tip.Probes.age_seconds
+               ; max_age = max_age_field
+               ; error
+               }
+           in
+           if tip.Probes.fresh then
+             if json then
+               output (record ~healthy:true ~max_age_field:None ~error:None)
+             else
+               output_line
+                 (sprintf "tip height=%Ld hash=%s age=%Lds" tip.Probes.height
+                    tip.Probes.hash tip.Probes.age_seconds )
+           else
+             let message =
+               sprintf "tip is %Ld seconds old, exceeds max age %d"
+                 tip.Probes.age_seconds max_age
+             in
+             fail ~json
+               ~record:
+                 ( lazy
+                   (record ~healthy:false ~max_age_field:(Some max_age)
+                      ~error:(Some message) ) )
+               ~line:(lazy message) )
+
+(* ---------- ready and wait ---------- *)
+
+let ready_command =
+  Command.async
+    ~summary:
+      "Composite readiness: connectivity + tip-recency + /network/options"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let%map result =
+         Probes.readiness client ~expected_blockchain:blockchain
+           ~expected_network:network ~max_age
+       in
+       if result.Probes.ready then
+         if json then output (readiness_json result) else output_line "READY"
+       else
+         fail ~json
+           ~record:(lazy (readiness_json result))
+           ~line:
+             ( lazy
+               (sprintf "NOT READY: %s"
+                  (String.concat ~sep:", " result.Probes.problems) ) ) )
+
+let wait_command =
+  Command.async
+    ~summary:"Block until Rosetta passes readiness checks or timeout expires"
+    (let%map_open.Command online_uri = online_uri_flag
+     and blockchain = blockchain_flag
+     and network = network_flag
+     and json = json_flag
+     and max_age = max_age_flag
+     and timeout = timeout_flag ~default:default_timeout
+     and interval = interval_flag in
+     fun () ->
+       let client = make_client ~online_uri ~blockchain ~network in
+       let start = Time.now () in
+       let deadline = Time.add start (Time.Span.of_int_sec timeout) in
+       let timed_out () = Time.( >= ) (Time.now ()) deadline in
+       let elapsed () =
+         Float.to_int (Time.Span.to_sec (Time.diff (Time.now ()) start))
+       in
+       let rec loop () =
+         let%bind result =
+           Probes.readiness client ~expected_blockchain:blockchain
+             ~expected_network:network ~max_age
+         in
+         let problems = String.concat ~sep:", " result.Probes.problems in
+         if result.Probes.ready then (
+           if json then output (readiness_json result) else output_line "READY" ;
+           Deferred.unit )
+         else if timed_out () then
+           fail ~json
+             ~record:(lazy (readiness_json ~timed_out:true result))
+             ~line:
+               (lazy (sprintf "timed out waiting for readiness: %s" problems))
+         else (
+           eprintf "[%3ds] not ready: %s\n" (elapsed ()) problems ;
+           (* Never sleep past the deadline: a plain [--interval] nap
+              would let [--timeout 600 --interval 300] run for 900s
+              before reporting that it had timed out. *)
+           let%bind () =
+             after
+               (Time.Span.min
+                  (Time.Span.of_int_sec interval)
+                  (Time.diff deadline (Time.now ())) )
+           in
+           loop () )
+       in
+       loop () )
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta healthcheck CLI — readiness and recency probes. For \
+          generic Rosetta API calls use 'rosetta-client'."
+       [ ("ready", ready_command)
+       ; ("wait", wait_command)
+       ; ("tip-recency", tip_recency_command)
+       ; ("connectivity", connectivity_command)
+       ] )

--- a/src/app/rosetta/healthcheck/tests/dune
+++ b/src/app/rosetta/healthcheck/tests/dune
@@ -1,0 +1,21 @@
+;; Hermetic alcotest smoke tests for rosetta-healthcheck.
+;;
+;; These exercise only the subcommands that don't require a running
+;; Rosetta server: --help at the top level and the single-JSON-record
+;; contract for [ready --json] / [tip-recency --json] /
+;; [connectivity --json] against a dead port.
+
+(test
+ (name test_rosetta_healthcheck)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  core_unix
+  stdio
+  yojson)
+ (deps ../rosetta_healthcheck.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
@@ -1,0 +1,169 @@
+(* Hermetic alcotest smoke tests for rosetta-healthcheck.
+
+   These exercise only the subcommands that don't require a running
+   Rosetta server: --help at the top level and the single-JSON-record
+   contract for [ready --json] / [tip-recency --json] /
+   [connectivity --json] against a dead port. *)
+
+open Core
+
+let bin =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here "../rosetta_healthcheck.exe"
+
+let read_all_fd fd =
+  let ic = Core_unix.in_channel_of_descr fd in
+  let s = In_channel.input_all ic in
+  In_channel.close ic ; s
+
+(* Spawn the CLI with [args] + optional env overrides, capture
+   stdout/stderr, return [(exit_code, stdout, stderr)]. *)
+let run_cli ?(env = []) args =
+  let pi = Core_unix.create_process_env ~prog:bin ~args ~env:(`Extend env) () in
+  Core_unix.close pi.stdin ;
+  let out = read_all_fd pi.stdout in
+  let err = read_all_fd pi.stderr in
+  let status = Core_unix.waitpid pi.pid in
+  let code =
+    match status with
+    | Ok () ->
+        0
+    | Error (`Exit_non_zero n) ->
+        n
+    | Error (`Signal s) ->
+        128 + Signal.to_system_int s
+  in
+  (code, out, err)
+
+(* Regression guard: user-visible output must not leak raw OCaml
+   exception syntax.  The original defect was [Unix_error]
+   propagating unwrapped through stderr on ECONNREFUSED. *)
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains s ~sub = String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  List.iter [ "ready"; "wait"; "tip-recency"; "connectivity" ] ~f:(fun sub ->
+      check_contains ~label:(sprintf "--help lists %s" sub) out ~sub ) ;
+  assert_no_ocaml_exn_leak "--help stderr" err
+
+let test_ready_dead_port_text () =
+  let code, out, err =
+    run_cli [ "ready"; "--online-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then Alcotest.failf "ready (dead port): expected non-zero exit" ;
+  let combined = out ^ "\n" ^ err in
+  check_contains ~label:"ready text mentions NOT READY" combined
+    ~sub:"NOT READY" ;
+  assert_no_ocaml_exn_leak "ready stdout" out ;
+  assert_no_ocaml_exn_leak "ready stderr" err
+
+(* Shared helper for "exactly one JSON object on stdout" assertions.
+   Parses [out] as a single Yojson object, returns the field list.
+   Guards against a second JSON object being tacked on, which is the
+   double-print regression the ready/wait/tip-recency/connectivity
+   paths all need to avoid. *)
+let parse_single_json_record ~label out err =
+  let trimmed = String.strip out in
+  if String.is_empty trimmed then
+    Alcotest.failf "%s: stdout empty, stderr:\n%s" label err ;
+  let json =
+    try Yojson.Safe.from_string trimmed
+    with exn ->
+      Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
+        (Exn.to_string exn) out
+  in
+  if String.is_substring trimmed ~substring:"}\n{" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by newlines:\n%s"
+      label out ;
+  if String.is_substring trimmed ~substring:"} {" then
+    Alcotest.failf
+      "%s: stdout contains multiple JSON objects separated by whitespace:\n%s"
+      label out ;
+  match json with
+  | `Assoc fields ->
+      fields
+  | _ ->
+      Alcotest.failf "%s: stdout was not a JSON object: %s" label out
+
+let check_bool_field ~label fields ~field ~expected =
+  match List.Assoc.find fields ~equal:String.equal field with
+  | Some (`Bool b) when Bool.equal b expected ->
+      ()
+  | Some v ->
+      Alcotest.failf "%s: expected %s:%b, got %s" label field expected
+        (Yojson.Safe.to_string v)
+  | None ->
+      Alcotest.failf "%s: missing %S field" label field
+
+(* The key "single JSON record per invocation" contract test: when
+   [ready --json] fails, stdout must contain exactly one well-formed
+   JSON object with [ready: false] and no OCaml exception leakage. *)
+let test_ready_dead_port_json_single_record () =
+  let code, out, err =
+    run_cli [ "ready"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "ready --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "ready --json stdout" out ;
+  assert_no_ocaml_exn_leak "ready --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"ready --json (dead port)" out err
+  in
+  check_bool_field ~label:"ready --json" fields ~field:"ready" ~expected:false
+
+let test_tip_recency_dead_port_json () =
+  let code, out, err =
+    run_cli [ "tip-recency"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "tip-recency --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "tip-recency --json stdout" out ;
+  assert_no_ocaml_exn_leak "tip-recency --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"tip-recency --json (dead port)" out err
+  in
+  check_bool_field ~label:"tip-recency --json" fields ~field:"healthy"
+    ~expected:false
+
+let test_connectivity_dead_port_json () =
+  let code, out, err =
+    run_cli [ "connectivity"; "--online-uri"; "http://127.0.0.1:1"; "--json" ]
+  in
+  Alcotest.(check int) "connectivity --json (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "connectivity --json stdout" out ;
+  assert_no_ocaml_exn_leak "connectivity --json stderr" err ;
+  let fields =
+    parse_single_json_record ~label:"connectivity --json (dead port)" out err
+  in
+  check_bool_field ~label:"connectivity --json" fields ~field:"healthy"
+    ~expected:false
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-healthcheck CLI smoke tests"
+    [ ("help", [ ("root", `Quick, test_help_root) ])
+    ; ( "ready against dead port"
+      , [ ("text format", `Quick, test_ready_dead_port_text)
+        ; ( "json is single well-formed record"
+          , `Quick
+          , test_ready_dead_port_json_single_record )
+        ] )
+    ; ( "dead port"
+      , [ ("tip-recency --json", `Quick, test_tip_recency_dead_port_json)
+        ; ("connectivity --json", `Quick, test_connectivity_dead_port_json)
+        ] )
+    ]


### PR DESCRIPTION
Moves the Rosetta sanity and load tests off hand-written `curl` + `jq`
request bodies and onto `rosetta-client`.

**3 of 3.** Stacked on #18796, which is stacked on #19284 (the
`rosetta-client` binary this uses).

## What changes

`scripts/tests/rosetta-helper.sh` built each request body as a JSON string
in bash. Every call now goes through one wrapper:

```bash
function rosetta_client() {
    declare -n __test_data=$1
    shift
    MINA_ROSETTA_URI="${__test_data[address]}" \
    MINA_ROSETTA_NETWORK="${__test_data[id]}" \
        rosetta-client --timeout "${ROSETTA_CLIENT_TIMEOUT}" "$@"
}
```

so no call site repeats `--rosetta-uri` or `--network`, and none repeats
the blockchain at all — `rosetta-client` already defaults it to `mina`.
`readonly BLOCKCHAIN` stays for the one remaining raw `curl`, in
`wait_for_sync`.

`ROSETTA_CLIENT_TIMEOUT` defaults to 300 s, not the CLI's 30 s: the `curl`
calls this replaces had no timeout at all, `rosetta-load.sh` exists to put
the server under load, and a `/search/transactions` sweep can take minutes
under exactly that load. 300 s is the `http_timeout` the rosetta-cli audit
config uses against the same server.

The binary is checked for once, when the helper is sourced. It cannot be
checked inside the test functions: those run in a command substitution,
where an `exit` leaves only the subshell and the message would be captured
as the response instead of being shown.

## CI wiring

`Command/Rosetta/Connectivity.dhall` gains `rosetta-client` in its
`bareBinaries`. That job restores every binary from the apps cache, which
makes `restore-or-install.sh` skip the deb install — so anything the tests
call has to be listed, or `rosetta-sanity.sh` fails with
`rosetta-client: command not found`. The apps cache picks the binary up on
its own (`apps/write_to_cache.sh` globs `_build` for `*.exe`), and if it
were ever missing the restore fails and the deb install takes over, which
also carries it.
