### PR TITLE
Install curl in the delegation-verifier image

### DIFF
--- a/changes/19295.md
+++ b/changes/19295.md
@@ -1,0 +1,3 @@
+Fix `mina-delegation-verify` failing to start in the `mina-delegation-verifier` image
+
+The image could not download the genesis and epoch ledger artifacts named by its runtime config. Unless `/var/lib/coda` was pre-populated by hand, the tool exited 4 with `{"error":"fail to read config file"}` after logging `Could not find or generate a $ledger for $root_hash`. It now fetches those artifacts and starts from a runtime config alone. Fixes #19290.

--- a/dockerfiles/Dockerfile-delegation-stateless-verifier
+++ b/dockerfiles/Dockerfile-delegation-stateless-verifier
@@ -34,8 +34,9 @@ RUN echo "deb [trusted=yes] ${deb_repo} $deb_codename $deb_release" | tee /etc/a
   && apt-get install --quiet --yes --no-install-recommends --allow-downgrades "mina-delegation-verify=$deb_version" \
   && rm -rf /var/lib/apt/lists/*
 
-# awscli and cqlsh-expansion are used by the delegation verification tool
-RUN apt-get update && apt-get install -y --no-install-recommends tzdata python3 python3-pip python3-venv jq wget dnsutils gawk \
+# awscli and cqlsh-expansion are used by the delegation verification tool;
+# curl is used by the daemon to download genesis/epoch ledger artifacts
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata python3 python3-pip python3-venv curl jq wget dnsutils gawk \
   && rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment for Python tools


### PR DESCRIPTION
Fixes #19290.

## Problem

`mina-delegation-verify` downloads genesis/epoch ledger artifacts by shelling out to `curl` (`Cache_dir.load_from_s3`, `src/lib/cache_dir/native/cache_dir.ml:64`). `Dockerfile-delegation-stateless-verifier` never installed `curl`, so every download failed:

```
Could not download $ledger from $uri: $error
  error = (monitor.ml.Error (Unix.Unix_error "No such file or directory"
           Core.Unix.create_process "((prog curl) (args (--fail --silent --show-error -o …
```

and initialization ended in `Could not find or generate a $ledger for $root_hash`, exit 4, `{"error":"fail to read config file"}`.

The image also installs no config package, so `/var/lib/coda` is empty in every such container — meaning **any** `--config-file` whose ledgers are not inlined hit this path.

## Fix

Add `curl` to the existing apt layer that already installs `wget`, `jq`, `dnsutils`, `gawk`.

## Verification

Cannot be checked at build time from a working tree — it needs the published `mina-delegation-verify` deb. Once CI publishes an image from this branch:

```
docker run --rm --entrypoint sh <image> -c 'command -v curl'
```

should succeed, and the image should initialize from a runtime config alone. Mounting the artifacts in by hand already makes the unmodified image verify a live devnet block (exit 0) — see #19288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyUjpEAY81hpEycyiYz9t7