### PR TITLE
Report verified: false when a submission fails verification

### DIFF
--- a/changes/19296.md
+++ b/changes/19296.md
@@ -1,0 +1,3 @@
+Fix `mina-delegation-verify` reporting `verified: true` for submissions that failed verification
+
+A submission whose block or SNARK proof failed to verify was still reported as `verified: true`, with the reason only in `validation_error`, so anything reading `verified` counted a rejected block as valid. Both the `stdin` output and the `submissions` table written by the `cassandra` subcommand did this. `verified` is now `false` whenever `validation_error` is set. A submission that does verify also clears `validation_error` back to `NULL`, rather than leaving behind the error text from an earlier attempt. Fixes #19291.

--- a/src/app/delegation_verify/dune
+++ b/src/app/delegation_verify/dune
@@ -43,7 +43,8 @@
   genesis_ledger_helper
   mina_runtime_config
   precomputed_values
-  logger)
+  logger
+  delegation_verify_lib)
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/app/delegation_verify/lib/delegation_verify_lib.ml
+++ b/src/app/delegation_verify/lib/delegation_verify_lib.ml
@@ -2,11 +2,11 @@ open Core
 
 (** The outcome of verifying a submission.
 
-    [verified] and [validation_error] are two views of the same fact, and each
-    output site builds them separately, which leaves them free to disagree.
-    This gathers both encodings in one place so the pairing can be stated as a
-    test. The encodings here reproduce what the output sites do today; the
-    tests below say what they should do, and currently fail. *)
+    [verified] and [validation_error] are two views of the same fact, so both
+    are always emitted together from here: a submission is verified exactly
+    when it carries no validation error. Building the two fields separately at
+    each output site is what let them disagree, reporting [verified: true]
+    alongside a proof failure. *)
 module Verification_status = struct
   type t = Verified | Failed of string
 
@@ -20,13 +20,13 @@ module Verification_status = struct
     | Verified ->
         [ ("verified", `Bool true); ("validation_error", `Null) ]
     | Failed e ->
-        [ ("verified", `Bool true); ("validation_error", `String e) ]
+        [ ("verified", `Bool false); ("validation_error", `String e) ]
 
   let to_cassandra_updates = function
     | Verified ->
-        [ ("verified", "true") ]
+        [ ("verified", "true"); ("validation_error", "NULL") ]
     | Failed e ->
-        [ ("verified", "true"); ("validation_error", sprintf "'%s'" e) ]
+        [ ("verified", "false"); ("validation_error", sprintf "'%s'" e) ]
 
   let%test_module "verified and validation_error cannot disagree" =
     ( module struct

--- a/src/app/delegation_verify/lib/delegation_verify_lib.ml
+++ b/src/app/delegation_verify/lib/delegation_verify_lib.ml
@@ -1,0 +1,88 @@
+open Core
+
+(** The outcome of verifying a submission.
+
+    [verified] and [validation_error] are two views of the same fact, and each
+    output site builds them separately, which leaves them free to disagree.
+    This gathers both encodings in one place so the pairing can be stated as a
+    test. The encodings here reproduce what the output sites do today; the
+    tests below say what they should do, and currently fail. *)
+module Verification_status = struct
+  type t = Verified | Failed of string
+
+  let of_or_error = function
+    | Ok _ ->
+        Verified
+    | Error e ->
+        Failed (Error.to_string_hum e)
+
+  let to_json_fields = function
+    | Verified ->
+        [ ("verified", `Bool true); ("validation_error", `Null) ]
+    | Failed e ->
+        [ ("verified", `Bool true); ("validation_error", `String e) ]
+
+  let to_cassandra_updates = function
+    | Verified ->
+        [ ("verified", "true") ]
+    | Failed e ->
+        [ ("verified", "true"); ("validation_error", sprintf "'%s'" e) ]
+
+  let%test_module "verified and validation_error cannot disagree" =
+    ( module struct
+      let statuses = [ Verified; Failed "(Pickles.verify dlog_check)" ]
+
+      let field fields name =
+        List.Assoc.find_exn fields name ~equal:String.equal
+
+      let%test "json: verified is true exactly when there is no error" =
+        List.for_all statuses ~f:(fun status ->
+            let fields = to_json_fields status in
+            let verified =
+              match field fields "verified" with
+              | `Bool b ->
+                  b
+              | _ ->
+                  failwith "verified is not a boolean"
+            in
+            let no_error =
+              match field fields "validation_error" with
+              | `Null ->
+                  true
+              | _ ->
+                  false
+            in
+            Bool.equal verified no_error )
+
+      (* An absent validation_error column counts as no error: a caller reading
+         the row cannot tell it from an explicit NULL. *)
+      let%test "cassandra: verified is true exactly when there is no error" =
+        List.for_all statuses ~f:(fun status ->
+            let fields = to_cassandra_updates status in
+            let no_error =
+              match
+                List.Assoc.find fields "validation_error" ~equal:String.equal
+              with
+              | None | Some "NULL" ->
+                  true
+              | Some _ ->
+                  false
+            in
+            Bool.equal (String.equal (field fields "verified") "true") no_error )
+
+      let%test "a failed submission reports its reason" =
+        let fields = to_json_fields (Failed "(Pickles.verify dlog_check)") in
+        match (field fields "verified", field fields "validation_error") with
+        | `Bool false, `String "(Pickles.verify dlog_check)" ->
+            true
+        | _ ->
+            false
+
+      let%test "of_or_error carries the error text through" =
+        match of_or_error (Error (Error.of_string "boom")) with
+        | Failed "boom" ->
+            true
+        | Verified | Failed _ ->
+            false
+    end )
+end

--- a/src/app/delegation_verify/lib/dune
+++ b/src/app/delegation_verify/lib/dune
@@ -1,0 +1,12 @@
+(library
+ (name delegation_verify_lib)
+ (libraries
+  ;;opam libraries
+  core
+  yojson)
+ (inline_tests
+  (flags -verbose -show-counts))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane)))

--- a/src/app/delegation_verify/output.ml
+++ b/src/app/delegation_verify/output.ml
@@ -28,8 +28,8 @@ let valid_payload_to_cassandra_updates (p : t) =
     , Printf.sprintf "'%s'" @@ State_hash.to_base58_check p.state_hash )
   ; ("raw_block", "NULL")
   ; ("snark_work", "NULL")
-  ; ("verified", "true")
   ]
+  @ Delegation_verify_lib.Verification_status.(to_cassandra_updates Verified)
 
 let display valid_payload =
   printf "%s\n" @@ Yojson.Safe.to_string

--- a/src/app/delegation_verify/submission.ml
+++ b/src/app/delegation_verify/submission.ml
@@ -249,11 +249,9 @@ module Cassandra = struct
                (List.hd_exn @@ String.split ~on:' ' submission.submitted_at)
                (shard @@ Time.of_string submission.submitted_at)
                submission.submitted_at submission.submitter )
-          [ ("validation_error", sprintf "'%s'" (Error.to_string_hum e))
-          ; ("raw_block", "NULL")
-          ; ("snark_work", "NULL")
-          ; ("verified", "true")
-          ]
+          ( [ ("raw_block", "NULL"); ("snark_work", "NULL") ]
+          @ Delegation_verify_lib.Verification_status.(
+              to_cassandra_updates (Failed (Error.to_string_hum e))) )
 end
 
 module Stdin = struct
@@ -297,7 +295,7 @@ module Stdin = struct
      attached. So here we extract the data from the payload and combine it with the
      submission JSON. *)
   let output () submission output =
-    let results =
+    let payload_fields =
       match output with
       | Ok (payload : Output.t) ->
           [ ( "state_hash"
@@ -309,17 +307,20 @@ module Stdin = struct
           ; ( "slot"
             , `Int (Mina_numbers.Global_slot_since_genesis.to_int payload.slot)
             )
-          ; ("verified", `Bool true)
-          ; ("validation_error", `Null)
           ]
-      | Error e ->
+      | Error _ ->
           [ ("state_hash", `Null)
           ; ("parent", `Null)
           ; ("height", `Null)
           ; ("slot", `Null)
-          ; ("verified", `Bool true)
-          ; ("validation_error", `String (Error.to_string_hum e))
           ]
+    in
+    (* Derived from the same [output] as the payload above, so [verified] and
+       [validation_error] cannot disagree. *)
+    let results =
+      payload_fields
+      @ Delegation_verify_lib.Verification_status.(
+          to_json_fields (of_or_error output))
     in
     Json.json_update results submission
     |> Yojson.Safe.to_channel Out_channel.stdout ;


### PR DESCRIPTION
Fixes #19291.

## Problem

`delegation_verify` emitted `"verified": true` alongside a non-null `validation_error`, so a consumer reading the obviously-named field scored a rejected block as valid:

```json
{"…": "…", "validation_error": "(Pickles.verify dlog_check)", "verified": true}
```

Both output modes did this — the stdin JSON and the Cassandra `submissions` update.

## Fix

The two fields are two views of one fact, so they are no longer built independently at each output site. A new `Verification_status` in `src/app/delegation_verify/lib/` emits both together, in JSON and Cassandra encodings, and the stdin path derives it from the same `Or_error` as the rest of the payload — so they cannot drift.

The library follows the existing app-with-`lib/` pattern (cf. `runtime_genesis_ledger`) so the invariant can carry inline tests.

### One change beyond the issue's letter

A verified submission now writes `validation_error = NULL` to Cassandra. The old success path never touched that column, so a row that failed once kept stale error text after a later successful re-verify — the invariant could not actually hold in the table. The same UPDATE already writes `raw_block = NULL` and `snark_work = NULL`, so this adds no new tombstone pressure.

## Tests

Four inline tests pin the pairing (`dune runtest src/app/delegation_verify/lib`). They were mutation-checked rather than written red-first: restoring the pre-fix `verified: true` in both output modes fails 3 of the 4, so they genuinely catch this regression rather than merely passing.

## Verification

- `dune build @src/app/delegation_verify/check` — clean (run in the nix devshell; the app needs `ppx_mina`).
- `dune runtest src/app/delegation_verify/lib` — 4/4.
- Formatted with the pinned ocamlformat 0.20.1, not the newer one on PATH.

### Downstream compatibility

Checked against `submission-updater`, the wrapper that actually drives this binary in the Delegation Program pipeline. It runs `<bin> stdin` and performs its own Cassandra/Postgres writes, so it never reaches the `cassandra` subcommand's output path. Decoding post-fix records through its own `parseDelegationVerifyOutput`: the success record's `"validation_error": null` decodes to `""` (no error, not malformed), and the failure record now yields `Verified=false` with the reason intact. Its existing test suite still passes.

This fix corrects a real defect there: the wrapper copies `verified` straight into the database, so today a failed submission lands in Cassandra and Postgres as `verified = true`. Its log line already used a belt-and-braces `ValidationError != "" || !Verified` check, so the logs were right while the stored column was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyUjpEAY81hpEycyiYz9t7