### PR TITLE
Packaging dumps docker images, publishing pushes them

### DIFF
--- a/buildkite/scripts/docker/publish_from_cache.sh
+++ b/buildkite/scripts/docker/publish_from_cache.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Push the docker images this build cached, without rebuilding them.
+#
+# The packaging jobs normally push each image as they finish, so images reach a
+# registry before the packaging stage as a whole has succeeded. Debians do not
+# work that way: they are written to a cache and published in one step after a
+# gate. This script is the other half of making images behave the same, so a
+# release publishes everything or nothing.
+#
+# It pairs with scripts/docker/build.sh --load-only --save-to-ci-cache, which
+# builds the image, tags it exactly as it would have been published, and writes
+# it to ${CACHE_ROOT}/<service>/<hashtag-version>.tar.zst. Nothing is retagged
+# here: the tar already carries the tag the image is meant to have, so what is
+# pushed is what was built.
+#
+# Images are found by this build's commit. HASHTAG_VERSION_PART begins with
+# GITHASH (see scripts/docker/helper.sh), and the cache is shared between
+# builds, so the hash is what separates this build's images from everyone
+# else's.
+
+set -euo pipefail
+
+CLEAR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+CACHE_ROOT="${CACHE_ROOT:-/var/storagebox/docker-cache}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# shellcheck disable=SC1090,SC1091
+source ./buildkite/scripts/export-git-env-vars.sh
+
+if [[ ! -d "$CACHE_ROOT" ]]; then
+  echo -e "${RED}❌ No docker cache at ${CACHE_ROOT}.${CLEAR}" >&2
+  exit 1
+fi
+
+echo "--- Looking for images built at ${GITHASH} under ${CACHE_ROOT}"
+
+mapfile -t TARS < <(find "$CACHE_ROOT" -mindepth 2 -maxdepth 2 -name "${GITHASH}-*.tar.zst" | sort)
+
+if [[ ${#TARS[@]} -eq 0 ]]; then
+  echo -e "${RED}❌ No cached images for ${GITHASH}.${CLEAR}" >&2
+  echo "   The packaging stage writes them with --save-to-ci-cache. Either it" >&2
+  echo "   did not run, or it ran without deferring the push, in which case the" >&2
+  echo "   images are already in the registry and this step is not wanted." >&2
+  exit 1
+fi
+
+echo "--- ${#TARS[@]} cached image(s) to publish"
+
+PUSHED=0
+for tar in "${TARS[@]}"; do
+  echo "--- Loading $(basename "$(dirname "$tar")")/$(basename "$tar")"
+
+  # `docker load` names every tag the archive carries. build.sh saves the
+  # published tag and the hash tag together, and both are meant to exist in
+  # the registry, so both are pushed rather than one being recreated from the
+  # other afterwards.
+  mapfile -t TAGS < <(zstd -dc "$tar" | docker load | sed -n 's/^Loaded image: //p')
+
+  if [[ ${#TAGS[@]} -eq 0 ]]; then
+    echo -e "${RED}❌ ${tar} loaded no image.${CLEAR}" >&2
+    exit 1
+  fi
+
+  for tag in "${TAGS[@]}"; do
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    would push ${tag}"
+    else
+      echo "    pushing ${tag}"
+      docker push "$tag"
+    fi
+    PUSHED=$((PUSHED + 1))
+  done
+done
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo -e "${GREEN}✅ Dry run: ${PUSHED} tag(s) would be pushed.${CLEAR}"
+else
+  echo -e "${GREEN}✅ Pushed ${PUSHED} tag(s) from ${#TARS[@]} cached image(s).${CLEAR}"
+fi

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -767,26 +767,15 @@ let docker_step
                 }
                 entry.service
 
-let deferDockerPublish
-    : Optional Text
-    =
-      -- Set by a release pipeline to hold every image back until the packaging
-      -- stage has finished, so images and debians are published together
-      -- rather than image by image as each job lands.
-      --
-      -- Presence is the whole signal; there are only two outcomes.
-      Some env:MINA_RELEASE_DEFER_DOCKER_PUBLISH as Text ? None Text
-
-let deferred
-    : Bool
-    = Prelude.Optional.fold
-        Text
-        deferDockerPublish
-        Bool
-        (\(_ : Text) -> True)
-        False
-
 let docker_commands
+    -- Packaging builds images and writes them to the CI cache. It does not
+    -- push them: pushing is what the publish stage does, for images exactly as
+    -- for debians, so a release puts out everything or nothing.
+    --
+    -- These jobs are shared -- nightly runs them too -- and nightly has no
+    -- publish stage, which is now the whole reason nightly cannot push. It is
+    -- structural rather than conditional: there is no flag to set, and no way
+    -- to set it wrong.
     : PackagingSpec.Type -> List Command.Type
     =     \(spec : PackagingSpec.Type)
       ->  let services =
@@ -812,13 +801,8 @@ let docker_commands
                           //  { deb_release =
                                   DebianChannel.effective spec.channel
                               , docker_repo = spec.docker_repo
-                              , docker_publish =
-                                        if deferred
-
-                                  then  DockerPublish.Type.Disabled
-
-                                  else  s.docker_publish
-                              , save_to_ci_cache = deferred
+                              , docker_publish = DockerPublish.Type.Disabled
+                              , save_to_ci_cache = True
                               }
                         )
                 )

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -767,6 +767,25 @@ let docker_step
                 }
                 entry.service
 
+let deferDockerPublish
+    : Optional Text
+    =
+      -- Set by a release pipeline to hold every image back until the packaging
+      -- stage has finished, so images and debians are published together
+      -- rather than image by image as each job lands.
+      --
+      -- Presence is the whole signal; there are only two outcomes.
+      Some env:MINA_RELEASE_DEFER_DOCKER_PUBLISH as Text ? None Text
+
+let deferred
+    : Bool
+    = Prelude.Optional.fold
+        Text
+        deferDockerPublish
+        Bool
+        (\(_ : Text) -> True)
+        False
+
 let docker_commands
     : PackagingSpec.Type -> List Command.Type
     =     \(spec : PackagingSpec.Type)
@@ -793,6 +812,13 @@ let docker_commands
                           //  { deb_release =
                                   DebianChannel.effective spec.channel
                               , docker_repo = spec.docker_repo
+                              , docker_publish =
+                                        if deferred
+
+                                  then  DockerPublish.Type.Disabled
+
+                                  else  s.docker_publish
+                              , save_to_ci_cache = deferred
                               }
                         )
                 )

--- a/buildkite/src/Jobs/Release/PublishDockers.dhall
+++ b/buildkite/src/Jobs/Release/PublishDockers.dhall
@@ -1,0 +1,63 @@
+-- Push the docker images this build cached, without rebuilding them.
+--
+-- Only wanted when the packaging stage was told to hold its images back
+-- (MINA_RELEASE_DEFER_DOCKER_PUBLISH). Without that the packaging jobs push as
+-- they finish and there is nothing in the cache for this job to find, so it
+-- selects itself out rather than failing on an empty cache.
+--
+-- Tagged Publish, so a release pipeline's publish stage picks it up alongside
+-- PublishDebians and the two go out together.
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Prelude = ../../External/Prelude.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+
+let Size = ../../Command/Size.dhall
+
+let deferred
+    : Optional Text
+    = Some env:MINA_RELEASE_DEFER_DOCKER_PUBLISH as Text ? None Text
+
+let steps
+    : List Command.Type
+    = Prelude.Optional.fold
+        Text
+        deferred
+        (List Command.Type)
+        (     \(_ : Text)
+          ->  [ Command.build
+                  Command.Config::{
+                  , commands =
+                    [ Cmd.run "./buildkite/scripts/docker/publish_from_cache.sh"
+                    ]
+                  , label = "Publish: docker images"
+                  , key = "publish-dockers"
+                  , target = Size.Small
+                  }
+              ]
+        )
+        ([] : List Command.Type)
+
+in  Pipeline.build
+      Pipeline.Config::{
+      , spec = JobSpec::{
+        , dirtyWhen = [ S.everything ]
+        , path = "Release"
+        , name = "PublishDockers"
+        , scope = [ PipelineScope.Type.Release ]
+        , tags = [ PipelineTag.Type.Publish, PipelineTag.Type.Release ]
+        }
+      , steps = steps
+      }

--- a/buildkite/src/Jobs/Release/PublishDockers.dhall
+++ b/buildkite/src/Jobs/Release/PublishDockers.dhall
@@ -1,16 +1,14 @@
--- Push the docker images this build cached, without rebuilding them.
+-- Push the docker images this build cached.
 --
--- Only wanted when the packaging stage was told to hold its images back
--- (MINA_RELEASE_DEFER_DOCKER_PUBLISH). Without that the packaging jobs push as
--- they finish and there is nothing in the cache for this job to find, so it
--- selects itself out rather than failing on an empty cache.
+-- The packaging stage builds every image and writes it to the CI cache without
+-- pushing, so this is where images reach a registry -- in the same stage the
+-- debians do, after the same gate.
 --
--- Tagged Publish, so a release pipeline's publish stage picks it up alongside
--- PublishDebians and the two go out together.
+-- Nightly runs the packaging jobs but not this one, which is what stops
+-- nightly pushing. Nothing is conditional: a pipeline either selects the
+-- Publish stage or it does not.
 
 let S = ../../Lib/SelectFiles.dhall
-
-let Prelude = ../../External/Prelude.dhall
 
 let Cmd = ../../Lib/Cmds.dhall
 
@@ -26,30 +24,6 @@ let Command = ../../Command/Base.dhall
 
 let Size = ../../Command/Size.dhall
 
-let deferred
-    : Optional Text
-    = Some env:MINA_RELEASE_DEFER_DOCKER_PUBLISH as Text ? None Text
-
-let steps
-    : List Command.Type
-    = Prelude.Optional.fold
-        Text
-        deferred
-        (List Command.Type)
-        (     \(_ : Text)
-          ->  [ Command.build
-                  Command.Config::{
-                  , commands =
-                    [ Cmd.run "./buildkite/scripts/docker/publish_from_cache.sh"
-                    ]
-                  , label = "Publish: docker images"
-                  , key = "publish-dockers"
-                  , target = Size.Small
-                  }
-              ]
-        )
-        ([] : List Command.Type)
-
 in  Pipeline.build
       Pipeline.Config::{
       , spec = JobSpec::{
@@ -59,5 +33,14 @@ in  Pipeline.build
         , scope = [ PipelineScope.Type.Release ]
         , tags = [ PipelineTag.Type.Publish, PipelineTag.Type.Release ]
         }
-      , steps = steps
+      , steps =
+        [ Command.build
+            Command.Config::{
+            , commands =
+              [ Cmd.run "./buildkite/scripts/docker/publish_from_cache.sh" ]
+            , label = "Publish: docker images"
+            , key = "publish-dockers"
+            , target = Size.Small
+            }
+        ]
       }


### PR DESCRIPTION
Makes images and debians publish together, and makes it structural rather than conditional.

### The asymmetry

| | gated by tests | gated by **all** packaging succeeding |
| --- | --- | --- |
| docker images | yes | **no** — each job pushed as it finished |
| debians | yes | yes — cached, then published after a gate |

If packaging job 8 of 12 failed, jobs 1–7 had already pushed their images and no debians were published. There is no rollback for images; the registry is the state.

### Packaging dumps, publishing pushes

The packaging jobs now always build with `--load-only --save-to-ci-cache` and never push. `PublishDockers` always pushes what it finds. **There is no flag.** Which of the two a pipeline does is decided by the stages it runs, like everything else here.

```
packaging job -> --load-only: 16, --save-to-ci-cache: 16, docker push: 0
publish job   -> publish_from_cache.sh
```

An earlier version of this PR used `MINA_RELEASE_DEFER_DOCKER_PUBLISH` to switch the behaviour. A switch is a thing that can be set wrong, and what it guards is a release reaching a public registry — so it is gone.

### This is also what stops nightly pushing

| scope | Packaging jobs | Publish jobs |
| --- | --- | --- |
| Nightly | 5 | **0** |
| Release | 10 | 2 |

Nightly still runs the packaging jobs — it has to, because `HardforkPackageConversion` and `DebianAutomodeTransitionTestMainnet` wait on `build-deb-pkg`. Both wait on **debians only**, which come from the cache and are unaffected. I checked every job that depends on a packaging step: none depends on an image having been pushed.

So nightly cannot push because it has no publish stage, not because a variable told it not to.

### Nothing is retagged

`build.sh` tags each image exactly as it would have published it and saves *that* tar, so the push is of what was built rather than something reconstructed from it. Images are found by `GITHASH`, which begins `HASHTAG_VERSION_PART` — the docker cache is shared between builds, so the commit hash is what separates one build's images from another's.

Both halves already existed: `--save-to-ci-cache` wrote the tars and `load_from_cache.sh` read them back for the `mina-base` preload. The missing piece was the push — `manager.sh publish --only-dockers` promotes registry-to-registry and needs the image already in a registry, which is the thing being avoided.

### Two consequences, stated rather than discovered

- **Nightly now caches images it does not use.** That is disk on the storagebox, which has caused outages before. Worth a prune policy for `docker-cache`.
- **The nightly promoter's docker path has nothing to promote**, because promotion pulls from a registry nightly no longer populates.

Both follow from "nightly must not push", which is the intent.

### Verification

`make all` passes: 18 tests, 48 assertions. `shellcheck -S warning` clean.

The push itself is exercised only in CI — it needs the real Hetzner cache and a registry. The discovery, the guards and the argument construction are what I could verify locally.