### PR TITLE
Keep docker images out of nightly by giving them their own jobs

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -610,7 +610,7 @@ let docker_step
           let withDocker =
                     \(dep : Docker.Type)
                 ->    deps
-                    # [ { name = selfName spec
+                    # [ { name = "${selfName spec}Docker"
                         , key = "${Docker.lowerName dep}${netSeg}"
                         }
                       ]
@@ -630,7 +630,7 @@ let docker_step
                 then  deps
 
                 else    deps
-                      # [ { name = genericPackagingName spec
+                      # [ { name = "${genericPackagingName spec}Docker"
                           , key =
                               "${Docker.lowerName
                                    Docker.Type.DaemonGeneric}-${Network.lowerName
@@ -922,12 +922,41 @@ let packagePipeline
             , includeIf = spec.includeIf
             , excludeIf = spec.excludeIf
             }
-          , steps = [ build_debian spec ] # docker_commands spec
+          , steps = [ build_debian spec ]
+          }
+
+let dockerPipeline
+    : PackagingSpec.Type -> Pipeline.Config.Type
+    =
+      -- The images of a packaging spec, as a job of their own.
+      --
+      -- Separate from the debians because scope is a property of a job and the
+      -- two belong to different pipelines. Nightly needs the debians --
+      -- HardforkPackageConversion and DebianAutomodeTransitionTestMainnet both
+      -- wait on build-deb-pkg -- and needs no image at all, so building images
+      -- there produced 21 tarballs a night that nothing ever read.
+      --
+      -- selfName is deliberately left alone: the docker steps name it in their
+      -- depends_on, and what they wait for is the debian job, which is where
+      -- the packages they install are built.
+          \(spec : PackagingSpec.Type)
+      ->  Pipeline.Config::{
+          , spec = JobSpec::{
+            , dirtyWhen = DebianVersions.packageDirtyWhen
+            , path = "Release"
+            , name = "${selfName spec}Docker"
+            , tags = spec.tags
+            , scope = [ PipelineScope.Type.Release ]
+            , includeIf = spec.includeIf
+            , excludeIf = spec.excludeIf
+            }
+          , steps = docker_commands spec
           }
 
 in  { onlyDebianPipeline = onlyDebianPipeline
     , appsPipeline = appsPipeline
     , packagePipeline = packagePipeline
+    , dockerPipeline = dockerPipeline
     , PackagingSpec = PackagingSpec
     , AppsSpec = AppsSpec
     , labelSuffix = labelSuffix

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Docker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormArm64Docker.dhall
@@ -1,0 +1,45 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBookwormDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBookwormDocker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeDocker.dhall
@@ -1,0 +1,39 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactBullseyeInstrumentedDocker.dhall
@@ -1,0 +1,37 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let BuildFlags = ../../Constants/BuildFlags.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , buildFlags = BuildFlags.Type.Instrumented
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactFocalDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactFocalDocker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Focal
+            ]
+          , debVersion = DebianVersions.DebVersion.Focal
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericBookwormArm64Docker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericBookwormArm64Docker.dhall
@@ -1,0 +1,40 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericBookwormDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericBookwormDocker.dhall
@@ -1,0 +1,38 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DelegationVerifier
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericBullseyeDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericBullseyeDocker.dhall
@@ -1,0 +1,34 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TestExecutive
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            , Artifacts.Type.FunctionalTestSuite
+            ]
+          , generic = True
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericBullseyeInstrumentedDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericBullseyeInstrumentedDocker.dhall
@@ -1,0 +1,35 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let BuildFlags = ../../Constants/BuildFlags.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.FunctionalTestSuite
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , buildFlags = BuildFlags.Type.Instrumented
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericFocalDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericFocalDocker.dhall
@@ -1,0 +1,37 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Focal
+            ]
+          , debVersion = DebianVersions.DebVersion.Focal
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericJammyDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericJammyDocker.dhall
@@ -1,0 +1,37 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Jammy
+            ]
+          , debVersion = DebianVersions.DebVersion.Jammy
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactGenericNobleDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactGenericNobleDocker.dhall
@@ -1,0 +1,37 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.DaemonGeneric
+            , Artifacts.Type.ArchiveGeneric
+            , Artifacts.Type.RosettaGeneric
+            , Artifacts.Type.LogProc
+            , Artifacts.Type.TxTools
+            , Artifacts.Type.DaemonStorageToolbox
+            ]
+          , generic = True
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactJammyDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactJammyDocker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Jammy
+            ]
+          , debVersion = DebianVersions.DebVersion.Jammy
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBookwormArm64Docker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBookwormArm64Docker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let Arch = ../../Constants/Arch.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , arch = Arch.Type.Arm64
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Arm64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBookwormDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBookwormDocker.dhall
@@ -1,0 +1,43 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bookworm
+            ]
+          , debVersion = DebianVersions.DebVersion.Bookworm
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetBullseyeDocker.dhall
@@ -1,0 +1,41 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , scope = PipelineScope.AllButPullRequest
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Rosetta
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Bullseye
+            ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetFocalDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetFocalDocker.dhall
@@ -1,0 +1,43 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Focal
+            ]
+          , debVersion = DebianVersions.DebVersion.Focal
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetJammyDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetJammyDocker.dhall
@@ -1,0 +1,43 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Jammy
+            ]
+          , debVersion = DebianVersions.DebVersion.Jammy
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactMainnetNobleDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactMainnetNobleDocker.dhall
@@ -1,0 +1,43 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Mainnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Mainnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Mainnet }
+            , Artifacts.Type.Archive { network = Network.Type.Mainnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Mainnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Mainnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleDocker.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleDocker.dhall
@@ -1,0 +1,44 @@
+let ArtifactPipelines = ../../Command/MinaArtifact.dhall
+
+let DebianVersions = ../../Constants/DebianVersions.dhall
+
+let Artifacts = ../../Constants/Artifact/Artifacts.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let PipelineTag = ../../Pipeline/Tag.dhall
+
+let PipelineScope = ../../Pipeline/Scope.dhall
+
+let Network = ../../Constants/Network.dhall
+
+let Profile = ../../Constants/Profiles.dhall
+
+in  Pipeline.build
+      ( ArtifactPipelines.dockerPipeline
+          ArtifactPipelines.PackagingSpec::{
+          , artifacts =
+            [ Artifacts.Type.Daemon { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Lightnet }
+            , Artifacts.Type.DaemonProfiled { profile = Profile.Type.Devnet }
+            , Artifacts.Type.DaemonPrefork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonPostfork { network = Network.Type.Devnet }
+            , Artifacts.Type.DaemonAutoHardfork
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.CreatePreforkGenesis
+                { network = Network.Type.Devnet }
+            , Artifacts.Type.Archive { network = Network.Type.Devnet }
+            , Artifacts.Type.Rosetta { network = Network.Type.Devnet }
+            ]
+          , tags =
+            [ PipelineTag.Type.Packaging
+            , PipelineTag.Type.Release
+            , PipelineTag.Type.Docker
+            , PipelineTag.Type.Devnet
+            , PipelineTag.Type.Amd64
+            , PipelineTag.Type.Noble
+            ]
+          , debVersion = DebianVersions.DebVersion.Noble
+          , scope = [ PipelineScope.Type.Weekly, PipelineScope.Type.Release ]
+          }
+      )


### PR DESCRIPTION
> **Based on the integration branch**, because it needs both #19287 (the generic job) and #19297 (packaging dumps rather than pushes), and neither is an ancestor of the other. Retarget to `develop` once those land.

### The waste

Nightly built **21 docker images a night that nothing read**. It runs the packaging jobs because two tests need the debians — `HardforkPackageConversion` and `DebianAutomodeTransitionTestMainnet` both wait on `build-deb-pkg` — and the images came along because they were steps of the same job. Once packaging stopped pushing them (#19297), they were built, cached, and never looked at again.

### Scope is a property of a job, so the images had to become one

Each packaging spec now yields two jobs:

| job | holds | scope |
| --- | --- | --- |
| `MinaArtifact<X>` | the debian step | as before — nightly, release, … |
| `MinaArtifact<X>Docker` | the image steps | **Release only** |

```
nightly debian packages: 27      (unchanged)
nightly docker images  :  0      (was 21)
```

No environment variable, no step conditional. Nightly cannot build images because it does not select the jobs that build them.

### `selfName` is unchanged on purpose

The docker steps name it when they wait for the packages they install, and those are still built by the debian job. Only two references had to move:

- an image waiting on a **sibling image** (`withDocker`)
- the daemon images built `FROM` the **generic** image (`dependsOnGeneric`)

Both now name a `Docker` job. `check_deps` caught both when I got them wrong — which is what it is for.

### Precedent

`MinaArtifactOnlyDebianBullseye` already worked this way: one debian step, no images, and the only packaging job that runs in pull-request CI. This gives every other codename the same shape.

### Verification

- `make all` passes: 18 tests, 48 assertions, including `check_deps` and `check_dups`
- no `MinaArtifact*Docker` job is selected in nightly under `Packaging`, `DockerBuild` or `AllDockersAndDebians`
- release still selects them: `Packaging=64  Docker=64  Publish=2`

### Consequence

Job count rises again — 20 new job files. That is the cost of scope being per-job. The alternative was a variable saying "do not build images this time", which is the thing that can be set wrong.