### PR TITLE
[HARD FORK] Carry the fee excess and total currency as registers

### DIFF
--- a/changes/19303.md
+++ b/changes/19303.md
@@ -1,0 +1,5 @@
+Track unsettled fees and total currency as ledger state in transaction proofs
+
+Transaction proof statements used to describe a transition by the net fees and the net supply change it caused. They now record the unsettled fees and the total currency before and after it, so both are proven state rather than running totals, and consensus no longer maintains its own total currency separately. This is a hard-fork change: verification keys, protocol state hashes, block formats and peer-to-peer RPCs all differ from earlier releases, so a node built from this change cannot exchange blocks or snark work with one that is not.
+
+In the GraphQL API a snark work statement replaces `feeExcess` with `sourceFeeExcess` and `targetFeeExcess`, and replaces `supplyIncrease` and `supplyChange` with `sourceTotalCurrency` and `targetTotalCurrency`; the `Registers` type gains `feeExcess` and `totalCurrency`. The output of `mina client pending-snark-work` is unchanged, since it reports the differences between those pairs.

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6917,8 +6917,8 @@
               "deprecationReason": null
             },
             {
-              "name": "supplyIncrease",
-              "description": "Increase in total supply",
+              "name": "sourceTotalCurrency",
+              "description": "Total currency at the source ledger",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6929,19 +6929,19 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": true,
-              "deprecationReason": "Use supplyChange"
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
-              "name": "supplyChange",
-              "description": "Increase/Decrease in total supply",
+              "name": "targetTotalCurrency",
+              "description": "Total currency at the target ledger",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SignedAmount",
+                  "kind": "SCALAR",
+                  "name": "Amount",
                   "ofType": null
                 }
               },
@@ -11290,6 +11290,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "totalCurrency",
+              "description": "Total currency in the ledger at this point",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Amount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -11360,22 +11376,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "LedgerHash",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "supplyIncrease",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SignedAmount",
                   "ofType": null
                 }
               },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6885,8 +6885,24 @@
               "deprecationReason": null
             },
             {
-              "name": "feeExcess",
-              "description": "Total transaction fee that is not accounted for in the transition from source ledger to target ledger",
+              "name": "sourceFeeExcess",
+              "description": "Unsettled transaction fees at the source ledger",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedFee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetFeeExcess",
+              "description": "Unsettled transaction fees at the target ledger",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -11258,6 +11274,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "feeExcess",
+              "description": "Transaction fees collected but not yet settled",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SignedFee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -11344,22 +11376,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "SignedAmount",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "feeExcess",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "SignedFee",
                   "ofType": null
                 }
               },

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1084,9 +1084,19 @@ let pending_snark_work =
                           { Cli_lib.Graphql_types.Pending_snark_work.Work
                             .work_id = w.work_id
                           ; fee_excess =
+                              (* The excess is now a register either side of
+                                 the work, so what the work settles is the
+                                 difference between them. *)
                               Currency.Amount.Signed.of_fee
-                                (to_signed_fee_exn w.fee_excess.sign
-                                   w.fee_excess.feeMagnitude )
+                                (Option.value_exn ~message:"fee excess overflow"
+                                   (Currency.Fee.Signed.add
+                                      (to_signed_fee_exn
+                                         w.target_fee_excess.sign
+                                         w.target_fee_excess.feeMagnitude )
+                                      (Currency.Fee.Signed.negate
+                                         (to_signed_fee_exn
+                                            w.source_fee_excess.sign
+                                            w.source_fee_excess.feeMagnitude ) ) ) )
                           ; supply_increase = w.supply_increase
                           ; source_first_pass_ledger_hash =
                               w.source_first_pass_ledger_hash

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1097,7 +1097,14 @@ let pending_snark_work =
                                          (to_signed_fee_exn
                                             w.source_fee_excess.sign
                                             w.source_fee_excess.feeMagnitude ) ) ) )
-                          ; supply_increase = w.supply_increase
+                          ; supply_increase =
+                              (* The total currency is a register either side of
+                                 the work, so the supply it adds is the
+                                 difference. *)
+                              Option.value_exn
+                                ~message:"supply increase out of range"
+                                (Currency.Amount.sub w.target_total_currency
+                                   w.source_total_currency )
                           ; source_first_pass_ledger_hash =
                               w.source_first_pass_ledger_hash
                           ; target_first_pass_ledger_hash =

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -116,7 +116,8 @@ query pendingSnarkWork {
         sign
         feeMagnitude
       }
-      supply_increase : supplyIncrease
+      source_total_currency: sourceTotalCurrency
+      target_total_currency: targetTotalCurrency
       work_id: workId
       }
     }

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -108,7 +108,11 @@ query pendingSnarkWork {
       target_first_pass_ledger_hash: targetFirstPassLedgerHash
       source_second_pass_ledger_hash: sourceSecondPassLedgerHash
       target_second_pass_ledger_hash: targetSecondPassLedgerHash
-      fee_excess: feeExcess {
+      source_fee_excess: sourceFeeExcess {
+        sign
+        feeMagnitude
+      }
+      target_fee_excess: targetFeeExcess {
         sign
         feeMagnitude
       }

--- a/src/app/cli/src/init/test_ledger_application.ml
+++ b/src/app/cli/src/init/test_ledger_application.ml
@@ -159,11 +159,12 @@ let apply_txs ~transfer_parties_get_actions_events ~action_elements
     Staged_ledger.Test_helpers.update_coinbase_stack_and_get_data_impl
       ~first_partition_slots ~is_new_stack:(not no_new_stack)
       ~no_second_partition:(not has_second_partition) ~constraint_constants
-      ~logger ~global_slot ~signature_kind:Mina_signature_kind.Testnet ledger
-      pending_coinbase zkapps' prev_state_view
+      ~logger ~global_slot ~signature_kind:Mina_signature_kind.Testnet
+      ~init_total_currency:Currency.Amount.zero ledger pending_coinbase zkapps'
+      prev_state_view
       (prev_protocol_state_hash, prev_protocol_state_body_hash)
   with
-  | Ok (b, _, _, _, _) ->
+  | Ok (b, _, _, _, _, _) ->
       let root = Ledger.merkle_root ledger in
       let elapsed = Time_float.diff (Time_float_unix.now ()) start in
       printf

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -203,7 +203,8 @@ module Values (S : Sample) = struct
            (Mina_state.Snarked_ledger_state.genesis
               ~genesis_ledger_hash:
                 (Mina_base.Frozen_ledger_hash.of_ledger_hash
-                   Mina_base.Ledger_hash.empty_hash ) )
+                   Mina_base.Ledger_hash.empty_hash )
+              ~genesis_total_currency:Currency.Amount.zero )
          ~fee:(fee ()) ~prover:(public_key ()) )
 
   let one_priced_proof () :
@@ -382,6 +383,7 @@ module Values (S : Sample) = struct
             ; pending_coinbase_stack = pending_coinbase_stack ()
             ; local_state = local_state ()
             ; fee_excess = fee_excess ()
+            ; total_currency = Currency.Amount.zero
             }
         ; target =
             { first_pass_ledger = field ()
@@ -389,11 +391,10 @@ module Values (S : Sample) = struct
             ; pending_coinbase_stack = pending_coinbase_stack ()
             ; local_state = local_state ()
             ; fee_excess = fee_excess ()
+            ; total_currency = Currency.Amount.zero
             }
         ; connecting_ledger_left = field ()
         ; connecting_ledger_right = field ()
-        ; supply_increase =
-            (* TODO: insure uniqueness *) Currency.Amount.Signed.zero
         ; sok_digest = ()
         }
       ~init_stack:(pending_coinbase_stack ())

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -381,18 +381,19 @@ module Values (S : Sample) = struct
             ; second_pass_ledger = field ()
             ; pending_coinbase_stack = pending_coinbase_stack ()
             ; local_state = local_state ()
+            ; fee_excess = fee_excess ()
             }
         ; target =
             { first_pass_ledger = field ()
             ; second_pass_ledger = field ()
             ; pending_coinbase_stack = pending_coinbase_stack ()
             ; local_state = local_state ()
+            ; fee_excess = fee_excess ()
             }
         ; connecting_ledger_left = field ()
         ; connecting_ledger_right = field ()
         ; supply_increase =
             (* TODO: insure uniqueness *) Currency.Amount.Signed.zero
-        ; fee_excess = fee_excess ()
         ; sok_digest = ()
         }
       ~init_stack:(pending_coinbase_stack ())

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -144,6 +144,7 @@ let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t)
     Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
       ~constraint_constants ~global_slot ~state_body
       ~fee_excess:Currency.Amount.Signed.zero
+      ~total_currency:Currency.Amount.zero
       [ ( `Pending_coinbase_init_stack pending_coinbase_init_stack
         , `Pending_coinbase_of_statement pending_coinbase_state_stack
         , `Ledger ledger
@@ -234,6 +235,7 @@ let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
     Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
       ~constraint_constants ~global_slot ~state_body
       ~fee_excess:Currency.Amount.Signed.zero
+      ~total_currency:Currency.Amount.zero
       [ ( `Pending_coinbase_init_stack pending_coinbase_init_stack
         , `Pending_coinbase_of_statement pending_coinbase_state_stack
         , `Ledger ledger

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -540,11 +540,16 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                   previous_protocol_state |> Protocol_state.blockchain_state
                   |> Blockchain_state.genesis_ledger_hash
                 in
-                let supply_increase =
+                let total_currency =
+                  (* The total currency only moves when a proof is emitted;
+                     otherwise it stays where consensus already has it. *)
                   Option.value_map ledger_proof_opt
                     ~f:(fun proof ->
-                      (Ledger_proof.Cached.statement proof).supply_increase )
-                    ~default:Currency.Amount.Signed.zero
+                      (Ledger_proof.Cached.statement proof).target
+                        .total_currency )
+                    ~default:
+                      (Consensus.Data.Consensus_state.total_currency
+                         (Protocol_state.consensus_state previous_protocol_state) )
                 in
                 let body_reference =
                   Staged_ledger_diff.Body.compute_reference
@@ -574,7 +579,7 @@ let generate_next_state ~commit_id ~zkapp_cmd_limit ~constraint_constants
                       ~previous_protocol_state ~blockchain_state ~current_time
                       ~block_data ~supercharge_coinbase
                       ~snarked_ledger_hash:previous_ledger_hash
-                      ~genesis_ledger_hash ~supply_increase ~logger
+                      ~genesis_ledger_hash ~total_currency ~logger
                       ~constraint_constants ) )
           in
           lift_sync (fun () ->

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -80,6 +80,7 @@ let non_pc_registers_equal_var t1 t2 =
           acc )
         ~local_state:(fun acc f ->
           Local_state.Checked.equal' (F.get f t1) (F.get f t2) @ acc )
+        ~fee_excess:(f !Fee_excess.equal_checked)
       |> Impl.Boolean.all )
 
 let txn_statement_ledger_hashes_equal
@@ -277,7 +278,15 @@ let%snarkydef_ step ~(logger : Logger.t)
     let%bind txn_snark_input_correct =
       let open Checked in
       let%bind () =
-        Fee_excess.(assert_equal_checked (var_of_t zero) txn_snark.fee_excess)
+        (* The fee excess is carried in the registers, so a ledger proof that
+           settles all of the fees it collects starts and ends at zero. This is
+           the same requirement as the previous accumulated excess being zero,
+           given that the scan state's excess starts at zero. *)
+        Fee_excess.(
+          Checked.all_unit
+            [ assert_equal_checked (var_of_t zero) txn_snark.source.fee_excess
+            ; assert_equal_checked (var_of_t zero) txn_snark.target.fee_excess
+            ] )
       in
       let ledger_statement_valid =
         Impl.make_checked (fun () ->

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -81,6 +81,7 @@ let non_pc_registers_equal_var t1 t2 =
         ~local_state:(fun acc f ->
           Local_state.Checked.equal' (F.get f t1) (F.get f t2) @ acc )
         ~fee_excess:(f !Fee_excess.equal_checked)
+        ~total_currency:(f !Currency.Amount.equal_var)
       |> Impl.Boolean.all )
 
 let txn_statement_ledger_hashes_equal
@@ -107,17 +108,8 @@ let txn_statement_ledger_hashes_equal
         !(Frozen_ledger_hash.equal_var s1.connecting_ledger_right
             s2.connecting_ledger_right )
       in
-      let supply_increase_eq =
-        !(Currency.Amount.Signed.Checked.equal s1.supply_increase
-            s2.supply_increase )
-      in
-      Impl.Boolean.all
-        [ source_eq
-        ; target_eq
-        ; left_ledger_eq
-        ; right_ledger_eq
-        ; supply_increase_eq
-        ] )
+
+      Impl.Boolean.all [ source_eq; target_eq; left_ledger_eq; right_ledger_eq ] )
 
 (* Blockchain_snark ~old ~nonce ~ledger_snark ~ledger_hash ~timestamp ~new_hash
       Input:
@@ -183,19 +175,22 @@ let%snarkydef_ step ~(logger : Logger.t)
       (previous_state |> Protocol_state.blockchain_state).ledger_proof_statement
       { txn_snark with sok_digest = () }
   in
-  let%bind supply_increase =
-    (* only increase the supply if the txn statement represents a new ledger transition *)
-    Currency.Amount.(
-      Signed.Checked.if_ txn_stmt_ledger_hashes_didn't_change
-        ~then_:
-          (Signed.create_var ~magnitude:(var_of_t zero) ~sgn:Sgn.Checked.pos)
-        ~else_:txn_snark.supply_increase )
+  let previous_total_currency =
+    Consensus.Data.Consensus_state.total_currency_var
+      (Protocol_state.consensus_state previous_state)
+  in
+  let%bind total_currency =
+    (* The total currency only moves when the txn statement represents a new
+       ledger transition; the transaction snark is what proves the new value
+       follows from the old one, so consensus no longer accumulates it. *)
+    Currency.Amount.Checked.if_ txn_stmt_ledger_hashes_didn't_change
+      ~then_:previous_total_currency ~else_:txn_snark.target.total_currency
   in
   let%bind `Success updated_consensus_state, consensus_state =
     with_label __LOC__ (fun () ->
         Consensus_state_hooks.next_state_checked ~constraint_constants
           ~prev_state:previous_state ~prev_state_hash:previous_state_hash
-          transition supply_increase )
+          transition total_currency )
   in
   let global_slot =
     Consensus.Data.Consensus_state.global_slot_since_genesis_var consensus_state
@@ -299,6 +294,10 @@ let%snarkydef_ step ~(logger : Logger.t)
          in the statement required?*)
       all
         [ ledger_statement_valid
+          (* The proof has to continue the total currency from where consensus
+             left it, which is what makes [total_currency] above sound. *)
+        ; Currency.Amount.equal_var txn_snark.source.total_currency
+            previous_total_currency
         ; Pending_coinbase.Stack.equal_var
             txn_snark.source.pending_coinbase_stack
             pending_coinbase_source_stack

--- a/src/lib/blockchain_snark/tests/test_blockchain_snark.ml
+++ b/src/lib/blockchain_snark/tests/test_blockchain_snark.ml
@@ -27,10 +27,10 @@ type circuit_stats =
   }
 
 let dev_expected_values =
-  { constraints = 9266
+  { constraints = 9267
   ; public_input_size = 1
-  ; auxiliary_input_size = 31987
-  ; digest = "81ef2a46071ad8c4c5380461808ec15a"
+  ; auxiliary_input_size = 31740
+  ; digest = "d3f022cc66f8f30b27d661e2a6c87d78"
   }
 
 let devnet_expected_values =

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -61,7 +61,7 @@ module type Blockchain_state = sig
       , Mina_transaction_logic.Zkapp_command_logic.Local_state.Value.t
       , Block_time.t
       , Body_reference.t
-      , Amount.Signed.t
+      , Amount.t
       , Pending_coinbase.Stack_versioned.Stable.V1.t
       , Fee_excess.Stable.V2.t
       , unit )
@@ -75,7 +75,7 @@ module type Blockchain_state = sig
     , Mina_transaction_logic.Zkapp_command_logic.Local_state.Checked.t
     , Block_time.Checked.t
     , Body_reference.var
-    , Currency.Amount.Signed.var
+    , Currency.Amount.var
     , Pending_coinbase.Stack.var
     , Fee_excess.var
     , unit )
@@ -223,7 +223,7 @@ module type State_hooks = sig
     -> supercharge_coinbase:bool
     -> snarked_ledger_hash:Mina_base.Frozen_ledger_hash.t
     -> genesis_ledger_hash:Mina_base.Frozen_ledger_hash.t
-    -> supply_increase:Currency.Amount.Signed.t
+    -> total_currency:Currency.Amount.t
     -> logger:Logger.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> protocol_state * consensus_transition
@@ -237,7 +237,7 @@ module type State_hooks = sig
     -> prev_state:protocol_state_var
     -> prev_state_hash:Mina_base.State_hash.var
     -> snark_transition_var
-    -> Currency.Amount.Signed.var
+    -> Currency.Amount.var
     -> ([ `Success of Snark_params.Tick.Boolean.var ] * consensus_state_var)
        Snark_params.Tick.Checked.t
 
@@ -296,6 +296,9 @@ module type S = sig
   end
 
   module Genesis_data : sig
+    val genesis_ledger_total_currency :
+      ledger:Mina_ledger.Ledger.t Lazy.t -> Currency.Amount.t
+
     module Hashed : sig
       type t =
         { total_currency : Currency.Amount.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1857,7 +1857,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~(previous_consensus_state : Value.t)
           ~(consensus_transition : Consensus_transition.t)
           ~(previous_protocol_state_hash : Mina_base.State_hash.t)
-          ~(supply_increase : Currency.Amount.Signed.t)
+          ~(total_currency : Currency.Amount.t)
           ~(snarked_ledger_hash : Mina_base.Frozen_ledger_hash.t)
           ~(genesis_ledger_hash : Mina_base.Frozen_ledger_hash.t)
           ~(producer_vrf_result : Random_oracle.Digest.t)
@@ -1888,18 +1888,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                     previous_consensus_state.curr_global_slot_since_hard_fork )
                ~f:(fun diff -> Ok diff )
         in
-        let%map total_currency =
-          let total, `Overflow overflow =
-            Amount.add_signed_flagged previous_consensus_state.total_currency
-              supply_increase
-          in
-          if overflow then
-            Or_error.errorf
-              !"New total currency less than zero. supply_increase: %{sexp: \
-                Amount.Signed.t} previous total currency: %{sexp: Amount.t}"
-              supply_increase previous_consensus_state.total_currency
-          else Ok total
-        and () =
+        let%map () =
           if
             Consensus_transition.(
               equal consensus_transition Consensus_transition.genesis )
@@ -2063,7 +2052,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                (negative_one ~genesis_ledger ~genesis_epoch_data ~constants
                   ~constraint_constants )
              ~previous_protocol_state_hash:negative_one_protocol_state_hash
-             ~consensus_transition ~supply_increase:Currency.Amount.Signed.zero
+             ~consensus_transition ~total_currency:genesis_ledger.total_currency
              ~snarked_ledger_hash ~genesis_ledger_hash:snarked_ledger_hash
              ~block_stake_winner:genesis_winner_pk
              ~block_creator:genesis_winner_pk
@@ -2108,7 +2097,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let%snarkydef_ update_var (previous_state : var)
           (transition_data : Consensus_transition.var)
           (previous_protocol_state_hash : Mina_base.State_hash.var)
-          ~(supply_increase : Currency.Amount.Signed.var)
+          ~(total_currency : Currency.Amount.var)
           ~(previous_blockchain_state_ledger_hash :
              Mina_base.Frozen_ledger_hash.var ) ~genesis_ledger_hash
           ~constraint_constants
@@ -2181,14 +2170,10 @@ module Make_str (A : Wire_types.Concrete) = struct
           compute_supercharge_coinbase ~winner_account
             ~global_slot:global_slot_since_genesis
         in
-        let%bind new_total_currency, `Overflow overflow =
-          Currency.Amount.Checked.add_signed_flagged
-            previous_state.total_currency supply_increase
-        in
-        let%bind () =
-          [%with_label_ "Total currency is greater than or equal to zero"]
-            (fun () -> Boolean.Assert.is_true (Boolean.not overflow) )
-        in
+        (*The total currency is carried in the transaction snark's registers
+          now, so it arrives already computed; the transaction snark is what
+          rejects an update that would take it out of range.*)
+        let new_total_currency = total_currency in
         let%bind has_ancestor_in_same_checkpoint_window =
           same_checkpoint_window ~constants ~prev:prev_global_slot
             ~next:next_global_slot
@@ -3236,7 +3221,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       let generate_transition
           ~(previous_protocol_state : Protocol_state.Value.t) ~blockchain_state
           ~current_time ~(block_data : Block_data.t) ~supercharge_coinbase
-          ~snarked_ledger_hash ~genesis_ledger_hash ~supply_increase ~logger
+          ~snarked_ledger_hash ~genesis_ledger_hash ~total_currency ~logger
           ~constraint_constants =
         [%log internal] "Generate_transition" ;
         let previous_consensus_state =
@@ -3267,7 +3252,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             (Consensus_state.update ~constants ~previous_consensus_state
                ~consensus_transition
                ~producer_vrf_result:block_data.Block_data.vrf_result
-               ~previous_protocol_state_hash ~supply_increase
+               ~previous_protocol_state_hash ~total_currency
                ~snarked_ledger_hash ~genesis_ledger_hash
                ~block_stake_winner:block_data.stake_proof.delegator_pk
                ~block_creator
@@ -3293,11 +3278,11 @@ module Make_str (A : Wire_types.Concrete) = struct
         let%snarkydef.Tick next_state_checked ~constraint_constants
             ~(prev_state : Protocol_state.var)
             ~(prev_state_hash : Mina_base.State_hash.var) transition
-            supply_increase =
+            total_currency =
           Consensus_state.update_var ~constraint_constants
             (Protocol_state.consensus_state prev_state)
             (Snark_transition.consensus_transition transition)
-            prev_state_hash ~supply_increase
+            prev_state_hash ~total_currency
             ~previous_blockchain_state_ledger_hash:
               ( Protocol_state.blockchain_state prev_state
               |> Blockchain_state.snarked_ledger_hash )
@@ -3470,8 +3455,11 @@ module Make_str (A : Wire_types.Concrete) = struct
         let consensus_transition : Consensus_transition.t =
           Global_slot.slot_number global_slot
         in
-        let supply_increase =
-          Currency.Amount.(Signed.of_unsigned (of_nanomina_int_exn 42))
+        let total_currency =
+          Option.value_exn
+            Currency.Amount.(
+              add previous_consensus_state.total_currency
+                (of_nanomina_int_exn 42) )
         in
         (* setup ledger, needed to compute producer_vrf_result here and handler below *)
         let open Mina_base in
@@ -3515,7 +3503,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         in
         let next_consensus_state =
           update ~constants ~previous_consensus_state ~consensus_transition
-            ~previous_protocol_state_hash ~supply_increase ~snarked_ledger_hash
+            ~previous_protocol_state_hash ~total_currency ~snarked_ledger_hash
             ~genesis_ledger_hash:snarked_ledger_hash ~producer_vrf_result
             ~block_stake_winner:producer_public_key_compressed
             ~block_creator:producer_public_key_compressed
@@ -3560,8 +3548,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             exists State_hash.typ
               ~compute:(As_prover.return previous_protocol_state_hash)
           in
-          let%bind supply_increase =
-            exists Amount.Signed.typ ~compute:(As_prover.return supply_increase)
+          let%bind total_currency =
+            exists Amount.typ ~compute:(As_prover.return total_currency)
           in
           let%bind previous_blockchain_state_ledger_hash =
             exists Mina_base.Frozen_ledger_hash.typ
@@ -3577,7 +3565,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           in
           let result =
             update_var previous_state transition_data
-              previous_protocol_state_hash ~supply_increase
+              previous_protocol_state_hash ~total_currency
               ~previous_blockchain_state_ledger_hash ~genesis_ledger_hash
               ~constraint_constants ~protocol_constants:constants_checked
           in

--- a/src/lib/graphql/mina_graphql/types.ml
+++ b/src/lib/graphql/mina_graphql/types.ml
@@ -598,19 +598,16 @@ let work_statement =
           ~args:Arg.[]
           ~resolve:(fun _ ({ target; _ } : Transaction_snark.Statement.t) ->
             target.fee_excess )
-      ; field "supplyIncrease" ~typ:(non_null amount)
-          ~doc:"Increase in total supply"
+      ; field "sourceTotalCurrency" ~typ:(non_null amount)
+          ~doc:"Total currency at the source ledger"
           ~args:Arg.[]
-          ~deprecated:(Deprecated (Some "Use supplyChange"))
-          ~resolve:(fun
-              _ ({ supply_increase; _ } : Transaction_snark.Statement.t) ->
-            supply_increase.magnitude )
-      ; field "supplyChange" ~typ:(non_null signed_amount)
-          ~doc:"Increase/Decrease in total supply"
+          ~resolve:(fun _ ({ source; _ } : Transaction_snark.Statement.t) ->
+            source.total_currency )
+      ; field "targetTotalCurrency" ~typ:(non_null amount)
+          ~doc:"Total currency at the target ledger"
           ~args:Arg.[]
-          ~resolve:(fun
-              _ ({ supply_increase; _ } : Transaction_snark.Statement.t) ->
-            supply_increase )
+          ~resolve:(fun _ ({ target; _ } : Transaction_snark.Statement.t) ->
+            target.total_currency )
       ; field "workId" ~doc:"Unique identifier for a snark work"
           ~typ:(non_null int)
           ~args:Arg.[]
@@ -830,6 +827,11 @@ let registers : (Mina_lib.t, Mina_state.Registers.Value.t option) typ =
           ~doc:"Transaction fees collected but not yet settled"
           ~typ:(non_null signed_fee)
           ~resolve:(fun _ ({ fee_excess; _ } : _ M.t) -> fee_excess)
+      ; field "totalCurrency"
+          ~args:Arg.[]
+          ~doc:"Total currency in the ledger at this point"
+          ~typ:(non_null amount)
+          ~resolve:(fun _ ({ total_currency; _ } : _ M.t) -> total_currency)
       ]
 
 let snarked_ledger_state :
@@ -855,10 +857,6 @@ let snarked_ledger_state :
           ~typ:(non_null ledger_hash)
           ~resolve:(fun _ ({ connecting_ledger_right; _ } : _ M.t) ->
             connecting_ledger_right )
-      ; field "supplyIncrease"
-          ~args:Arg.[]
-          ~typ:(non_null signed_amount)
-          ~resolve:(fun _ ({ supply_increase; _ } : _ M.t) -> supply_increase)
       ; field "sokDigest"
           ~args:Arg.[]
           ~doc:"Placeholder for SOK digest" ~typ:string

--- a/src/lib/graphql/mina_graphql/types.ml
+++ b/src/lib/graphql/mina_graphql/types.ml
@@ -588,13 +588,16 @@ let work_statement =
           ~args:Arg.[]
           ~resolve:(fun _ { Transaction_snark.Statement.Poly.target; _ } ->
             target.second_pass_ledger )
-      ; field "feeExcess" ~typ:(non_null signed_fee)
-          ~doc:
-            "Total transaction fee that is not accounted for in the transition \
-             from source ledger to target ledger"
+      ; field "sourceFeeExcess" ~typ:(non_null signed_fee)
+          ~doc:"Unsettled transaction fees at the source ledger"
           ~args:Arg.[]
-          ~resolve:(fun _ ({ fee_excess; _ } : Transaction_snark.Statement.t) ->
-            fee_excess )
+          ~resolve:(fun _ ({ source; _ } : Transaction_snark.Statement.t) ->
+            source.fee_excess )
+      ; field "targetFeeExcess" ~typ:(non_null signed_fee)
+          ~doc:"Unsettled transaction fees at the target ledger"
+          ~args:Arg.[]
+          ~resolve:(fun _ ({ target; _ } : Transaction_snark.Statement.t) ->
+            target.fee_excess )
       ; field "supplyIncrease" ~typ:(non_null amount)
           ~doc:"Increase in total supply"
           ~args:Arg.[]
@@ -822,6 +825,11 @@ let registers : (Mina_lib.t, Mina_state.Registers.Value.t option) typ =
           ~args:Arg.[]
           ~doc:"Local state" ~typ:(non_null local_state)
           ~resolve:(fun _ ({ local_state; _ } : _ M.t) -> local_state)
+      ; field "feeExcess"
+          ~args:Arg.[]
+          ~doc:"Transaction fees collected but not yet settled"
+          ~typ:(non_null signed_fee)
+          ~resolve:(fun _ ({ fee_excess; _ } : _ M.t) -> fee_excess)
       ]
 
 let snarked_ledger_state :
@@ -851,10 +859,6 @@ let snarked_ledger_state :
           ~args:Arg.[]
           ~typ:(non_null signed_amount)
           ~resolve:(fun _ ({ supply_increase; _ } : _ M.t) -> supply_increase)
-      ; field "feeExcess"
-          ~args:Arg.[]
-          ~typ:(non_null signed_fee)
-          ~resolve:(fun _ ({ fee_excess; _ } : _ M.t) -> fee_excess)
       ; field "sokDigest"
           ~args:Arg.[]
           ~doc:"Placeholder for SOK digest" ~typ:string

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -13,7 +13,7 @@ module For_tests : sig
          , Mina_base.Fee_excess.Stable.V2.t
          , 'a
          , Mina_state.Local_state.Stable.V1.t )
-         Mina_wire_types.Mina_state_snarked_ledger_state.M.Poly.V2.t
+         Mina_wire_types.Mina_state_snarked_ledger_state.M.Poly.V3.t
     -> fee:Mina_wire_types.Currency.M.Fee.V1.t
     -> prover:Mina_base_import.Public_key.Compressed.Stable.Latest.t
     -> t

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -6,9 +6,7 @@ module For_tests : sig
   val mk_dummy_proof :
        statement:
          ( Pasta_bindings.Fp.t
-         , ( Mina_wire_types.Currency.M.Amount.V1.t
-           , Sgn.Stable.V1.t )
-           Mina_wire_types.Signed_poly.V1.t
+         , Mina_wire_types.Currency.M.Amount.V1.t
          , Mina_wire_types.Mina_base_pending_coinbase.M.Stack_versioned.V1.t
          , Mina_base.Fee_excess.Stable.V2.t
          , 'a

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -26,7 +26,8 @@ module type S = sig
     -> ( Frozen_ledger_hash.t
        , Pending_coinbase.Stack_versioned.t
        , Mina_state.Local_state.t
-       , Mina_base.Fee_excess.t )
+       , Mina_base.Fee_excess.t
+       , Currency.Amount.t )
        Mina_state.Registers.t
 
   val statement : t -> Mina_state.Snarked_ledger_state.t
@@ -40,7 +41,8 @@ module type S = sig
     -> ( Frozen_ledger_hash.t
        , Pending_coinbase.Stack_versioned.t
        , Mina_state.Local_state.t
-       , Mina_base.Fee_excess.t )
+       , Mina_base.Fee_excess.t
+       , Currency.Amount.t )
        Mina_state.Registers.t
 
   val underlying_proof : t -> Proof.t

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -25,7 +25,8 @@ module type S = sig
        Mina_state.Snarked_ledger_state.t
     -> ( Frozen_ledger_hash.t
        , Pending_coinbase.Stack_versioned.t
-       , Mina_state.Local_state.t )
+       , Mina_state.Local_state.t
+       , Mina_base.Fee_excess.t )
        Mina_state.Registers.t
 
   val statement : t -> Mina_state.Snarked_ledger_state.t
@@ -38,7 +39,8 @@ module type S = sig
        Mina_state.Snarked_ledger_state.With_sok.t
     -> ( Frozen_ledger_hash.t
        , Pending_coinbase.Stack_versioned.t
-       , Mina_state.Local_state.t )
+       , Mina_state.Local_state.t
+       , Mina_base.Fee_excess.t )
        Mina_state.Registers.t
 
   val underlying_proof : t -> Proof.t

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -40,6 +40,9 @@ let to_input_checked :
 let assert_equal_checked : var -> var -> unit Checked.t =
   Fee.Signed.Checked.assert_equal
 
+let equal_checked : var -> var -> Boolean.var Checked.t =
+  Fee.Signed.Checked.equal
+
 (** Combine the fee excesses from two transitions. *)
 let combine (t1 : t) (t2 : t) : t Or_error.t =
   match Fee.Signed.add t1 t2 with

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -71,7 +71,7 @@ module Value = struct
         , Local_state.Stable.V1.t
         , Block_time.Stable.V1.t
         , Consensus.Body_reference.Stable.V1.t
-        , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+        , Amount.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V2.t
         , unit )
@@ -89,7 +89,7 @@ type var =
   , Local_state.Checked.t
   , Block_time.Checked.t
   , Consensus.Body_reference.var
-  , Currency.Amount.Signed.var
+  , Currency.Amount.var
   , Pending_coinbase.Stack.var
   , Fee_excess.var
   , unit )
@@ -160,11 +160,12 @@ let set_timestamp t timestamp = { t with Poly.timestamp }
 let negative_one
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~(consensus_constants : Consensus.Constants.t) ~genesis_ledger_hash
-    ~genesis_body_reference : Value.t =
+    ~genesis_total_currency ~genesis_body_reference : Value.t =
   { staged_ledger_hash =
       Staged_ledger_hash.genesis ~constraint_constants ~genesis_ledger_hash
   ; genesis_ledger_hash
-  ; ledger_proof_statement = Snarked_ledger_state.genesis ~genesis_ledger_hash
+  ; ledger_proof_statement =
+      Snarked_ledger_state.genesis ~genesis_ledger_hash ~genesis_total_currency
   ; timestamp = consensus_constants.genesis_state_timestamp
   ; body_reference = genesis_body_reference
   }

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -36,7 +36,7 @@ module Poly = struct
             , 'fee_excess
             , 'sok_digest
             , 'local_state )
-            Snarked_ledger_state.Poly.Stable.V2.t
+            Snarked_ledger_state.Poly.Stable.V3.t
         ; timestamp : 'time
         ; body_reference : 'body_reference
         }

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -36,7 +36,7 @@ module Poly : sig
             , 'fee_excess
             , 'sok_digest
             , 'local_state )
-            Snarked_ledger_state.Poly.Stable.V2.t
+            Snarked_ledger_state.Poly.Stable.V3.t
         ; timestamp : 'time
         ; body_reference : 'body_reference
         }

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -55,7 +55,7 @@ module Value : sig
         , Local_state.Stable.V1.t
         , Block_time.Stable.V1.t
         , Consensus.Body_reference.Stable.V1.t
-        , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+        , Amount.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V2.t
         , unit )
@@ -75,7 +75,7 @@ include
       , Local_state.Checked.t
       , Block_time.Checked.t
       , Consensus.Body_reference.var
-      , Currency.Amount.Signed.var
+      , Currency.Amount.var
       , Pending_coinbase.Stack.var
       , Fee_excess.var
       , unit )
@@ -129,6 +129,7 @@ val negative_one :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t
   -> genesis_ledger_hash:Ledger_hash.t
+  -> genesis_total_currency:Currency.Amount.t
   -> genesis_body_reference:Consensus.Body_reference.t
   -> Value.t
 
@@ -136,6 +137,7 @@ val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t
   -> genesis_ledger_hash:Ledger_hash.t
+  -> genesis_total_currency:Currency.Amount.t
   -> genesis_body_reference:Consensus.Body_reference.t
   -> Value.t
 

--- a/src/lib/mina_state/genesis_protocol_state.ml
+++ b/src/lib/mina_state/genesis_protocol_state.ml
@@ -28,6 +28,7 @@ let t ~genesis_ledger ~genesis_epoch_data ~constraint_constants
         (Blockchain_state.genesis ~constraint_constants ~consensus_constants
            ~genesis_ledger_hash:
              (Consensus.Genesis_data.Hashed.hash genesis_ledger)
+           ~genesis_total_currency:genesis_ledger.total_currency
            ~genesis_body_reference )
       ~consensus_state:genesis_consensus_state ~constants:protocol_constants
   in

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -304,6 +304,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               ~consensus_constants
               ~genesis_ledger_hash:
                 (Consensus.Genesis_data.Hashed.hash genesis_ledger)
+              ~genesis_total_currency:genesis_ledger.total_currency
               ~genesis_body_reference
         ; genesis_state_hash = State_hash.of_hash Outside_hash_image.t
         ; consensus_state =

--- a/src/lib/mina_state/registers.ml
+++ b/src/lib/mina_state/registers.ml
@@ -4,16 +4,18 @@ module Impl = Pickles.Impls.Step
 
 [%%versioned
 module Stable = struct
-  module V1 = struct
-    type ('ledger, 'pending_coinbase_stack, 'local_state) t =
+  module V2 = struct
+    type ('ledger, 'pending_coinbase_stack, 'local_state, 'fee_excess) t =
           ( 'ledger
           , 'pending_coinbase_stack
-          , 'local_state )
-          Mina_wire_types.Mina_state.Registers.V1.t =
+          , 'local_state
+          , 'fee_excess )
+          Mina_wire_types.Mina_state.Registers.V2.t =
       { first_pass_ledger : 'ledger
       ; second_pass_ledger : 'ledger
       ; pending_coinbase_stack : 'pending_coinbase_stack
       ; local_state : 'local_state
+      ; fee_excess : 'fee_excess
       }
     [@@deriving compare, equal, hash, sexp, yojson, hlist, fields]
   end
@@ -24,20 +26,28 @@ let gen =
   let%map first_pass_ledger = Frozen_ledger_hash.gen
   and second_pass_ledger = Frozen_ledger_hash.gen
   and pending_coinbase_stack = Pending_coinbase.Stack.gen
-  and local_state = Local_state.gen in
-  { first_pass_ledger; second_pass_ledger; pending_coinbase_stack; local_state }
+  and local_state = Local_state.gen
+  and fee_excess = Fee_excess.gen in
+  { first_pass_ledger
+  ; second_pass_ledger
+  ; pending_coinbase_stack
+  ; local_state
+  ; fee_excess
+  }
 
 let to_input
     { first_pass_ledger
     ; second_pass_ledger
     ; pending_coinbase_stack
     ; local_state
+    ; fee_excess
     } =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [| Frozen_ledger_hash.to_input first_pass_ledger
      ; Frozen_ledger_hash.to_input second_pass_ledger
      ; Pending_coinbase.Stack.to_input pending_coinbase_stack
      ; Local_state.to_input local_state
+     ; Fee_excess.to_input fee_excess
     |]
 
 let typ spec =
@@ -48,13 +58,19 @@ module Value = struct
   type t =
     ( Frozen_ledger_hash.t
     , Pending_coinbase.Stack.t
-    , Local_state.t )
+    , Local_state.t
+    , Fee_excess.t )
     Stable.Latest.t
   [@@deriving compare, equal, sexp, yojson, hash]
 
   let connected t t' =
     let module Without_pending_coinbase_stack = struct
-      type t = (Frozen_ledger_hash.t, unit, Local_state.t) Stable.Latest.t
+      type t =
+        ( Frozen_ledger_hash.t
+        , unit
+        , Local_state.t
+        , Fee_excess.t )
+        Stable.Latest.t
       [@@deriving compare, equal, sexp, yojson, hash]
     end in
     Without_pending_coinbase_stack.equal
@@ -66,28 +82,38 @@ end
 
 module Checked = struct
   type nonrec t =
-    (Ledger_hash.var, Pending_coinbase.Stack.var, Local_state.Checked.t) t
+    ( Ledger_hash.var
+    , Pending_coinbase.Stack.var
+    , Local_state.Checked.t
+    , Fee_excess.var )
+    t
 
   let to_input
       { first_pass_ledger
       ; second_pass_ledger
       ; pending_coinbase_stack
       ; local_state
+      ; fee_excess
       } =
+    let open Snark_params.Tick.Checked.Let_syntax in
+    let%map fee_excess = Fee_excess.to_input_checked fee_excess in
     Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
       [| Frozen_ledger_hash.var_to_input first_pass_ledger
        ; Frozen_ledger_hash.var_to_input second_pass_ledger
        ; Pending_coinbase.Stack.var_to_input pending_coinbase_stack
        ; Local_state.Checked.to_input local_state
+       ; fee_excess
       |]
 
   let equal t1 t2 =
     let ( ! ) eq x1 x2 = Impl.run_checked (eq x1 x2) in
     let f eq acc field = eq (Field.get field t1) (Field.get field t2) :: acc in
-    Fields.fold ~init:[] ~first_pass_ledger:(f !Frozen_ledger_hash.equal_var)
+    Fields.fold ~init:[]
+      ~first_pass_ledger:(f !Frozen_ledger_hash.equal_var)
       ~second_pass_ledger:(f !Frozen_ledger_hash.equal_var)
       ~pending_coinbase_stack:(f !Pending_coinbase.Stack.equal_var)
       ~local_state:(fun acc f ->
         Local_state.Checked.equal' (Field.get f t1) (Field.get f t2) @ acc )
+      ~fee_excess:(f !Fee_excess.equal_checked)
     |> Impl.Boolean.all
 end

--- a/src/lib/mina_state/registers.ml
+++ b/src/lib/mina_state/registers.ml
@@ -5,17 +5,24 @@ module Impl = Pickles.Impls.Step
 [%%versioned
 module Stable = struct
   module V2 = struct
-    type ('ledger, 'pending_coinbase_stack, 'local_state, 'fee_excess) t =
+    type ( 'ledger
+         , 'pending_coinbase_stack
+         , 'local_state
+         , 'fee_excess
+         , 'amount )
+         t =
           ( 'ledger
           , 'pending_coinbase_stack
           , 'local_state
-          , 'fee_excess )
+          , 'fee_excess
+          , 'amount )
           Mina_wire_types.Mina_state.Registers.V2.t =
       { first_pass_ledger : 'ledger
       ; second_pass_ledger : 'ledger
       ; pending_coinbase_stack : 'pending_coinbase_stack
       ; local_state : 'local_state
       ; fee_excess : 'fee_excess
+      ; total_currency : 'amount
       }
     [@@deriving compare, equal, hash, sexp, yojson, hlist, fields]
   end
@@ -27,12 +34,14 @@ let gen =
   and second_pass_ledger = Frozen_ledger_hash.gen
   and pending_coinbase_stack = Pending_coinbase.Stack.gen
   and local_state = Local_state.gen
-  and fee_excess = Fee_excess.gen in
+  and fee_excess = Fee_excess.gen
+  and total_currency = Currency.Amount.gen in
   { first_pass_ledger
   ; second_pass_ledger
   ; pending_coinbase_stack
   ; local_state
   ; fee_excess
+  ; total_currency
   }
 
 let to_input
@@ -41,6 +50,7 @@ let to_input
     ; pending_coinbase_stack
     ; local_state
     ; fee_excess
+    ; total_currency
     } =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [| Frozen_ledger_hash.to_input first_pass_ledger
@@ -48,6 +58,7 @@ let to_input
      ; Pending_coinbase.Stack.to_input pending_coinbase_stack
      ; Local_state.to_input local_state
      ; Fee_excess.to_input fee_excess
+     ; Currency.Amount.to_input total_currency
     |]
 
 let typ spec =
@@ -59,7 +70,8 @@ module Value = struct
     ( Frozen_ledger_hash.t
     , Pending_coinbase.Stack.t
     , Local_state.t
-    , Fee_excess.t )
+    , Fee_excess.t
+    , Currency.Amount.t )
     Stable.Latest.t
   [@@deriving compare, equal, sexp, yojson, hash]
 
@@ -69,7 +81,8 @@ module Value = struct
         ( Frozen_ledger_hash.t
         , unit
         , Local_state.t
-        , Fee_excess.t )
+        , Fee_excess.t
+        , Currency.Amount.t )
         Stable.Latest.t
       [@@deriving compare, equal, sexp, yojson, hash]
     end in
@@ -85,7 +98,8 @@ module Checked = struct
     ( Ledger_hash.var
     , Pending_coinbase.Stack.var
     , Local_state.Checked.t
-    , Fee_excess.var )
+    , Fee_excess.var
+    , Currency.Amount.var )
     t
 
   let to_input
@@ -94,6 +108,7 @@ module Checked = struct
       ; pending_coinbase_stack
       ; local_state
       ; fee_excess
+      ; total_currency
       } =
     let open Snark_params.Tick.Checked.Let_syntax in
     let%map fee_excess = Fee_excess.to_input_checked fee_excess in
@@ -103,6 +118,7 @@ module Checked = struct
        ; Pending_coinbase.Stack.var_to_input pending_coinbase_stack
        ; Local_state.Checked.to_input local_state
        ; fee_excess
+       ; Currency.Amount.var_to_input total_currency
       |]
 
   let equal t1 t2 =
@@ -115,5 +131,6 @@ module Checked = struct
       ~local_state:(fun acc f ->
         Local_state.Checked.equal' (Field.get f t1) (Field.get f t2) @ acc )
       ~fee_excess:(f !Fee_excess.equal_checked)
+      ~total_currency:(f !Currency.Amount.equal_var)
     |> Impl.Boolean.all
 end

--- a/src/lib/mina_state/snark_transition.ml
+++ b/src/lib/mina_state/snark_transition.ml
@@ -56,11 +56,14 @@ let create_value ~blockchain_state ~consensus_transition
 
 let genesis ~constraint_constants ~consensus_constants ~genesis_ledger
     ~genesis_body_reference : value =
+  let genesis_total_currency =
+    Consensus.Genesis_data.genesis_ledger_total_currency ~ledger:genesis_ledger
+  in
   let genesis_ledger = Lazy.force genesis_ledger in
   { Poly.blockchain_state =
       Blockchain_state.genesis ~constraint_constants ~consensus_constants
         ~genesis_ledger_hash:(Mina_ledger.Ledger.merkle_root genesis_ledger)
-        ~genesis_body_reference
+        ~genesis_total_currency ~genesis_body_reference
   ; consensus_transition = Consensus.Data.Consensus_transition.genesis
   ; pending_coinbase_update = Pending_coinbase.Update.genesis
   }

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -122,30 +122,31 @@ module Make_str (A : Wire_types.Concrete) = struct
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Registers.Stable.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Registers.Stable.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
-          ; supply_increase : 'amount
           ; sok_digest : 'sok_digest
           }
         [@@deriving compare, equal, hash, sexp, yojson, hlist]
       end
     end]
 
-    let with_empty_local_state ~supply_increase ~source_fee_excess
-        ~target_fee_excess ~sok_digest ~source_first_pass_ledger
-        ~target_first_pass_ledger ~source_second_pass_ledger
-        ~target_second_pass_ledger ~connecting_ledger_left
-        ~connecting_ledger_right ~pending_coinbase_stack_state : _ t =
-      { supply_increase
-      ; sok_digest
+    let with_empty_local_state ~source_total_currency ~target_total_currency
+        ~source_fee_excess ~target_fee_excess ~sok_digest
+        ~source_first_pass_ledger ~target_first_pass_ledger
+        ~source_second_pass_ledger ~target_second_pass_ledger
+        ~connecting_ledger_left ~connecting_ledger_right
+        ~pending_coinbase_stack_state : _ t =
+      { sok_digest
       ; connecting_ledger_left
       ; connecting_ledger_right
       ; source =
@@ -155,6 +156,7 @@ module Make_str (A : Wire_types.Concrete) = struct
               pending_coinbase_stack_state.Pending_coinbase_stack_state.source
           ; local_state = Local_state.empty ()
           ; fee_excess = source_fee_excess
+          ; total_currency = source_total_currency
           }
       ; target =
           { first_pass_ledger = target_first_pass_ledger
@@ -162,6 +164,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; pending_coinbase_stack = pending_coinbase_stack_state.target
           ; local_state = Local_state.empty ()
           ; fee_excess = target_fee_excess
+          ; total_currency = target_total_currency
           }
       }
 
@@ -176,12 +179,13 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; pending_coinbase
           ; local_state_typ
           ; fee_excess
+          ; amount
           ]
           ~var_to_hlist:Registers.to_hlist ~var_of_hlist:Registers.of_hlist
           ~value_to_hlist:Registers.to_hlist ~value_of_hlist:Registers.of_hlist
       in
       Tick.Typ.of_hlistable
-        [ registers; registers; ledger_hash; ledger_hash; amount; sok_digest ]
+        [ registers; registers; ledger_hash; ledger_hash; sok_digest ]
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
         ~value_of_hlist:of_hlist
 
@@ -193,7 +197,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     module V3 = struct
       type t =
         ( Frozen_ledger_hash.Stable.V1.t
-        , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+        , Amount.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V2.t
         , unit
@@ -207,7 +211,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   type var =
     ( Frozen_ledger_hash.var
-    , Currency.Amount.Signed.var
+    , Currency.Amount.var
     , Pending_coinbase.Stack.var
     , Fee_excess.var
     , unit
@@ -215,7 +219,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     Poly.t
 
   let typ : (var, t) Tick.Typ.t =
-    Poly.typ Frozen_ledger_hash.typ Currency.Amount.Signed.typ
+    Poly.typ Frozen_ledger_hash.typ Currency.Amount.typ
       Pending_coinbase.Stack.typ Fee_excess.typ Tick.Typ.unit Local_state.typ
 
   type display =
@@ -234,32 +238,31 @@ module Make_str (A : Wire_types.Concrete) = struct
           |> Yojson.Safe.to_string
       ; local_state = Local_state.display t.local_state
       ; fee_excess = Fee_excess.to_yojson t.fee_excess |> Yojson.Safe.to_string
+      ; total_currency =
+          Currency.Amount.to_yojson t.total_currency |> Yojson.Safe.to_string
       }
     in
     { Poly.source = display_register t.source
     ; target = display_register t.target
     ; connecting_ledger_left = display_ledger_hash t.connecting_ledger_left
     ; connecting_ledger_right = display_ledger_hash t.connecting_ledger_right
-    ; supply_increase =
-        Currency.Amount.Signed.to_yojson t.supply_increase
-        |> Yojson.Safe.to_string
     ; sok_digest = ()
     }
 
-  let genesis ~genesis_ledger_hash : t =
+  let genesis ~genesis_ledger_hash ~genesis_total_currency : t =
     let registers =
       { Registers.first_pass_ledger = genesis_ledger_hash
       ; second_pass_ledger = genesis_ledger_hash
       ; pending_coinbase_stack = Pending_coinbase.Stack.empty
       ; local_state = Local_state.dummy ()
       ; fee_excess = Fee_excess.empty
+      ; total_currency = genesis_total_currency
       }
     in
     { source = registers
     ; target = registers
     ; connecting_ledger_left = genesis_ledger_hash
     ; connecting_ledger_right = genesis_ledger_hash
-    ; supply_increase = Currency.Amount.Signed.zero
     ; sok_digest = ()
     }
 
@@ -268,7 +271,6 @@ module Make_str (A : Wire_types.Concrete) = struct
        ; target
        ; connecting_ledger_left
        ; connecting_ledger_right
-       ; supply_increase
        ; sok_digest = _
        } :
         t ) =
@@ -278,7 +280,6 @@ module Make_str (A : Wire_types.Concrete) = struct
          ; Registers.to_input target
          ; Frozen_ledger_hash.to_input connecting_ledger_left
          ; Frozen_ledger_hash.to_input connecting_ledger_right
-         ; Amount.Signed.to_input supply_increase
         |]
     in
     if !top_hash_logging_enabled then
@@ -298,7 +299,6 @@ module Make_str (A : Wire_types.Concrete) = struct
          ; target
          ; connecting_ledger_left
          ; connecting_ledger_right
-         ; supply_increase
          ; sok_digest = _
          } :
           t ) =
@@ -306,16 +306,12 @@ module Make_str (A : Wire_types.Concrete) = struct
       let open Checked.Let_syntax in
       let%bind source = Registers.Checked.to_input source in
       let%bind target = Registers.Checked.to_input target in
-      let%bind supply_increase =
-        Amount.Signed.Checked.to_input supply_increase
-      in
       let input =
         Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
           [| source
            ; target
            ; Frozen_ledger_hash.var_to_input connecting_ledger_left
            ; Frozen_ledger_hash.var_to_input connecting_ledger_right
-           ; supply_increase
           |]
       in
       let%map () =
@@ -342,7 +338,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       module V3 = struct
         type t =
           ( Frozen_ledger_hash.Stable.V1.t
-          , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+          , Amount.Stable.V1.t
           , Pending_coinbase.Stack_versioned.Stable.V1.t
           , Fee_excess.Stable.V2.t
           , Sok_message.Digest.Stable.V1.t
@@ -364,13 +360,15 @@ module Make_str (A : Wire_types.Concrete) = struct
           Sok_message.Digest.to_yojson t.sok_digest |> Yojson.Safe.to_string
       }
 
-    let genesis ~genesis_ledger_hash : t =
-      let genesis_without_sok = genesis ~genesis_ledger_hash in
+    let genesis ~genesis_ledger_hash ~genesis_total_currency : t =
+      let genesis_without_sok =
+        genesis ~genesis_ledger_hash ~genesis_total_currency
+      in
       { genesis_without_sok with sok_digest = Sok_message.Digest.default }
 
     type var =
       ( Frozen_ledger_hash.var
-      , Currency.Amount.Signed.var
+      , Currency.Amount.var
       , Pending_coinbase.Stack.var
       , Fee_excess.var
       , Sok_message.Digest.Checked.t
@@ -378,7 +376,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       Poly.t
 
     let typ : (var, t) Tick.Typ.t =
-      Poly.typ Frozen_ledger_hash.typ Currency.Amount.Signed.typ
+      Poly.typ Frozen_ledger_hash.typ Currency.Amount.typ
         Pending_coinbase.Stack.typ Fee_excess.typ Sok_message.Digest.typ
         Local_state.typ
 
@@ -386,9 +384,6 @@ module Make_str (A : Wire_types.Concrete) = struct
       let (Typ { value_to_fields; _ }) = typ in
       Fn.compose fst value_to_fields
   end
-
-  let option lab =
-    Option.value_map ~default:(Or_error.error_string lab) ~f:(fun x -> Ok x)
 
   module type Ledger_hash_intf = sig
     type t
@@ -626,15 +621,15 @@ module Make_str (A : Wire_types.Concrete) = struct
     in
     let connecting_ledger_left = s1.connecting_ledger_left in
     let connecting_ledger_right = s2.connecting_ledger_right in
-    let%map supply_increase =
-      Currency.Amount.Signed.add s1.supply_increase s2.supply_increase
-      |> option "Error adding supply_increase"
+    (*The total currency is a register: [s1] must end where [s2] begins.*)
+    let%map () =
+      or_error_of_bool ~error:"Total currency is not connected"
+        (Currency.Amount.equal s1.target.total_currency s2.source.total_currency)
     in
     ( { source = s1.source
       ; target = s2.target
       ; connecting_ledger_left
       ; connecting_ledger_right
-      ; supply_increase
       ; sok_digest = ()
       }
       : t )
@@ -647,13 +642,11 @@ module Make_str (A : Wire_types.Concrete) = struct
     let%map source = Registers.gen
     and target = Registers.gen
     and connecting_ledger_left = Frozen_ledger_hash.gen
-    and connecting_ledger_right = Frozen_ledger_hash.gen
-    and supply_increase = Currency.Amount.Signed.gen in
+    and connecting_ledger_right = Frozen_ledger_hash.gen in
     ( { source
       ; target
       ; connecting_ledger_left
       ; connecting_ledger_right
-      ; supply_increase
       ; sok_digest = ()
       }
       : t )

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -17,14 +17,14 @@ module Make_sig (A : Wire_types.Types.S) = struct
                 , 'fee_excess
                 , 'sok_digest
                 , 'local_state )
-                Poly.Stable.V2.t =
+                Poly.Stable.V3.t =
         ( 'ledger_hash
         , 'amount
         , 'pending_coinbase
         , 'fee_excess
         , 'sok_digest
         , 'local_state )
-        A.Poly.V2.t
+        A.Poly.V3.t
        and type Stable.V3.t = A.V3.t
        and type With_sok.Stable.V3.t = A.With_sok.V3.t
 end
@@ -103,7 +103,7 @@ module Make_str (A : Wire_types.Concrete) = struct
   module Poly = struct
     [%%versioned
     module Stable = struct
-      module V2 = struct
+      module V3 = struct
         type ( 'ledger_hash
              , 'amount
              , 'pending_coinbase
@@ -117,34 +117,34 @@ module Make_str (A : Wire_types.Concrete) = struct
               , 'fee_excess
               , 'sok_digest
               , 'local_state )
-              A.Poly.V2.t =
+              A.Poly.V3.t =
           { source :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Registers.Stable.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Registers.Stable.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Registers.Stable.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Registers.Stable.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
-          ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
         [@@deriving compare, equal, hash, sexp, yojson, hlist]
       end
     end]
 
-    let with_empty_local_state ~supply_increase ~fee_excess ~sok_digest
-        ~source_first_pass_ledger ~target_first_pass_ledger
-        ~source_second_pass_ledger ~target_second_pass_ledger
-        ~connecting_ledger_left ~connecting_ledger_right
-        ~pending_coinbase_stack_state : _ t =
+    let with_empty_local_state ~supply_increase ~source_fee_excess
+        ~target_fee_excess ~sok_digest ~source_first_pass_ledger
+        ~target_first_pass_ledger ~source_second_pass_ledger
+        ~target_second_pass_ledger ~connecting_ledger_left
+        ~connecting_ledger_right ~pending_coinbase_stack_state : _ t =
       { supply_increase
-      ; fee_excess
       ; sok_digest
       ; connecting_ledger_left
       ; connecting_ledger_right
@@ -154,33 +154,34 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; pending_coinbase_stack =
               pending_coinbase_stack_state.Pending_coinbase_stack_state.source
           ; local_state = Local_state.empty ()
+          ; fee_excess = source_fee_excess
           }
       ; target =
           { first_pass_ledger = target_first_pass_ledger
           ; second_pass_ledger = target_second_pass_ledger
           ; pending_coinbase_stack = pending_coinbase_stack_state.target
           ; local_state = Local_state.empty ()
+          ; fee_excess = target_fee_excess
           }
       }
 
     let typ ledger_hash amount pending_coinbase fee_excess sok_digest
         local_state_typ =
       let registers =
-        let open Registers in
+        (* NB: [Registers]'s field accessors would shadow [fee_excess] here, so
+           the hlist functions are named explicitly rather than opened. *)
         Tick.Typ.of_hlistable
-          [ ledger_hash; ledger_hash; pending_coinbase; local_state_typ ]
-          ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
-          ~value_of_hlist:of_hlist
+          [ ledger_hash
+          ; ledger_hash
+          ; pending_coinbase
+          ; local_state_typ
+          ; fee_excess
+          ]
+          ~var_to_hlist:Registers.to_hlist ~var_of_hlist:Registers.of_hlist
+          ~value_to_hlist:Registers.to_hlist ~value_of_hlist:Registers.of_hlist
       in
       Tick.Typ.of_hlistable
-        [ registers
-        ; registers
-        ; ledger_hash
-        ; ledger_hash
-        ; amount
-        ; fee_excess
-        ; sok_digest
-        ]
+        [ registers; registers; ledger_hash; ledger_hash; amount; sok_digest ]
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
         ~value_of_hlist:of_hlist
 
@@ -197,7 +198,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         , Fee_excess.Stable.V2.t
         , unit
         , Local_state.Stable.V1.t )
-        Poly.Stable.V2.t
+        Poly.Stable.V3.t
       [@@deriving compare, equal, hash, sexp, yojson]
 
       let to_latest = Fn.id
@@ -232,6 +233,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           Pending_coinbase.Stack.to_yojson t.pending_coinbase_stack
           |> Yojson.Safe.to_string
       ; local_state = Local_state.display t.local_state
+      ; fee_excess = Fee_excess.to_yojson t.fee_excess |> Yojson.Safe.to_string
       }
     in
     { Poly.source = display_register t.source
@@ -241,7 +243,6 @@ module Make_str (A : Wire_types.Concrete) = struct
     ; supply_increase =
         Currency.Amount.Signed.to_yojson t.supply_increase
         |> Yojson.Safe.to_string
-    ; fee_excess = Fee_excess.to_yojson t.fee_excess |> Yojson.Safe.to_string
     ; sok_digest = ()
     }
 
@@ -251,6 +252,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       ; second_pass_ledger = genesis_ledger_hash
       ; pending_coinbase_stack = Pending_coinbase.Stack.empty
       ; local_state = Local_state.dummy ()
+      ; fee_excess = Fee_excess.empty
       }
     in
     { source = registers
@@ -258,7 +260,6 @@ module Make_str (A : Wire_types.Concrete) = struct
     ; connecting_ledger_left = genesis_ledger_hash
     ; connecting_ledger_right = genesis_ledger_hash
     ; supply_increase = Currency.Amount.Signed.zero
-    ; fee_excess = Fee_excess.empty
     ; sok_digest = ()
     }
 
@@ -268,7 +269,6 @@ module Make_str (A : Wire_types.Concrete) = struct
        ; connecting_ledger_left
        ; connecting_ledger_right
        ; supply_increase
-       ; fee_excess
        ; sok_digest = _
        } :
         t ) =
@@ -279,7 +279,6 @@ module Make_str (A : Wire_types.Concrete) = struct
          ; Frozen_ledger_hash.to_input connecting_ledger_left
          ; Frozen_ledger_hash.to_input connecting_ledger_right
          ; Amount.Signed.to_input supply_increase
-         ; Fee_excess.to_input fee_excess
         |]
     in
     if !top_hash_logging_enabled then
@@ -300,15 +299,13 @@ module Make_str (A : Wire_types.Concrete) = struct
          ; connecting_ledger_left
          ; connecting_ledger_right
          ; supply_increase
-         ; fee_excess
          ; sok_digest = _
          } :
           t ) =
       let open Tick in
       let open Checked.Let_syntax in
-      let%bind fee_excess = Fee_excess.to_input_checked fee_excess in
-      let source = Registers.Checked.to_input source
-      and target = Registers.Checked.to_input target in
+      let%bind source = Registers.Checked.to_input source in
+      let%bind target = Registers.Checked.to_input target in
       let%bind supply_increase =
         Amount.Signed.Checked.to_input supply_increase
       in
@@ -319,7 +316,6 @@ module Make_str (A : Wire_types.Concrete) = struct
            ; Frozen_ledger_hash.var_to_input connecting_ledger_left
            ; Frozen_ledger_hash.var_to_input connecting_ledger_right
            ; supply_increase
-           ; fee_excess
           |]
       in
       let%map () =
@@ -351,7 +347,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           , Fee_excess.Stable.V2.t
           , Sok_message.Digest.Stable.V1.t
           , Local_state.Stable.V1.t )
-          Poly.Stable.V2.t
+          Poly.Stable.V3.t
         [@@deriving compare, equal, hash, sexp, yojson]
 
         let to_latest = Fn.id
@@ -622,10 +618,15 @@ module Make_str (A : Wire_types.Concrete) = struct
            { s1.target.local_state with ledger = Ledger_hash.empty_hash }
            { s2.source.local_state with ledger = Ledger_hash.empty_hash } )
     in
+    (*The fee excess is a register: rather than summing the two excesses, the
+       excess that [s1] ends with must be the one that [s2] starts from.*)
+    let%bind () =
+      or_error_of_bool ~error:"Fee excesses are not connected"
+        (Fee_excess.equal s1.target.fee_excess s2.source.fee_excess)
+    in
     let connecting_ledger_left = s1.connecting_ledger_left in
     let connecting_ledger_right = s2.connecting_ledger_right in
-    let%map fee_excess = Fee_excess.combine s1.fee_excess s2.fee_excess
-    and supply_increase =
+    let%map supply_increase =
       Currency.Amount.Signed.add s1.supply_increase s2.supply_increase
       |> option "Error adding supply_increase"
     in
@@ -633,7 +634,6 @@ module Make_str (A : Wire_types.Concrete) = struct
       ; target = s2.target
       ; connecting_ledger_left
       ; connecting_ledger_right
-      ; fee_excess
       ; supply_increase
       ; sok_digest = ()
       }
@@ -648,13 +648,11 @@ module Make_str (A : Wire_types.Concrete) = struct
     and target = Registers.gen
     and connecting_ledger_left = Frozen_ledger_hash.gen
     and connecting_ledger_right = Frozen_ledger_hash.gen
-    and fee_excess = Fee_excess.gen
     and supply_increase = Currency.Amount.Signed.gen in
     ( { source
       ; target
       ; connecting_ledger_left
       ; connecting_ledger_right
-      ; fee_excess
       ; supply_increase
       ; sok_digest = ()
       }

--- a/src/lib/mina_state/snarked_ledger_state.mli
+++ b/src/lib/mina_state/snarked_ledger_state.mli
@@ -6,11 +6,11 @@ include
               , 'fee_excess
               , 'sok_digest
               , 'local_state )
-              Poly.Stable.V2.t =
+              Poly.Stable.V3.t =
       ( 'ledger_hash
       , 'amount
       , 'pending_coinbase
       , 'fee_excess
       , 'sok_digest
       , 'local_state )
-      Mina_wire_types.Mina_state.Snarked_ledger_state.Poly.V2.t
+      Mina_wire_types.Mina_state.Snarked_ledger_state.Poly.V3.t

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -75,17 +75,18 @@ module type Full = sig
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Registers.Stable.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Registers.Stable.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
-          ; supply_increase : 'amount
           ; sok_digest : 'sok_digest
           }
         [@@deriving compare, equal, hash, sexp, yojson]
@@ -93,7 +94,8 @@ module type Full = sig
     end]
 
     val with_empty_local_state :
-         supply_increase:'amount
+         source_total_currency:'amount
+      -> target_total_currency:'amount
       -> source_fee_excess:'fee_excess
       -> target_fee_excess:'fee_excess
       -> sok_digest:'sok_digest
@@ -167,7 +169,7 @@ module type Full = sig
     module V3 : sig
       type t =
         ( Frozen_ledger_hash.Stable.V1.t
-        , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+        , Amount.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V2.t
         , unit
@@ -179,7 +181,7 @@ module type Full = sig
 
   type var =
     ( Frozen_ledger_hash.var
-    , Currency.Amount.Signed.var
+    , Currency.Amount.var
     , Pending_coinbase.Stack.var
     , Fee_excess.var
     , unit
@@ -193,7 +195,10 @@ module type Full = sig
 
   val display : Stable.Latest.t -> display
 
-  val genesis : genesis_ledger_hash:Frozen_ledger_hash.t -> t
+  val genesis :
+       genesis_ledger_hash:Frozen_ledger_hash.t
+    -> genesis_total_currency:Currency.Amount.t
+    -> t
 
   val to_input : t -> Tick.Field.t Random_oracle.Input.Chunked.t
 
@@ -215,7 +220,7 @@ module type Full = sig
       module V3 : sig
         type t =
           ( Frozen_ledger_hash.Stable.V1.t
-          , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
+          , Amount.Stable.V1.t
           , Pending_coinbase.Stack_versioned.Stable.V1.t
           , Fee_excess.Stable.V2.t
           , Sok_message.Digest.Stable.V1.t
@@ -230,11 +235,14 @@ module type Full = sig
 
     val display : Stable.Latest.t -> display
 
-    val genesis : genesis_ledger_hash:Frozen_ledger_hash.t -> t
+    val genesis :
+         genesis_ledger_hash:Frozen_ledger_hash.t
+      -> genesis_total_currency:Currency.Amount.t
+      -> t
 
     type var =
       ( Frozen_ledger_hash.var
-      , Amount.Signed.var
+      , Amount.var
       , Pending_coinbase.Stack.var
       , Fee_excess.var
       , Sok_message.Digest.Checked.t

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -63,7 +63,7 @@ module type Full = sig
   module Poly : sig
     [%%versioned:
     module Stable : sig
-      module V2 : sig
+      module V3 : sig
         type ( 'ledger_hash
              , 'amount
              , 'pending_coinbase
@@ -74,17 +74,18 @@ module type Full = sig
           { source :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Registers.Stable.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Registers.Stable.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Registers.Stable.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Registers.Stable.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
-          ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
         [@@deriving compare, equal, hash, sexp, yojson]
@@ -93,7 +94,8 @@ module type Full = sig
 
     val with_empty_local_state :
          supply_increase:'amount
-      -> fee_excess:'fee_excess
+      -> source_fee_excess:'fee_excess
+      -> target_fee_excess:'fee_excess
       -> sok_digest:'sok_digest
       -> source_first_pass_ledger:'ledger_hash
       -> target_first_pass_ledger:'ledger_hash
@@ -170,7 +172,7 @@ module type Full = sig
         , Fee_excess.Stable.V2.t
         , unit
         , Local_state.Stable.V1.t )
-        Poly.Stable.V2.t
+        Poly.Stable.V3.t
       [@@deriving compare, equal, hash, sexp, yojson]
     end
   end]
@@ -218,7 +220,7 @@ module type Full = sig
           , Fee_excess.Stable.V2.t
           , Sok_message.Digest.Stable.V1.t
           , Local_state.Stable.V1.t )
-          Poly.Stable.V2.t
+          Poly.Stable.V3.t
         [@@deriving compare, equal, hash, sexp, yojson]
       end
     end]

--- a/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
@@ -19,7 +19,7 @@ module Poly = struct
           , 'fee_excess
           , 'sok_digest
           , 'local_state )
-          Mina_state_snarked_ledger_state.Poly.V2.t
+          Mina_state_snarked_ledger_state.Poly.V3.t
       ; timestamp : 'time
       ; body_reference : 'body_reference
       }

--- a/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
@@ -34,7 +34,7 @@ module Value = struct
       , Mina_state_local_state.V1.t
       , Block_time.V1.t
       , Consensus.Body_reference.V1.t
-      , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+      , Currency.Amount.V1.t
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V2.t
       , unit )

--- a/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
@@ -1,9 +1,10 @@
 module V2 = struct
-  type ('ledger, 'pending_coinbase_stack, 'local_state, 'fee_excess) t =
+  type ('ledger, 'pending_coinbase_stack, 'local_state, 'fee_excess, 'amount) t =
     { first_pass_ledger : 'ledger
     ; second_pass_ledger : 'ledger
     ; pending_coinbase_stack : 'pending_coinbase_stack
     ; local_state : 'local_state
     ; fee_excess : 'fee_excess
+    ; total_currency : 'amount
     }
 end

--- a/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
@@ -1,8 +1,9 @@
-module V1 = struct
-  type ('ledger, 'pending_coinbase_stack, 'local_state) t =
+module V2 = struct
+  type ('ledger, 'pending_coinbase_stack, 'local_state, 'fee_excess) t =
     { first_pass_ledger : 'ledger
     ; second_pass_ledger : 'ledger
     ; pending_coinbase_stack : 'pending_coinbase_stack
     ; local_state : 'local_state
+    ; fee_excess : 'fee_excess
     }
 end

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
@@ -15,17 +15,18 @@ module Types = struct
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Mina_state_registers.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Mina_state_registers.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
-          ; supply_increase : 'amount
           ; sok_digest : 'sok_digest
           }
       end
@@ -34,7 +35,7 @@ module Types = struct
     module V3 : sig
       type t =
         ( Mina_base.Frozen_ledger_hash.V1.t
-        , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+        , Currency.Amount.V1.t
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V2.t
         , unit
@@ -46,7 +47,7 @@ module Types = struct
       module V3 : sig
         type t =
           ( Mina_base.Ledger_hash.V1.t
-          , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+          , Currency.Amount.V1.t
           , Mina_base.Pending_coinbase.Stack_versioned.V1.t
           , Mina_base.Fee_excess.V2.t
           , Mina_base.Sok_message.Digest.V1.t
@@ -71,17 +72,18 @@ module type Concrete = sig
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
-        ; supply_increase : 'amount
         ; sok_digest : 'sok_digest
         }
     end
@@ -90,7 +92,7 @@ module type Concrete = sig
   module V3 : sig
     type t =
       ( Mina_base.Frozen_ledger_hash.V1.t
-      , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+      , Currency.Amount.V1.t
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V2.t
       , unit
@@ -102,7 +104,7 @@ module type Concrete = sig
     module V3 : sig
       type t =
         ( Mina_base.Ledger_hash.V1.t
-        , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+        , Currency.Amount.V1.t
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t
@@ -126,17 +128,18 @@ module M = struct
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
-        ; supply_increase : 'amount
         ; sok_digest : 'sok_digest
         }
     end
@@ -145,7 +148,7 @@ module M = struct
   module V3 = struct
     type t =
       ( Mina_base.Frozen_ledger_hash.V1.t
-      , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+      , Currency.Amount.V1.t
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V2.t
       , unit
@@ -157,7 +160,7 @@ module M = struct
     module V3 = struct
       type t =
         ( Mina_base.Ledger_hash.V1.t
-        , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+        , Currency.Amount.V1.t
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
@@ -3,7 +3,7 @@ open Utils
 module Types = struct
   module type S = sig
     module Poly : sig
-      module V2 : sig
+      module V3 : sig
         type ( 'ledger_hash
              , 'amount
              , 'pending_coinbase
@@ -14,17 +14,18 @@ module Types = struct
           { source :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Mina_state_registers.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Mina_state_registers.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Mina_state_registers.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Mina_state_registers.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
-          ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
       end
@@ -38,7 +39,7 @@ module Types = struct
         , Mina_base.Fee_excess.V2.t
         , unit
         , Mina_state_local_state.V1.t )
-        Poly.V2.t
+        Poly.V3.t
     end
 
     module With_sok : sig
@@ -50,7 +51,7 @@ module Types = struct
           , Mina_base.Fee_excess.V2.t
           , Mina_base.Sok_message.Digest.V1.t
           , Mina_state_local_state.V1.t )
-          Poly.V2.t
+          Poly.V3.t
       end
     end
   end
@@ -58,7 +59,7 @@ end
 
 module type Concrete = sig
   module Poly : sig
-    module V2 : sig
+    module V3 : sig
       type ( 'ledger_hash
            , 'amount
            , 'pending_coinbase
@@ -69,17 +70,18 @@ module type Concrete = sig
         { source :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
-        ; fee_excess : 'fee_excess
         ; sok_digest : 'sok_digest
         }
     end
@@ -93,7 +95,7 @@ module type Concrete = sig
       , Mina_base.Fee_excess.V2.t
       , unit
       , Mina_state_local_state.V1.t )
-      Poly.V2.t
+      Poly.V3.t
   end
 
   module With_sok : sig
@@ -105,14 +107,14 @@ module type Concrete = sig
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t
         , Mina_state_local_state.V1.t )
-        Poly.V2.t
+        Poly.V3.t
     end
   end
 end
 
 module M = struct
   module Poly = struct
-    module V2 = struct
+    module V3 = struct
       type ( 'ledger_hash
            , 'amount
            , 'pending_coinbase
@@ -123,17 +125,18 @@ module M = struct
         { source :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
-        ; fee_excess : 'fee_excess
         ; sok_digest : 'sok_digest
         }
     end
@@ -147,7 +150,7 @@ module M = struct
       , Mina_base.Fee_excess.V2.t
       , unit
       , Mina_state_local_state.V1.t )
-      Poly.V2.t
+      Poly.V3.t
   end
 
   module With_sok = struct
@@ -159,7 +162,7 @@ module M = struct
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t
         , Mina_state_local_state.V1.t )
-        Poly.V2.t
+        Poly.V3.t
     end
   end
 end

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
@@ -15,17 +15,18 @@ module Types : sig
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Mina_state_registers.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
               , 'local_state
-              , 'fee_excess )
+              , 'fee_excess
+              , 'amount )
               Mina_state_registers.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
-          ; supply_increase : 'amount
           ; sok_digest : 'sok_digest
           }
       end
@@ -34,7 +35,7 @@ module Types : sig
     module V3 : sig
       type t =
         ( Mina_base.Frozen_ledger_hash.V1.t
-        , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+        , Currency.Amount.V1.t
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V2.t
         , unit
@@ -46,7 +47,7 @@ module Types : sig
       module V3 : sig
         type t =
           ( Mina_base.Ledger_hash.V1.t
-          , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+          , Currency.Amount.V1.t
           , Mina_base.Pending_coinbase.Stack_versioned.V1.t
           , Mina_base.Fee_excess.V2.t
           , Mina_base.Sok_message.Digest.V1.t
@@ -71,17 +72,18 @@ module type Concrete = sig
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
             , 'local_state
-            , 'fee_excess )
+            , 'fee_excess
+            , 'amount )
             Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
-        ; supply_increase : 'amount
         ; sok_digest : 'sok_digest
         }
     end
@@ -90,7 +92,7 @@ module type Concrete = sig
   module V3 : sig
     type t =
       ( Mina_base.Frozen_ledger_hash.V1.t
-      , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+      , Currency.Amount.V1.t
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V2.t
       , unit
@@ -102,7 +104,7 @@ module type Concrete = sig
     module V3 : sig
       type t =
         ( Mina_base.Ledger_hash.V1.t
-        , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
+        , Currency.Amount.V1.t
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
@@ -3,7 +3,7 @@ open Utils
 module Types : sig
   module type S = sig
     module Poly : sig
-      module V2 : sig
+      module V3 : sig
         type ( 'ledger_hash
              , 'amount
              , 'pending_coinbase
@@ -14,17 +14,18 @@ module Types : sig
           { source :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Mina_state_registers.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Mina_state_registers.V2.t
           ; target :
               ( 'ledger_hash
               , 'pending_coinbase
-              , 'local_state )
-              Mina_state_registers.V1.t
+              , 'local_state
+              , 'fee_excess )
+              Mina_state_registers.V2.t
           ; connecting_ledger_left : 'ledger_hash
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
-          ; fee_excess : 'fee_excess
           ; sok_digest : 'sok_digest
           }
       end
@@ -38,7 +39,7 @@ module Types : sig
         , Mina_base.Fee_excess.V2.t
         , unit
         , Mina_state_local_state.V1.t )
-        Poly.V2.t
+        Poly.V3.t
     end
 
     module With_sok : sig
@@ -50,7 +51,7 @@ module Types : sig
           , Mina_base.Fee_excess.V2.t
           , Mina_base.Sok_message.Digest.V1.t
           , Mina_state_local_state.V1.t )
-          Poly.V2.t
+          Poly.V3.t
       end
     end
   end
@@ -58,7 +59,7 @@ end
 
 module type Concrete = sig
   module Poly : sig
-    module V2 : sig
+    module V3 : sig
       type ( 'ledger_hash
            , 'amount
            , 'pending_coinbase
@@ -69,17 +70,18 @@ module type Concrete = sig
         { source :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; target :
             ( 'ledger_hash
             , 'pending_coinbase
-            , 'local_state )
-            Mina_state_registers.V1.t
+            , 'local_state
+            , 'fee_excess )
+            Mina_state_registers.V2.t
         ; connecting_ledger_left : 'ledger_hash
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
-        ; fee_excess : 'fee_excess
         ; sok_digest : 'sok_digest
         }
     end
@@ -93,7 +95,7 @@ module type Concrete = sig
       , Mina_base.Fee_excess.V2.t
       , unit
       , Mina_state_local_state.V1.t )
-      Poly.V2.t
+      Poly.V3.t
   end
 
   module With_sok : sig
@@ -105,7 +107,7 @@ module type Concrete = sig
         , Mina_base.Fee_excess.V2.t
         , Mina_base.Sok_message.Digest.V1.t
         , Mina_state_local_state.V1.t )
-        Poly.V2.t
+        Poly.V3.t
     end
   end
 end

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -67,6 +67,11 @@ module Assert_equal4V1
     (W : V1S4 with type ('a, 'b, 'c, 'd) V1.t = ('a, 'b, 'c, 'd) O.V1.t) =
 struct end
 
+module Assert_equal4V2
+    (O : V2S4)
+    (W : V2S4 with type ('a, 'b, 'c, 'd) V2.t = ('a, 'b, 'c, 'd) O.V2.t) =
+struct end
+
 module Assert_equal8V1
     (O : V1S8)
     (W :
@@ -324,7 +329,7 @@ end
 module Mina_state = struct
   module O = Mina_state
   module W = WT.Mina_state
-  include Assert_equal3V1 (O.Registers.Stable) (W.Registers)
+  include Assert_equal4V2 (O.Registers.Stable) (W.Registers)
   include Assert_equal0V1 (O.Local_state.Stable) (W.Local_state)
   include
     Assert_equal0V3 (O.Blockchain_state.Value.Stable) (W.Blockchain_state.Value)

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -72,6 +72,11 @@ module Assert_equal4V2
     (W : V2S4 with type ('a, 'b, 'c, 'd) V2.t = ('a, 'b, 'c, 'd) O.V2.t) =
 struct end
 
+module Assert_equal5V2
+    (O : V2S5)
+    (W : V2S5 with type ('a, 'b, 'c, 'd, 'e) V2.t = ('a, 'b, 'c, 'd, 'e) O.V2.t) =
+struct end
+
 module Assert_equal8V1
     (O : V1S8)
     (W :
@@ -329,7 +334,7 @@ end
 module Mina_state = struct
   module O = Mina_state
   module W = WT.Mina_state
-  include Assert_equal4V2 (O.Registers.Stable) (W.Registers)
+  include Assert_equal5V2 (O.Registers.Stable) (W.Registers)
   include Assert_equal0V1 (O.Local_state.Stable) (W.Local_state)
   include
     Assert_equal0V3 (O.Blockchain_state.Value.Stable) (W.Blockchain_state.Value)

--- a/src/lib/mina_wire_types/utils.ml
+++ b/src/lib/mina_wire_types/utils.ml
@@ -32,6 +32,10 @@ module type S4 = sig
   type ('a, 'b, 'c, 'd) t
 end
 
+module type S5 = sig
+  type ('a, 'b, 'c, 'd, 'e) t
+end
+
 module type S8 = sig
   type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) t
 end
@@ -80,6 +84,10 @@ end
 
 module type V2S4 = sig
   module V2 : S4
+end
+
+module type V2S5 = sig
+  module V2 : S5
 end
 
 module type V3S0 = sig

--- a/src/lib/mina_wire_types/utils.ml
+++ b/src/lib/mina_wire_types/utils.ml
@@ -78,6 +78,10 @@ module type V2S3 = sig
   module V2 : S3
 end
 
+module type V2S4 = sig
+  module V2 : S4
+end
+
 module type V3S0 = sig
   module V3 : S0
 end

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -140,6 +140,7 @@ module Transaction_key = struct
         ~global_slot:Mina_numbers.Global_slot_since_genesis.zero
         ~state_body:Transaction_snark_tests.Util.genesis_state_body
         ~fee_excess:Currency.Amount.Signed.zero
+        ~total_currency:Currency.Amount.zero
         [ ( `Pending_coinbase_init_stack Pending_coinbase.Stack.empty
           , `Pending_coinbase_of_statement
               { Transaction_snark.Pending_coinbase_stack_state.source =
@@ -600,6 +601,7 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                      ; pending_coinbase_stack = coinbase_stack_source
                      ; local_state = Mina_state.Local_state.empty ()
                      ; fee_excess = Fee_excess.zero
+                     ; total_currency = Currency.Amount.zero
                      }
                  ; target =
                      { first_pass_ledger = target_hash
@@ -610,16 +612,12 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                      ; local_state = Mina_state.Local_state.empty ()
                      ; fee_excess =
                          Transaction.fee_excess txn |> Or_error.ok_exn
+                     ; total_currency =
+                         Transaction.expected_supply_increase txn
+                         |> Or_error.ok_exn
                      }
                  ; connecting_ledger_left = target_hash
                  ; connecting_ledger_right = target_hash
-                 ; supply_increase =
-                     (let magnitude =
-                        Transaction.expected_supply_increase txn
-                        |> Or_error.ok_exn
-                      in
-                      let sgn = Sgn.Pos in
-                      Currency.Amount.Signed.create ~magnitude ~sgn )
                  }
                ~init_stack:coinbase_stack_source
                { Transaction_protocol_state.Poly.transaction = valid_txn

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -599,6 +599,7 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                      ; second_pass_ledger = target_hash
                      ; pending_coinbase_stack = coinbase_stack_source
                      ; local_state = Mina_state.Local_state.empty ()
+                     ; fee_excess = Fee_excess.zero
                      }
                  ; target =
                      { first_pass_ledger = target_hash
@@ -607,6 +608,8 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                          coinbase_stack_target ~genesis_constants
                            ~constraint_constants
                      ; local_state = Mina_state.Local_state.empty ()
+                     ; fee_excess =
+                         Transaction.fee_excess txn |> Or_error.ok_exn
                      }
                  ; connecting_ledger_left = target_hash
                  ; connecting_ledger_right = target_hash
@@ -617,7 +620,6 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                       in
                       let sgn = Sgn.Pos in
                       Currency.Amount.Signed.create ~magnitude ~sgn )
-                 ; fee_excess = Transaction.fee_excess txn |> Or_error.ok_exn
                  }
                ~init_stack:coinbase_stack_source
                { Transaction_protocol_state.Poly.transaction = valid_txn

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -25,7 +25,8 @@ module Pre_statement = struct
     { partially_applied_transaction : Ledger.Transaction_partially_applied.t
     ; expected_status : Transaction_status.t
     ; accounts_accessed : Account_id.t list
-    ; fee_excess : Fee_excess.t
+    ; source_fee_excess : Fee_excess.t
+    ; target_fee_excess : Fee_excess.t
     ; first_pass_ledger_witness : Sparse_ledger.t
     ; first_pass_ledger_source_hash : Ledger_hash.t
     ; first_pass_ledger_target_hash : Ledger_hash.t
@@ -338,6 +339,7 @@ module T = struct
       ; second_pass_ledger = second_pass_ledger_end
       ; local_state = Mina_state.Local_state.empty ()
       ; pending_coinbase_stack
+      ; fee_excess = Fee_excess.zero
       }
     in
     let statement_check = `Partial in
@@ -370,6 +372,7 @@ module T = struct
         ~last_proof_statement
         ~registers_end:
           { local_state = Mina_state.Local_state.empty ()
+          ; fee_excess = Fee_excess.zero
           ; first_pass_ledger = first_pass_ledger_target
           ; second_pass_ledger =
               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
@@ -396,6 +399,7 @@ module T = struct
         ~last_proof_statement
         ~registers_end:
           { local_state = Mina_state.Local_state.empty ()
+          ; fee_excess = Fee_excess.zero
           ; first_pass_ledger = first_pass_ledger_target
           ; second_pass_ledger =
               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
@@ -549,7 +553,7 @@ module T = struct
     else Some constraint_constants.coinbase_amount
 
   let apply_single_transaction_first_pass ~constraint_constants ~global_slot
-      ~signature_kind ledger
+      ~signature_kind ~(source_fee_excess : Fee_excess.t) ledger
       (pending_coinbase_stack_state : Stack_state_with_init_stack.t)
       txn_with_status (txn_state_view : Zkapp_precondition.Protocol_state.View.t)
       :
@@ -563,6 +567,12 @@ module T = struct
     let accounts_accessed = Transaction.accounts_referenced txn in
     let%bind fee_excess =
       to_staged_ledger_or_error (Transaction.fee_excess txn)
+    in
+    (*The fee excess is a register threaded through the base statements, so this
+      transaction's fees accumulate into the excess it starts from.*)
+    let%bind target_fee_excess =
+      to_staged_ledger_or_error
+        (Fee_excess.combine source_fee_excess fee_excess)
     in
     let source_ledger_hash = Ledger.merkle_root ledger in
     let ledger_witness =
@@ -584,7 +594,8 @@ module T = struct
     ( { Pre_statement.partially_applied_transaction
       ; expected_status
       ; accounts_accessed
-      ; fee_excess
+      ; source_fee_excess
+      ; target_fee_excess
       ; first_pass_ledger_witness = ledger_witness
       ; first_pass_ledger_source_hash = source_ledger_hash
       ; first_pass_ledger_target_hash = target_ledger_hash
@@ -635,21 +646,22 @@ module T = struct
              (txn_with_expected_status, actual_status) )
     in
     let statement =
-      { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V2.source =
+      { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V3.source =
           { first_pass_ledger = pre_stmt.first_pass_ledger_source_hash
           ; second_pass_ledger = second_pass_ledger_source_hash
           ; pending_coinbase_stack = pre_stmt.pending_coinbase_stack_source
           ; local_state = empty_local_state
+          ; fee_excess = pre_stmt.source_fee_excess
           }
       ; target =
           { first_pass_ledger = pre_stmt.first_pass_ledger_target_hash
           ; second_pass_ledger = second_pass_ledger_target_hash
           ; pending_coinbase_stack = pre_stmt.pending_coinbase_stack_target
           ; local_state = empty_local_state
+          ; fee_excess = pre_stmt.target_fee_excess
           }
       ; connecting_ledger_left = connecting_ledger
       ; connecting_ledger_right = connecting_ledger
-      ; fee_excess = pre_stmt.fee_excess
       ; supply_increase
       ; sok_digest = ()
       }
@@ -666,10 +678,10 @@ module T = struct
     , Mina_transaction_logic.Transaction_applied.new_accounts applied_txn )
 
   let apply_transactions_first_pass ~yield ~constraint_constants ~global_slot
-      ~signature_kind ledger init_pending_coinbase_stack_state ts
-      current_state_view =
+      ~signature_kind ~init_fee_excess ledger init_pending_coinbase_stack_state
+      ts current_state_view =
     let open Deferred.Result.Let_syntax in
-    let apply pending_coinbase_stack_state txn =
+    let apply ~source_fee_excess pending_coinbase_stack_state txn =
       match
         List.find (Transaction.public_keys txn.With_status.data) ~f:(fun pk ->
             Option.is_none (Signature_lib.Public_key.decompress pk) )
@@ -678,18 +690,21 @@ module T = struct
           Error (Staged_ledger_error.Invalid_public_key pk)
       | None ->
           apply_single_transaction_first_pass ~constraint_constants ~global_slot
-            ~signature_kind ledger pending_coinbase_stack_state txn
-            current_state_view
+            ~signature_kind ~source_fee_excess ledger
+            pending_coinbase_stack_state txn current_state_view
     in
-    let%map res_rev, pending_coinbase_stack_state =
+    let%map res_rev, pending_coinbase_stack_state, _fee_excess =
       Mina_stdlib.Deferred.Result.List.fold ts
-        ~init:([], init_pending_coinbase_stack_state)
-        ~f:(fun (acc, pending_coinbase_stack_state) t ->
+        ~init:([], init_pending_coinbase_stack_state, init_fee_excess)
+        ~f:(fun (acc, pending_coinbase_stack_state, source_fee_excess) t ->
           let%bind pre_witness, pending_coinbase_stack_state' =
-            Deferred.return (apply pending_coinbase_stack_state t)
+            Deferred.return
+              (apply ~source_fee_excess pending_coinbase_stack_state t)
           in
           let%map () = yield () in
-          (pre_witness :: acc, pending_coinbase_stack_state') )
+          ( pre_witness :: acc
+          , pending_coinbase_stack_state'
+          , pre_witness.Pre_statement.target_fee_excess ) )
     in
     (List.rev res_rev, pending_coinbase_stack_state.pc.target)
 
@@ -712,7 +727,7 @@ module T = struct
     let open Deferred.Result.Let_syntax in
     let state_body_hash = snd state_and_body_hash in
     let ts, ts_opt = tss in
-    let apply_first_pass working_stack ts =
+    let apply_first_pass ~init_fee_excess working_stack ts =
       let working_stack_with_state =
         push_state working_stack state_body_hash global_slot
       in
@@ -721,14 +736,24 @@ module T = struct
         ; init_stack = working_stack
         }
       in
-      apply_transactions_first_pass ~constraint_constants ~global_slot ledger
-        init_pending_coinbase_stack_state ts current_state_view
+      apply_transactions_first_pass ~constraint_constants ~global_slot
+        ~init_fee_excess ledger init_pending_coinbase_stack_state ts
+        current_state_view
+    in
+    (*The excess a partition ends with is the one the next partition starts
+      from. Both are zero in practice, since [check_zero_fee_excess] requires
+      each partition's transactions to settle their own fees, but the excess is
+      threaded rather than assumed.*)
+    let end_fee_excess pre_stmts ~default =
+      Option.value_map (List.last pre_stmts) ~default
+        ~f:(fun (p : Pre_statement.t) -> p.target_fee_excess )
     in
     let yield =
       yield_result_every ~n:transaction_application_scheduler_batch_size
     in
     let%bind pre_stmts1, updated_stack1 =
-      apply_first_pass ~yield ~signature_kind current_stack ts
+      apply_first_pass ~yield ~signature_kind ~init_fee_excess:Fee_excess.zero
+        current_stack ts
     in
     let%bind pre_stmts2, updated_stack2 =
       match ts_opt with
@@ -738,7 +763,10 @@ module T = struct
           let current_stack2 =
             Pending_coinbase.Stack.create_with current_stack
           in
-          apply_first_pass ~yield ~signature_kind current_stack2 ts
+          apply_first_pass ~yield ~signature_kind
+            ~init_fee_excess:
+              (end_fee_excess pre_stmts1 ~default:Fee_excess.zero)
+            current_stack2 ts
     in
     let first_pass_ledger_end = Ledger.merkle_root ledger in
     let%map txns_with_witnesses =
@@ -2678,11 +2706,14 @@ let%test_module "staged ledger tests" =
     (* Fee excess at top level ledger proofs should always be zero *)
     let assert_fee_excess : Ledger_proof.Cached.t option -> unit =
      fun proof_opt ->
-      let fee_excess =
-        Option.value_map ~default:Fee_excess.zero proof_opt ~f:(fun proof ->
-            (Ledger_proof.Cached.statement proof).fee_excess )
+      let source_fee_excess, target_fee_excess =
+        Option.value_map ~default:(Fee_excess.zero, Fee_excess.zero) proof_opt
+          ~f:(fun proof ->
+            let stmt = Ledger_proof.Cached.statement proof in
+            (stmt.source.fee_excess, stmt.target.fee_excess) )
       in
-      assert (Fee_excess.is_zero fee_excess)
+      assert (Fee_excess.is_zero source_fee_excess) ;
+      assert (Fee_excess.is_zero target_fee_excess)
 
     let transaction_capacity =
       Int.pow 2 constraint_constants.transaction_capacity_log_2

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -330,7 +330,7 @@ module T = struct
 
   let verify_scan_state_after_apply ~constraint_constants
       ~pending_coinbase_stack ~first_pass_ledger_end ~second_pass_ledger_end
-      (scan_state : Scan_state.t) =
+      ~total_currency_end (scan_state : Scan_state.t) =
     let error_prefix =
       "Error verifying the parallel scan state after applying the diff."
     in
@@ -340,6 +340,7 @@ module T = struct
       ; local_state = Mina_state.Local_state.empty ()
       ; pending_coinbase_stack
       ; fee_excess = Fee_excess.zero
+      ; total_currency = total_currency_end
       }
     in
     let statement_check = `Partial in
@@ -350,6 +351,22 @@ module T = struct
     Statement_scanner.check_invariants ~constraint_constants scan_state
       ~statement_check ~verifier:() ~error_prefix ~registers_end
       ~last_proof_statement
+
+  (*The scan state's end total currency: there is no independent source for it
+    outside the proofs themselves, so it is read back from the scan state. What
+    verifies it is the chaining between statements in [scan_statement] and, at
+    the block level, the blockchain snark tying the emitted proof's source to
+    the consensus total currency.*)
+  let scan_state_total_currency ~default scan_state =
+    match Scan_state.latest_target_registers scan_state with
+    | Some (r : Mina_state.Registers.Value.t) ->
+        r.total_currency
+    | None ->
+        (*An empty scan state has no statement to read the total currency from.
+          It also means there are no pending transactions, so the staged ledger
+          is the snarked ledger and the value consensus already carries is the
+          right one.*)
+        default
 
   let of_scan_state_and_ledger ~logger
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
@@ -373,6 +390,13 @@ module T = struct
         ~registers_end:
           { local_state = Mina_state.Local_state.empty ()
           ; fee_excess = Fee_excess.zero
+          ; total_currency =
+              scan_state_total_currency scan_state
+                ~default:
+                  (Option.value_map last_proof_statement
+                     ~default:Currency.Amount.zero
+                     ~f:(fun (stmt : Transaction_snark.Statement.t) ->
+                       stmt.target.total_currency ) )
           ; first_pass_ledger = first_pass_ledger_target
           ; second_pass_ledger =
               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
@@ -400,6 +424,13 @@ module T = struct
         ~registers_end:
           { local_state = Mina_state.Local_state.empty ()
           ; fee_excess = Fee_excess.zero
+          ; total_currency =
+              scan_state_total_currency scan_state
+                ~default:
+                  (Option.value_map last_proof_statement
+                     ~default:Currency.Amount.zero
+                     ~f:(fun (stmt : Transaction_snark.Statement.t) ->
+                       stmt.target.total_currency ) )
           ; first_pass_ledger = first_pass_ledger_target
           ; second_pass_ledger =
               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
@@ -610,7 +641,8 @@ module T = struct
 
   let apply_single_transaction_second_pass ~constraint_constants
       ~connecting_ledger ledger state_and_body_hash ~global_slot
-      (pre_stmt : Pre_statement.t) =
+      ~(source_total_currency : Currency.Amount.t) (pre_stmt : Pre_statement.t)
+      =
     let open Result.Let_syntax in
     let empty_local_state = Mina_state.Local_state.empty () in
     let second_pass_ledger_source_hash = Ledger.merkle_root ledger in
@@ -629,6 +661,19 @@ module T = struct
       to_staged_ledger_or_error
         (Mina_transaction_logic.Transaction_applied.supply_increase
            ~constraint_constants applied_txn )
+    in
+    (*The total currency is a register threaded through the base statements, so
+      this transaction's supply increase accumulates into the total it starts
+      from.*)
+    let%bind target_total_currency =
+      match
+        Currency.Amount.add_signed_flagged source_total_currency supply_increase
+      with
+      | total, `Overflow false ->
+          return total
+      | _, `Overflow true ->
+          to_staged_ledger_or_error
+            (Or_error.error_string "Total currency out of range")
     in
     let%map () =
       let actual_status = Ledger.status_of_applied applied_txn in
@@ -652,6 +697,7 @@ module T = struct
           ; pending_coinbase_stack = pre_stmt.pending_coinbase_stack_source
           ; local_state = empty_local_state
           ; fee_excess = pre_stmt.source_fee_excess
+          ; total_currency = source_total_currency
           }
       ; target =
           { first_pass_ledger = pre_stmt.first_pass_ledger_target_hash
@@ -659,10 +705,10 @@ module T = struct
           ; pending_coinbase_stack = pre_stmt.pending_coinbase_stack_target
           ; local_state = empty_local_state
           ; fee_excess = pre_stmt.target_fee_excess
+          ; total_currency = target_total_currency
           }
       ; connecting_ledger_left = connecting_ledger
       ; connecting_ledger_right = connecting_ledger
-      ; supply_increase
       ; sok_digest = ()
       }
     in
@@ -709,21 +755,31 @@ module T = struct
     (List.rev res_rev, pending_coinbase_stack_state.pc.target)
 
   let apply_transactions_second_pass ~constraint_constants ~yield ~global_slot
-      ledger state_and_body_hash pre_stmts =
+      ~init_total_currency ledger state_and_body_hash pre_stmts =
     let open Deferred.Result.Let_syntax in
     let connecting_ledger = Ledger.merkle_root ledger in
-    Mina_stdlib.Deferred.Result.List.map pre_stmts ~f:(fun pre_stmt ->
-        let%bind result =
-          apply_single_transaction_second_pass ~constraint_constants
-            ~connecting_ledger ~global_slot ledger state_and_body_hash pre_stmt
-          |> Deferred.return
-        in
-        let%map () = yield () in
-        result )
+    let%map res_rev, total_currency_end =
+      Mina_stdlib.Deferred.Result.List.fold pre_stmts
+        ~init:([], init_total_currency)
+        ~f:(fun (acc, source_total_currency) pre_stmt ->
+          let%bind result =
+            apply_single_transaction_second_pass ~constraint_constants
+              ~connecting_ledger ~global_slot ~source_total_currency ledger
+              state_and_body_hash pre_stmt
+            |> Deferred.return
+          in
+          let%map () = yield () in
+          let txn_with_witness, _ = result in
+          ( result :: acc
+          , txn_with_witness.Scan_state.Transaction_with_witness.statement
+              .target
+              .total_currency ) )
+    in
+    (List.rev res_rev, total_currency_end)
 
   let update_ledger_and_get_statements ~constraint_constants ~global_slot
-      ~signature_kind ledger current_stack tss current_state_view
-      state_and_body_hash =
+      ~signature_kind ~init_total_currency ledger current_stack tss
+      current_state_view state_and_body_hash =
     let open Deferred.Result.Let_syntax in
     let state_body_hash = snd state_and_body_hash in
     let ts, ts_opt = tss in
@@ -769,11 +825,15 @@ module T = struct
             current_stack2 ts
     in
     let first_pass_ledger_end = Ledger.merkle_root ledger in
-    let%map txns_with_witnesses =
+    let%map txns_with_witnesses, total_currency_end =
       apply_transactions_second_pass ~constraint_constants ~yield ~global_slot
-        ledger state_and_body_hash (pre_stmts1 @ pre_stmts2)
+        ~init_total_currency ledger state_and_body_hash (pre_stmts1 @ pre_stmts2)
     in
-    (txns_with_witnesses, updated_stack1, updated_stack2, first_pass_ledger_end)
+    ( txns_with_witnesses
+    , updated_stack1
+    , updated_stack2
+    , first_pass_ledger_end
+    , total_currency_end )
 
   (** Checks if the work has already been verified before by the snark pool logic *)
   let work_already_verified_check ~get_completed_work jobs work =
@@ -902,8 +962,9 @@ module T = struct
 
   let update_coinbase_stack_and_get_data_impl ~logger ~constraint_constants
       ~global_slot ~first_partition_slots:slots ~no_second_partition
-      ~is_new_stack ~signature_kind ledger pending_coinbase_collection
-      transactions current_state_view state_and_body_hash =
+      ~is_new_stack ~signature_kind ~init_total_currency ledger
+      pending_coinbase_collection transactions current_state_view
+      state_and_body_hash =
     let open Deferred.Result.Let_syntax in
     let coinbase_exists txns =
       List.fold_until ~init:false txns
@@ -925,10 +986,11 @@ module T = struct
       in
       [%log internal] "Update_ledger_and_get_statements"
         ~metadata:[ ("partition", `String "single") ] ;
-      let%map data, updated_stack, _, first_pass_ledger_end =
+      let%map data, updated_stack, _, first_pass_ledger_end, total_currency_end
+          =
         update_ledger_and_get_statements ~constraint_constants ~global_slot
-          ~signature_kind ledger working_stack (transactions, None)
-          current_state_view state_and_body_hash
+          ~signature_kind ~init_total_currency ledger working_stack
+          (transactions, None) current_state_view state_and_body_hash
       in
       [%log internal] "Update_ledger_and_get_statements_done" ;
       [%log internal] "Update_coinbase_stack_done"
@@ -941,7 +1003,8 @@ module T = struct
       , data
       , Pending_coinbase.Update.Action.Update_one
       , `Update_one updated_stack
-      , `First_pass_ledger_end first_pass_ledger_end ) )
+      , `First_pass_ledger_end first_pass_ledger_end
+      , `Total_currency_end total_currency_end ) )
     else
       (*Two partition:
         Assumption: Only one of the partition will have coinbase transaction(s)in it.
@@ -961,9 +1024,14 @@ module T = struct
       let txns_for_partition2 = List.drop transactions slots in
       [%log internal] "Update_ledger_and_get_statements"
         ~metadata:[ ("partition", `String "both") ] ;
-      let%map data, updated_stack1, updated_stack2, first_pass_ledger_end =
+      let%map
+          ( data
+          , updated_stack1
+          , updated_stack2
+          , first_pass_ledger_end
+          , total_currency_end ) =
         update_ledger_and_get_statements ~constraint_constants ~global_slot
-          ~signature_kind ledger working_stack1
+          ~signature_kind ~init_total_currency ledger working_stack1
           (txns_for_partition1, Some txns_for_partition2)
           current_state_view state_and_body_hash
       in
@@ -1004,11 +1072,18 @@ module T = struct
       , data
       , pending_coinbase_action
       , stack_update
-      , `First_pass_ledger_end first_pass_ledger_end )
+      , `First_pass_ledger_end first_pass_ledger_end
+      , `Total_currency_end total_currency_end )
 
   let update_coinbase_stack_and_get_data ~logger ~constraint_constants
       ~global_slot ~signature_kind scan_state ledger pending_coinbase_collection
       transactions current_state_view state_and_body_hash =
+    let init_total_currency =
+      scan_state_total_currency scan_state
+        ~default:
+          current_state_view
+            .Zkapp_precondition.Protocol_state.Poly.total_currency
+    in
     let { Scan_state.Space_partition.first = slots, _; second } =
       Scan_state.partition_if_overflowing scan_state
     in
@@ -1017,8 +1092,8 @@ module T = struct
       update_coinbase_stack_and_get_data_impl ~logger ~constraint_constants
         ~global_slot ~first_partition_slots:slots
         ~no_second_partition:(Option.is_none second) ~is_new_stack
-        ~signature_kind ledger pending_coinbase_collection transactions
-        current_state_view state_and_body_hash
+        ~signature_kind ~init_total_currency ledger pending_coinbase_collection
+        transactions current_state_view state_and_body_hash
     else (
       [%log internal] "Update_coinbase_stack_done" ;
       Deferred.return
@@ -1027,7 +1102,8 @@ module T = struct
            , []
            , Pending_coinbase.Update.Action.Update_none
            , `Update_none
-           , `First_pass_ledger_end (Ledger.merkle_root ledger) ) ) )
+           , `First_pass_ledger_end (Ledger.merkle_root ledger)
+           , `Total_currency_end init_total_currency ) ) )
 
   (* Update the pending_coinbase tree with the updated/new stack and delete the
      oldest stack if a proof was emitted *)
@@ -1151,7 +1227,8 @@ module T = struct
         , data
         , stack_update_in_snark
         , stack_update
-        , `First_pass_ledger_end first_pass_ledger_end ) =
+        , `First_pass_ledger_end first_pass_ledger_end
+        , `Total_currency_end total_currency_end ) =
       O1trace.thread "update_coinbase_stack_start_time" (fun () ->
           update_coinbase_stack_and_get_data ~logger ~constraint_constants
             ~global_slot ~signature_kind t.scan_state new_ledger
@@ -1244,7 +1321,7 @@ module T = struct
         O1trace.thread "verify_scan_state_after_apply" (fun () ->
             Deferred.(
               verify_scan_state_after_apply ~constraint_constants ~logger
-                ~first_pass_ledger_end
+                ~total_currency_end ~first_pass_ledger_end
                 ~second_pass_ledger_end:
                   (Frozen_ledger_hash.of_ledger_hash
                      (Ledger.merkle_root new_ledger) )

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -363,6 +363,7 @@ module Test_helpers : sig
     -> no_second_partition:bool
     -> is_new_stack:bool
     -> signature_kind:Mina_signature_kind.t
+    -> init_total_currency:Currency.Amount.t
     -> Ledger.t
     -> Pending_coinbase.t
     -> Transaction.t With_status.t list
@@ -379,6 +380,7 @@ module Test_helpers : sig
              Pending_coinbase.Stack_versioned.t
              * Pending_coinbase.Stack_versioned.t ]
          * [> `First_pass_ledger_end of Frozen_ledger_hash.t ]
+         * [> `Total_currency_end of Currency.Amount.t ]
        , Staged_ledger_error.t )
        Deferred.Result.t
 end

--- a/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
+++ b/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
@@ -50,43 +50,43 @@ type profile_expected_values =
 
 let dev_expected_values =
   { transaction_merge =
-      { constraints = 564
+      { constraints = 568
       ; public_input_size = 298
-      ; auxiliary_input_size = 1761
-      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
+      ; auxiliary_input_size = 1843
+      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
       }
   ; transaction_base =
-      { constraints = 12864
+      { constraints = 12877
       ; public_input_size = 298
-      ; auxiliary_input_size = 37375
-      ; digest = "84bc56d329c4c4fc1568a5a431373b64"
+      ; auxiliary_input_size = 37511
+      ; digest = "8bfa307456fa9dd8e674059a412eb414"
       }
   ; zkapp_opt_signed_opt_signed =
-      { constraints = 16321
+      { constraints = 16334
       ; public_input_size = 298
-      ; auxiliary_input_size = 73353
-      ; digest = "471126c9da562837da265347db388edf"
+      ; auxiliary_input_size = 73489
+      ; digest = "29933b2934ac2be1d2ad971192f29612"
       }
   ; zkapp_opt_signed =
-      { constraints = 8913
+      { constraints = 8926
       ; public_input_size = 298
-      ; auxiliary_input_size = 40463
-      ; digest = "6922e2397468e7f88ef7a52b0779a6c1"
+      ; auxiliary_input_size = 40599
+      ; digest = "578e94634eb8ce36409a7e47aa7a2057"
       }
   ; zkapp_proved =
-      { constraints = 5136
+      { constraints = 5149
       ; public_input_size = 298
-      ; auxiliary_input_size = 39029
-      ; digest = "4dd774a3dfb922dc016c920a5e479163"
+      ; auxiliary_input_size = 39165
+      ; digest = "175f595e71ac83ebca6043c50974fc9f"
       }
   }
 
 let devnet_expected_values =
   { transaction_merge =
-      { constraints = 564
+      { constraints = 568
       ; public_input_size = 298
-      ; auxiliary_input_size = 1761
-      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
+      ; auxiliary_input_size = 1843
+      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
       }
   ; transaction_base =
       { constraints = 15357
@@ -116,10 +116,10 @@ let devnet_expected_values =
 
 let lightnet_expected_values =
   { transaction_merge =
-      { constraints = 564
+      { constraints = 568
       ; public_input_size = 298
-      ; auxiliary_input_size = 1761
-      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
+      ; auxiliary_input_size = 1843
+      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
       }
   ; transaction_base =
       { constraints = 15357
@@ -149,10 +149,10 @@ let lightnet_expected_values =
 
 let mainnet_expected_values =
   { transaction_merge =
-      { constraints = 564
+      { constraints = 568
       ; public_input_size = 298
-      ; auxiliary_input_size = 1761
-      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
+      ; auxiliary_input_size = 1843
+      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
       }
   ; transaction_base =
       { constraints = 15357

--- a/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
+++ b/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
@@ -50,65 +50,65 @@ type profile_expected_values =
 
 let dev_expected_values =
   { transaction_merge =
-      { constraints = 634
-      ; public_input_size = 300
-      ; auxiliary_input_size = 1899
-      ; digest = "d71089b3a1669535999e8f181cd59afc"
+      { constraints = 564
+      ; public_input_size = 298
+      ; auxiliary_input_size = 1761
+      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
       }
   ; transaction_base =
-      { constraints = 12875
-      ; public_input_size = 300
-      ; auxiliary_input_size = 37503
-      ; digest = "740db2397b0b01806a48f061a2e2b063"
+      { constraints = 12864
+      ; public_input_size = 298
+      ; auxiliary_input_size = 37375
+      ; digest = "84bc56d329c4c4fc1568a5a431373b64"
       }
   ; zkapp_opt_signed_opt_signed =
-      { constraints = 16332
-      ; public_input_size = 300
-      ; auxiliary_input_size = 73525
-      ; digest = "aa73b81ac2eca4d57fc889bfe562e01b"
+      { constraints = 16321
+      ; public_input_size = 298
+      ; auxiliary_input_size = 73353
+      ; digest = "471126c9da562837da265347db388edf"
       }
   ; zkapp_opt_signed =
-      { constraints = 8924
-      ; public_input_size = 300
-      ; auxiliary_input_size = 40635
-      ; digest = "080790458ad5287478889328c21ce774"
+      { constraints = 8913
+      ; public_input_size = 298
+      ; auxiliary_input_size = 40463
+      ; digest = "6922e2397468e7f88ef7a52b0779a6c1"
       }
   ; zkapp_proved =
-      { constraints = 5146
-      ; public_input_size = 300
-      ; auxiliary_input_size = 39201
-      ; digest = "7a16111a5abe7fb0d7c92e44b160218b"
+      { constraints = 5136
+      ; public_input_size = 298
+      ; auxiliary_input_size = 39029
+      ; digest = "4dd774a3dfb922dc016c920a5e479163"
       }
   }
 
 let devnet_expected_values =
   { transaction_merge =
-      { constraints = 634
-      ; public_input_size = 300
-      ; auxiliary_input_size = 1899
-      ; digest = "d71089b3a1669535999e8f181cd59afc"
+      { constraints = 564
+      ; public_input_size = 298
+      ; auxiliary_input_size = 1761
+      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 63807
       ; digest = "3bf6bb8a97665fe7a9df6fc146e4f942"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 91179
       ; digest = "614aec09ed5e4068f46d010f0070226b"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 49639
       ; digest = "0fe3381f501f432744727c296be464b0"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 48205
       ; digest = "cad581432831f10fee99161532504937"
       }
@@ -116,32 +116,32 @@ let devnet_expected_values =
 
 let lightnet_expected_values =
   { transaction_merge =
-      { constraints = 634
-      ; public_input_size = 300
-      ; auxiliary_input_size = 1899
-      ; digest = "d71089b3a1669535999e8f181cd59afc"
+      { constraints = 564
+      ; public_input_size = 298
+      ; auxiliary_input_size = 1761
+      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 63807
       ; digest = "3bf6bb8a97665fe7a9df6fc146e4f942"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 91179
       ; digest = "614aec09ed5e4068f46d010f0070226b"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 49639
       ; digest = "0fe3381f501f432744727c296be464b0"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 48205
       ; digest = "cad581432831f10fee99161532504937"
       }
@@ -149,32 +149,32 @@ let lightnet_expected_values =
 
 let mainnet_expected_values =
   { transaction_merge =
-      { constraints = 634
-      ; public_input_size = 300
-      ; auxiliary_input_size = 1899
-      ; digest = "d71089b3a1669535999e8f181cd59afc"
+      { constraints = 564
+      ; public_input_size = 298
+      ; auxiliary_input_size = 1761
+      ; digest = "bdabeb841fc2361392dd6ac6e541a944"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 63807
       ; digest = "d31948e661cc662675b0c079458f714a"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 91179
       ; digest = "ddaa38405c20a8f7a7cf5235c1ed1713"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 49639
       ; digest = "d048877d85e30a1ff9ff4cbdfcc33639"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 300
+      ; public_input_size = 298
       ; auxiliary_input_size = 48205
       ; digest = "2d8810bdbda316e4b1f9f41ae1b28f6c"
       }

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -43,6 +43,7 @@ let%test_module "Transaction union tests" =
     end
 
     let of_user_command' ?(source_fee_excess = Fee_excess.zero)
+        ?(source_total_currency = Currency.Amount.zero)
         (sok_digest : Sok_message.Digest.t) ledger
         (user_command : Signed_command.With_valid_signature.t) init_stack
         pending_coinbase_stack_state state_body handler =
@@ -63,6 +64,16 @@ let%test_module "Transaction union tests" =
         }
       in
       let user_command_supply_increase = Currency.Amount.Signed.zero in
+      let target_total_currency =
+        match
+          Currency.Amount.add_signed_flagged source_total_currency
+            user_command_supply_increase
+        with
+        | total, `Overflow false ->
+            total
+        | _, `Overflow true ->
+            failwith "total currency out of range"
+      in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let statement =
             let txn =
@@ -79,7 +90,7 @@ let%test_module "Transaction union tests" =
                 (Or_error.ok_exn
                    (Fee_excess.combine source_fee_excess
                       (Or_error.ok_exn (Transaction.fee_excess txn)) ) )
-              ~supply_increase:user_command_supply_increase
+              ~source_total_currency ~target_total_currency
               ~pending_coinbase_stack_state
           in
           T.of_user_command ~init_stack ~statement user_command_in_block handler )

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -42,7 +42,8 @@ let%test_module "Transaction union tests" =
       let merkle_root t = Frozen_ledger_hash.of_ledger_hash @@ merkle_root t
     end
 
-    let of_user_command' (sok_digest : Sok_message.Digest.t) ledger
+    let of_user_command' ?(source_fee_excess = Fee_excess.zero)
+        (sok_digest : Sok_message.Digest.t) ledger
         (user_command : Signed_command.With_valid_signature.t) init_stack
         pending_coinbase_stack_state state_body handler =
       let module T = (val Lazy.force U.snark_module) in
@@ -73,8 +74,11 @@ let%test_module "Transaction union tests" =
               ~source_first_pass_ledger:source ~target_first_pass_ledger:target
               ~source_second_pass_ledger:target
               ~target_second_pass_ledger:target ~connecting_ledger_left:target
-              ~connecting_ledger_right:target ~sok_digest
-              ~fee_excess:(Or_error.ok_exn (Transaction.fee_excess txn))
+              ~connecting_ledger_right:target ~sok_digest ~source_fee_excess
+              ~target_fee_excess:
+                (Or_error.ok_exn
+                   (Fee_excess.combine source_fee_excess
+                      (Or_error.ok_exn (Transaction.fee_excess txn)) ) )
               ~supply_increase:user_command_supply_increase
               ~pending_coinbase_stack_state
           in
@@ -527,8 +531,10 @@ let%test_module "Transaction union tests" =
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;
               let proof23 =
-                of_user_command' sok_digest ledger t2
-                  pending_coinbase_stack_state2.init_stack
+                of_user_command'
+                  ~source_fee_excess:
+                    (Transaction_snark.statement proof12).target.fee_excess
+                  sok_digest ledger t2 pending_coinbase_stack_state2.init_stack
                   pending_coinbase_stack_state2.pc state_body2
                   (unstage @@ Sparse_ledger.handler sparse_ledger)
               in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -158,7 +158,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
             Or_error.try_with (fun () ->
                 Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
                   ~constraint_constants ~global_slot ~state_body
-                  ~fee_excess:Amount.Signed.zero
+                  ~fee_excess:Amount.Signed.zero ~total_currency:Amount.zero
                   [ ( `Pending_coinbase_init_stack init_stack
                     , `Pending_coinbase_of_statement
                         (pending_coinbase_state_stack ~state_body_hash
@@ -215,6 +215,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                         ; pending_coinbase_stack = init_stack
                         ; local_state = Mina_state.Local_state.empty ()
                         ; fee_excess = Fee_excess.zero
+                        ; total_currency = Currency.Amount.zero
                         }
                     ; target =
                         { first_pass_ledger = first_pass_ledger_target_hash
@@ -224,13 +225,19 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                               global_slot init_stack
                         ; local_state = Mina_state.Local_state.empty ()
                         ; fee_excess = Zkapp_command.fee_excess zkapp_command
+                        ; total_currency =
+                            (let supply_increase =
+                               Mina_transaction_logic.Transaction_applied
+                               .supply_increase ~constraint_constants
+                                 applied_txn
+                               |> Or_error.ok_exn
+                             in
+                             fst
+                               (Currency.Amount.add_signed_flagged
+                                  Currency.Amount.zero supply_increase ) )
                         }
                     ; connecting_ledger_left = connecting_ledger
                     ; connecting_ledger_right = connecting_ledger
-                    ; supply_increase =
-                        Mina_transaction_logic.Transaction_applied
-                        .supply_increase ~constraint_constants applied_txn
-                        |> Or_error.ok_exn
                     ; sok_digest = ()
                     }
                   in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -207,13 +207,14 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                   in
                   (*Expected transaction statement*)
                   let stmt : Transaction_snark.Statement.t =
-                    { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V2
+                    { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V3
                       .source =
                         { first_pass_ledger =
                             Sparse_ledger.merkle_root first_pass_ledger_witness
                         ; second_pass_ledger = second_pass_ledger_source_hash
                         ; pending_coinbase_stack = init_stack
                         ; local_state = Mina_state.Local_state.empty ()
+                        ; fee_excess = Fee_excess.zero
                         }
                     ; target =
                         { first_pass_ledger = first_pass_ledger_target_hash
@@ -222,10 +223,10 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                             Pending_coinbase.Stack.push_state state_body_hash
                               global_slot init_stack
                         ; local_state = Mina_state.Local_state.empty ()
+                        ; fee_excess = Zkapp_command.fee_excess zkapp_command
                         }
                     ; connecting_ledger_left = connecting_ledger
                     ; connecting_ledger_right = connecting_ledger
-                    ; fee_excess = Zkapp_command.fee_excess zkapp_command
                     ; supply_increase =
                         Mina_transaction_logic.Transaction_applied
                         .supply_increase ~constraint_constants applied_txn

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -93,6 +93,13 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
   let ignore_outside_snark = Option.value ~default:false ignore_outside_snark in
   let state_view = Mina_state.Protocol_state.Body.view state_body in
   let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
+  (*The registers record the total currency the transaction starts from, and a
+    zkApp command that creates an account burns the creation fee. Starting from
+    zero would underflow, so start from the protocol's total currency, which is
+    what the block producer carries in.*)
+  let total_currency =
+    state_view.Zkapp_precondition.Protocol_state.Poly.total_currency
+  in
   let global_slot =
     Option.value global_slot
       ~default:
@@ -158,7 +165,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
             Or_error.try_with (fun () ->
                 Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
                   ~constraint_constants ~global_slot ~state_body
-                  ~fee_excess:Amount.Signed.zero ~total_currency:Amount.zero
+                  ~fee_excess:Amount.Signed.zero ~total_currency
                   [ ( `Pending_coinbase_init_stack init_stack
                     , `Pending_coinbase_of_statement
                         (pending_coinbase_state_stack ~state_body_hash
@@ -215,7 +222,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                         ; pending_coinbase_stack = init_stack
                         ; local_state = Mina_state.Local_state.empty ()
                         ; fee_excess = Fee_excess.zero
-                        ; total_currency = Currency.Amount.zero
+                        ; total_currency
                         }
                     ; target =
                         { first_pass_ledger = first_pass_ledger_target_hash
@@ -234,7 +241,7 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                              in
                              fst
                                (Currency.Amount.add_signed_flagged
-                                  Currency.Amount.zero supply_increase ) )
+                                  total_currency supply_increase ) )
                         }
                     ; connecting_ledger_left = connecting_ledger
                     ; connecting_ledger_right = connecting_ledger

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1913,7 +1913,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; second_pass_ledger =
                 ( statement.source.second_pass_ledger
                 , V.create (fun () -> !witness.global_second_pass_ledger) )
-            ; fee_excess = Amount.Signed.(Checked.constant zero)
+            ; fee_excess =
+                Amount.Signed.Checked.of_fee statement.source.fee_excess
             ; supply_increase = Amount.Signed.(Checked.constant zero)
             ; protocol_state =
                 Mina_state.Protocol_state.Body.view_checked state_body
@@ -2102,14 +2103,11 @@ module Make_str (A : Wire_types.Concrete) = struct
                  global.supply_increase ) ) ;
         with_label __LOC__ (fun () ->
             run_checked
-              (let expected = statement.fee_excess in
-               (* The global state that this segment starts from has a zero
-                  excess (see [init] above), so the segment's excess is just
-                  the excess that the global state ends with. *)
-               let got : Fee_excess.var =
-                 Amount.Signed.Checked.to_fee global.fee_excess
-               in
-               Fee_excess.assert_equal_checked expected got ) ) ;
+              (* The global state starts from the source register's excess (see
+                 [init] above) and accumulates this segment's fees into it, so
+                 the excess it ends with is the target register's. *)
+              (Fee_excess.assert_equal_checked statement.target.fee_excess
+                 (Amount.Signed.Checked.to_fee global.fee_excess) ) ) ;
         (Stdlib.( ! ) zkapp_input, `Must_verify (Stdlib.( ! ) must_verify))
 
       (* Horrible hack :( *)
@@ -3148,8 +3146,15 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; [%with_label_ "equal supply_increases"] (fun () ->
               Currency.Amount.Signed.Checked.assert_equal supply_increase
                 statement.supply_increase )
-        ; [%with_label_ "equal fee excesses"] (fun () ->
-              Fee_excess.assert_equal_checked fee_excess statement.fee_excess )
+        ; [%with_label_ "fee excess accumulates into the target register"]
+            (fun () ->
+              let open Tick.Checked.Let_syntax in
+              let%bind target_fee_excess =
+                Fee_excess.combine_checked statement.source.fee_excess
+                  fee_excess
+              in
+              Fee_excess.assert_equal_checked target_fee_excess
+                statement.target.fee_excess )
         ]
 
     let rule ~signature_kind ~constraint_constants : _ Pickles.Inductive_rule.t
@@ -3235,10 +3240,6 @@ module Make_str (A : Wire_types.Concrete) = struct
           Typ.(Statement.With_sok.typ * Statement.With_sok.typ)
           ~request:(As_prover.return Statements_to_merge)
       in
-      let%bind fee_excess =
-        Fee_excess.combine_checked s1.Statement.Poly.fee_excess
-          s2.Statement.Poly.fee_excess
-      in
       let%bind () =
         with_label __LOC__ (fun () ->
             let%bind valid_pending_coinbase_stack_transition =
@@ -3271,8 +3272,16 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let%map () =
         Checked.all_unit
-          [ [%with_label_ "equal fee excesses"] (fun () ->
-                Fee_excess.assert_equal_checked fee_excess s.fee_excess )
+          [ [%with_label_ "fee excess connects at the merge point"] (fun () ->
+                Fee_excess.assert_equal_checked
+                  s1.Statement.Poly.target.fee_excess
+                  s2.Statement.Poly.source.fee_excess )
+          ; [%with_label_ "equal source fee excess"] (fun () ->
+                Fee_excess.assert_equal_checked s.source.fee_excess
+                  s1.source.fee_excess )
+          ; [%with_label_ "equal target fee excess"] (fun () ->
+                Fee_excess.assert_equal_checked s.target.fee_excess
+                  s2.target.fee_excess )
           ; [%with_label_ "equal supply increases"] (fun () ->
                 Amount.Signed.Checked.assert_equal supply_increase
                   s.supply_increase )
@@ -3427,8 +3436,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         ~source_first_pass_ledger ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
         ~target_second_pass_ledger:target_first_pass_ledger
-        ~pending_coinbase_stack_state
-        ~fee_excess:(Transaction_union.fee_excess transaction)
+        ~pending_coinbase_stack_state ~source_fee_excess:Fee_excess.zero
+        ~target_fee_excess:(Transaction_union.fee_excess transaction)
         ~sok_digest ~connecting_ledger_left:target_first_pass_ledger
         ~connecting_ledger_right:target_first_pass_ledger
     in
@@ -3502,7 +3511,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     in
     let statement : Statement.With_sok.t =
       Statement.Poly.with_empty_local_state ~supply_increase
-        ~fee_excess:(Transaction_union.fee_excess transaction)
+        ~source_fee_excess:Fee_excess.zero
+        ~target_fee_excess:(Transaction_union.fee_excess transaction)
         ~sok_digest ~source_first_pass_ledger ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
         ~target_second_pass_ledger:target_first_pass_ledger
@@ -3933,21 +3943,8 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; block_global_slot = global_slot
           }
         in
-        let fee_excess =
-          (* capture only the difference in the fee excess *)
-          match
-            Amount.Signed.(
-              add target_global.fee_excess (negate source_global.fee_excess) )
-          with
-          | None ->
-              failwith
-                (sprintf
-                   !"unexpected fee excess. source %{sexp: Amount.Signed.t} \
-                     target %{sexp: Amount.Signed.t}"
-                   target_global.fee_excess source_global.fee_excess )
-          | Some balance_change ->
-              Amount.Signed.to_fee balance_change
-        in
+        let source_fee_excess = Amount.Signed.to_fee source_global.fee_excess in
+        let target_fee_excess = Amount.Signed.to_fee target_global.fee_excess in
         let supply_increase =
           (* capture only the difference in supply increase *)
           match
@@ -3990,6 +3987,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; call_stack = call_stack_hash source_local.call_stack
                   ; ledger = source_local_ledger
                   }
+              ; fee_excess = source_fee_excess
               }
           ; target =
               { first_pass_ledger = target_first_pass_ledger_root
@@ -4003,11 +4001,11 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; call_stack = call_stack_hash target_local.call_stack
                   ; ledger = target_local_ledger
                   }
+              ; fee_excess = target_fee_excess
               }
           ; connecting_ledger_left = connecting_ledger
           ; connecting_ledger_right = connecting_ledger
           ; supply_increase
-          ; fee_excess
           ; sok_digest = Sok_message.Digest.default
           }
         in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1915,7 +1915,10 @@ module Make_str (A : Wire_types.Concrete) = struct
                 , V.create (fun () -> !witness.global_second_pass_ledger) )
             ; fee_excess =
                 Amount.Signed.Checked.of_fee statement.source.fee_excess
-            ; supply_increase = Amount.Signed.(Checked.constant zero)
+            ; supply_increase =
+                Amount.Signed.(Checked.constant zero)
+                (*The segment's supply increase is a delta; the registers record
+                where the total currency starts and ends.*)
             ; protocol_state =
                 Mina_state.Protocol_state.Body.view_checked state_body
             ; block_global_slot
@@ -2099,8 +2102,17 @@ module Make_str (A : Wire_types.Concrete) = struct
                  statement.connecting_ledger_right ) ) ;
         with_label __LOC__ (fun () ->
             run_checked
-              (Amount.Signed.Checked.assert_equal statement.supply_increase
-                 global.supply_increase ) ) ;
+              (let open Tick.Checked.Let_syntax in
+               let%bind target_total_currency, `Overflow overflow =
+                 Amount.Checked.add_signed_flagged
+                   statement.source.total_currency global.supply_increase
+               in
+               let%bind () =
+                 Tick.Checked.return
+                   (Boolean.Assert.is_true (Boolean.not overflow))
+               in
+               Amount.Checked.assert_equal target_total_currency
+                 statement.target.total_currency ) ) ;
         with_label __LOC__ (fun () ->
             run_checked
               (* The global state starts from the source register's excess (see
@@ -3143,9 +3155,19 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; [%with_label_ "valid connecting ledgers"] (fun () ->
               Frozen_ledger_hash.assert_equal statement.connecting_ledger_left
                 statement.connecting_ledger_right )
-        ; [%with_label_ "equal supply_increases"] (fun () ->
-              Currency.Amount.Signed.Checked.assert_equal supply_increase
-                statement.supply_increase )
+        ; [%with_label_ "total currency accumulates into the target register"]
+            (fun () ->
+              let open Tick.Checked.Let_syntax in
+              let%bind target_total_currency, `Overflow overflow =
+                Currency.Amount.Checked.add_signed_flagged
+                  statement.source.total_currency supply_increase
+              in
+              let%bind () =
+                [%with_label_ "Total currency is in range"] (fun () ->
+                    Boolean.Assert.is_true (Boolean.not overflow) )
+              in
+              Currency.Amount.Checked.assert_equal target_total_currency
+                statement.target.total_currency )
         ; [%with_label_ "fee excess accumulates into the target register"]
             (fun () ->
               let open Tick.Checked.Let_syntax in
@@ -3253,9 +3275,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             in
             Boolean.Assert.is_true valid_pending_coinbase_stack_transition )
       in
-      let%bind supply_increase =
-        Amount.Signed.Checked.add s1.supply_increase s2.supply_increase
-      in
       let%bind () =
         make_checked (fun () ->
             Local_state.Checked.assert_equal s.source.local_state
@@ -3282,9 +3301,17 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; [%with_label_ "equal target fee excess"] (fun () ->
                 Fee_excess.assert_equal_checked s.target.fee_excess
                   s2.target.fee_excess )
-          ; [%with_label_ "equal supply increases"] (fun () ->
-                Amount.Signed.Checked.assert_equal supply_increase
-                  s.supply_increase )
+          ; [%with_label_ "total currency connects at the merge point"]
+              (fun () ->
+                Amount.Checked.assert_equal
+                  s1.Statement.Poly.target.total_currency
+                  s2.Statement.Poly.source.total_currency )
+          ; [%with_label_ "equal source total currency"] (fun () ->
+                Amount.Checked.assert_equal s.source.total_currency
+                  s1.source.total_currency )
+          ; [%with_label_ "equal target total currency"] (fun () ->
+                Amount.Checked.assert_equal s.target.total_currency
+                  s2.target.total_currency )
           ; [%with_label_ "equal source fee payment ledger hashes"] (fun () ->
                 Frozen_ledger_hash.assert_equal s.source.first_pass_ledger
                   s1.source.first_pass_ledger )
@@ -3431,9 +3458,21 @@ module Make_str (A : Wire_types.Concrete) = struct
       Base.transaction_union_handler handler transaction state_body global_slot
         init_stack
     in
+    (*These standalone helpers cover a single transaction, so any total currency
+      that makes the transition representable will do.*)
+    let source_total_currency, target_total_currency =
+      match Currency.Amount.Signed.sgn supply_increase with
+      | Sgn.Neg ->
+          ( Currency.Amount.Signed.magnitude supply_increase
+          , Currency.Amount.zero )
+      | Sgn.Pos ->
+          ( Currency.Amount.zero
+          , Currency.Amount.Signed.magnitude supply_increase )
+    in
     let statement : Statement.With_sok.t =
-      Statement.Poly.with_empty_local_state ~supply_increase
-        ~source_first_pass_ledger ~target_first_pass_ledger
+      Statement.Poly.with_empty_local_state ~source_total_currency
+        ~target_total_currency ~source_first_pass_ledger
+        ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
         ~target_second_pass_ledger:target_first_pass_ledger
         ~pending_coinbase_stack_state ~source_fee_excess:Fee_excess.zero
@@ -3509,9 +3548,20 @@ module Make_str (A : Wire_types.Concrete) = struct
       Base.transaction_union_handler handler transaction state_body global_slot
         init_stack
     in
+    (*These standalone helpers cover a single transaction, so any total currency
+      that makes the transition representable will do.*)
+    let source_total_currency, target_total_currency =
+      match Currency.Amount.Signed.sgn supply_increase with
+      | Sgn.Neg ->
+          ( Currency.Amount.Signed.magnitude supply_increase
+          , Currency.Amount.zero )
+      | Sgn.Pos ->
+          ( Currency.Amount.zero
+          , Currency.Amount.Signed.magnitude supply_increase )
+    in
     let statement : Statement.With_sok.t =
-      Statement.Poly.with_empty_local_state ~supply_increase
-        ~source_fee_excess:Fee_excess.zero
+      Statement.Poly.with_empty_local_state ~source_total_currency
+        ~target_total_currency ~source_fee_excess:Fee_excess.zero
         ~target_fee_excess:(Transaction_union.fee_excess transaction)
         ~sok_digest ~source_first_pass_ledger ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
@@ -3669,7 +3719,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         { stack_hash = Call_stack_digest.cons h_f h_tl; elt = f } :: tl
 
   let zkapp_command_witnesses_exn ~signature_kind ~constraint_constants
-      ~global_slot ~state_body ~fee_excess
+      ~global_slot ~state_body ~fee_excess ~total_currency
       (zkapp_commands_with_context :
         ( [ `Pending_coinbase_init_stack of Pending_coinbase.Stack.t ]
         * [ `Pending_coinbase_of_statement of Pending_coinbase_stack_state.t ]
@@ -3945,21 +3995,25 @@ module Make_str (A : Wire_types.Concrete) = struct
         in
         let source_fee_excess = Amount.Signed.to_fee source_global.fee_excess in
         let target_fee_excess = Amount.Signed.to_fee target_global.fee_excess in
-        let supply_increase =
-          (* capture only the difference in supply increase *)
-          match
-            Amount.Signed.(
-              add target_global.supply_increase
-                (negate source_global.supply_increase) )
-          with
-          | None ->
+        (*The global state accumulates a supply increase relative to where the
+          witnesses started; the registers record the total currency it reaches
+          either side of this segment.*)
+        let total_currency_at supply_increase =
+          match Amount.add_signed_flagged total_currency supply_increase with
+          | total, `Overflow false ->
+              total
+          | _, `Overflow true ->
               failwith
                 (sprintf
-                   !"unexpected supply increase. source %{sexp: \
-                     Amount.Signed.t} target %{sexp: Amount.Signed.t}"
-                   target_global.supply_increase source_global.supply_increase )
-          | Some supply_increase ->
-              supply_increase
+                   !"unexpected supply increase %{sexp: Amount.Signed.t} \
+                     against total currency %{sexp: Amount.t}"
+                   supply_increase total_currency )
+        in
+        let source_total_currency =
+          total_currency_at source_global.supply_increase
+        in
+        let target_total_currency =
+          total_currency_at target_global.supply_increase
         in
         let call_stack_hash s =
           List.hd s
@@ -3988,6 +4042,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; ledger = source_local_ledger
                   }
               ; fee_excess = source_fee_excess
+              ; total_currency = source_total_currency
               }
           ; target =
               { first_pass_ledger = target_first_pass_ledger_root
@@ -4002,10 +4057,10 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; ledger = target_local_ledger
                   }
               ; fee_excess = target_fee_excess
+              ; total_currency = target_total_currency
               }
           ; connecting_ledger_left = connecting_ledger
           ; connecting_ledger_right = connecting_ledger
-          ; supply_increase
           ; sok_digest = Sok_message.Digest.default
           }
         in

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -37,44 +37,44 @@
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 632         | 300          | 1,895           |
-    | transaction-base            | 12,875      | 300          | 37,502          |
-    | zkapp-opt_signed-opt_signed | 14,537      | 300          | 56,588          |
-    | zkapp-opt_signed            | 8,026       | 300          | 32,166          |
-    | zkapp-proved                | 4,249       | 300          | 30,732          |
+    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-base            | 12,864      | 298          | 37,375          |
+    | zkapp-opt_signed-opt_signed | 16,321      | 298          | 73,353          |
+    | zkapp-opt_signed            | 8,913       | 298          | 40,463          |
+    | zkapp-proved                | 5,136       | 298          | 39,029          |
     v}
 
     {b Devnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 632         | 300          | 1,895           |
-    | transaction-base            | 15,357      | 300          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 300          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 300          | 41,170          |
-    | zkapp-proved                | 5,106       | 300          | 39,736          |
+    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-base            | 15,357      | 298          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
+    | zkapp-proved                | 5,106       | 298          | 39,736          |
     v}
 
     {b Lightnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 632         | 300          | 1,895           |
-    | transaction-base            | 15,357      | 300          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 300          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 300          | 41,170          |
-    | zkapp-proved                | 5,106       | 300          | 39,736          |
+    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-base            | 15,357      | 298          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
+    | zkapp-proved                | 5,106       | 298          | 39,736          |
     v}
 
     {b Mainnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 632         | 300          | 1,895           |
-    | transaction-base            | 15,357      | 300          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 300          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 300          | 41,170          |
-    | zkapp-proved                | 5,106       | 300          | 39,736          |
+    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-base            | 15,357      | 298          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
+    | zkapp-proved                | 5,106       | 298          | 39,736          |
     v}
 
     If these values change, update the tables above and the expected values in

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -37,18 +37,18 @@
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 564         | 298          | 1,761           |
-    | transaction-base            | 12,864      | 298          | 37,375          |
-    | zkapp-opt_signed-opt_signed | 16,321      | 298          | 73,353          |
-    | zkapp-opt_signed            | 8,913       | 298          | 40,463          |
-    | zkapp-proved                | 5,136       | 298          | 39,029          |
+    | transaction-merge           | 568         | 298          | 1,843           |
+    | transaction-base            | 12,877      | 298          | 37,511          |
+    | zkapp-opt_signed-opt_signed | 16,334      | 298          | 73,489          |
+    | zkapp-opt_signed            | 8,926       | 298          | 40,599          |
+    | zkapp-proved                | 5,149       | 298          | 39,165          |
     v}
 
     {b Devnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-merge           | 568         | 298          | 1,843           |
     | transaction-base            | 15,357      | 298          | 63,806          |
     | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
     | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
@@ -59,7 +59,7 @@
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-merge           | 568         | 298          | 1,843           |
     | transaction-base            | 15,357      | 298          | 63,806          |
     | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
     | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
@@ -70,7 +70,7 @@
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 564         | 298          | 1,761           |
+    | transaction-merge           | 568         | 298          | 1,843           |
     | transaction-base            | 15,357      | 298          | 63,806          |
     | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
     | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
@@ -274,6 +274,7 @@ module type Full = sig
     -> global_slot:Mina_numbers.Global_slot_since_genesis.t
     -> state_body:Transaction_protocol_state.Block_data.t
     -> fee_excess:Currency.Amount.Signed.t
+    -> total_currency:Currency.Amount.t
     -> ( [ `Pending_coinbase_init_stack of Pending_coinbase.Stack.t ]
        * [ `Pending_coinbase_of_statement of Pending_coinbase_stack_state.t ]
        * [ `Ledger of Mina_ledger.Ledger.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -2,7 +2,6 @@ open Core
 open Async
 open Mina_base
 open Mina_transaction
-open Currency
 module Ledger = Mina_ledger.Ledger
 module Sparse_ledger = Mina_ledger.Sparse_ledger
 
@@ -173,7 +172,8 @@ module Job_view = struct
       type t =
         ( Frozen_ledger_hash.t
         , Pending_coinbase.Stack_versioned.t
-        , Mina_state.Local_state.t )
+        , Mina_state.Local_state.t
+        , Fee_excess.t )
         Mina_state.Registers.t
       [@@deriving to_yojson]
     end in
@@ -182,7 +182,6 @@ module Job_view = struct
         [ ("Work_id", `Int (Transaction_snark.Statement.hash s))
         ; ("Source", R.to_yojson s.source)
         ; ("Target", R.to_yojson s.target)
-        ; ("Fee Excess", Fee.Signed.to_yojson s.fee_excess)
         ; ("Supply Increase", Currency.Amount.Signed.to_yojson s.supply_increase)
         ]
     in
@@ -368,22 +367,27 @@ let create_expected_statement ~constraint_constants
     | _ ->
         pending_coinbase_with_state
   in
-  let%map fee_excess = Transaction.fee_excess transaction in
+  let%bind fee_excess = Transaction.fee_excess transaction in
+  (*The excess this transaction starts from is part of the statement being
+    checked; what has to follow from the witness is the excess it ends with.*)
+  let source_fee_excess = statement.source.fee_excess in
+  let%map target_fee_excess = Fee_excess.combine source_fee_excess fee_excess in
   { Transaction_snark.Statement.Poly.source =
       { first_pass_ledger = source_first_pass_merkle_root
       ; second_pass_ledger = source_second_pass_merkle_root
       ; pending_coinbase_stack = statement.source.pending_coinbase_stack
       ; local_state = empty_local_state
+      ; fee_excess = source_fee_excess
       }
   ; target =
       { first_pass_ledger = target_first_pass_merkle_root
       ; second_pass_ledger = target_second_pass_merkle_root
       ; pending_coinbase_stack = pending_coinbase_after
       ; local_state = empty_local_state
+      ; fee_excess = target_fee_excess
       }
   ; connecting_ledger_left = connecting_merkle_root
   ; connecting_ledger_right = connecting_merkle_root
-  ; fee_excess
   ; supply_increase
   ; sok_digest = ()
   }
@@ -630,7 +634,8 @@ struct
       ~(registers_end :
          ( Frozen_ledger_hash.t
          , Pending_coinbase.Stack.t
-         , Mina_state.Local_state.t )
+         , Mina_state.Local_state.t
+         , Fee_excess.t )
          Mina_state.Registers.t ) =
     let clarify_error cond err =
       if not cond then Or_error.errorf "%s : %s" error_prefix err else Ok ()
@@ -658,6 +663,10 @@ struct
           (Mina_transaction_logic.Zkapp_command_logic.Local_state.Value.equal
              reg1.local_state reg2.local_state )
           "did not connect with local state"
+      and () =
+        clarify_error
+          (Fee_excess.equal reg1.fee_excess reg2.fee_excess)
+          "did not connect with fee excess"
       in
       ()
     in
@@ -672,8 +681,7 @@ struct
         Option.value_map ~default:(Ok ()) last_proof_statement
           ~f:(fun statement -> check_registers statement.target registers_end )
     | Ok
-        ( { fee_excess
-          ; source = _
+        ( { source
           ; target
           ; connecting_ledger_left = _
           ; connecting_ledger_right = _
@@ -687,7 +695,11 @@ struct
               Transaction_snark.Statement.merge statement t |> Or_error.ignore_m )
         and () = check_registers registers_end target
         and () =
-          clarify_error (Fee_excess.is_zero fee_excess) "nonzero fee excess"
+          (*[check_registers] pins the excess the scan state ends with; the
+            excess it starts from must be settled too.*)
+          clarify_error
+            (Fee_excess.is_zero source.fee_excess)
+            "nonzero fee excess"
         in
         ()
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -173,7 +173,8 @@ module Job_view = struct
         ( Frozen_ledger_hash.t
         , Pending_coinbase.Stack_versioned.t
         , Mina_state.Local_state.t
-        , Fee_excess.t )
+        , Fee_excess.t
+        , Currency.Amount.t )
         Mina_state.Registers.t
       [@@deriving to_yojson]
     end in
@@ -182,7 +183,6 @@ module Job_view = struct
         [ ("Work_id", `Int (Transaction_snark.Statement.hash s))
         ; ("Source", R.to_yojson s.source)
         ; ("Target", R.to_yojson s.target)
-        ; ("Supply Increase", Currency.Amount.Signed.to_yojson s.supply_increase)
         ]
     in
     let job_to_yojson =
@@ -368,16 +368,30 @@ let create_expected_statement ~constraint_constants
         pending_coinbase_with_state
   in
   let%bind fee_excess = Transaction.fee_excess transaction in
-  (*The excess this transaction starts from is part of the statement being
-    checked; what has to follow from the witness is the excess it ends with.*)
+  (*The excess and total currency this transaction starts from are part of the
+    statement being checked; what has to follow from the witness is where it
+    ends up.*)
   let source_fee_excess = statement.source.fee_excess in
-  let%map target_fee_excess = Fee_excess.combine source_fee_excess fee_excess in
+  let%bind target_fee_excess =
+    Fee_excess.combine source_fee_excess fee_excess
+  in
+  let source_total_currency = statement.source.total_currency in
+  let%map target_total_currency =
+    match
+      Currency.Amount.add_signed_flagged source_total_currency supply_increase
+    with
+    | total, `Overflow false ->
+        Ok total
+    | _, `Overflow true ->
+        Or_error.error_string "Total currency out of range"
+  in
   { Transaction_snark.Statement.Poly.source =
       { first_pass_ledger = source_first_pass_merkle_root
       ; second_pass_ledger = source_second_pass_merkle_root
       ; pending_coinbase_stack = statement.source.pending_coinbase_stack
       ; local_state = empty_local_state
       ; fee_excess = source_fee_excess
+      ; total_currency = source_total_currency
       }
   ; target =
       { first_pass_ledger = target_first_pass_merkle_root
@@ -385,10 +399,10 @@ let create_expected_statement ~constraint_constants
       ; pending_coinbase_stack = pending_coinbase_after
       ; local_state = empty_local_state
       ; fee_excess = target_fee_excess
+      ; total_currency = target_total_currency
       }
   ; connecting_ledger_left = connecting_merkle_root
   ; connecting_ledger_right = connecting_merkle_root
-  ; supply_increase
   ; sok_digest = ()
   }
 
@@ -635,7 +649,8 @@ struct
          ( Frozen_ledger_hash.t
          , Pending_coinbase.Stack.t
          , Mina_state.Local_state.t
-         , Fee_excess.t )
+         , Fee_excess.t
+         , Currency.Amount.t )
          Mina_state.Registers.t ) =
     let clarify_error cond err =
       if not cond then Or_error.errorf "%s : %s" error_prefix err else Ok ()
@@ -685,7 +700,6 @@ struct
           ; target
           ; connecting_ledger_left = _
           ; connecting_ledger_right = _
-          ; supply_increase = _
           ; sok_digest = ()
           } as t ) ->
         let open Or_error.Let_syntax in
@@ -899,6 +913,22 @@ let incomplete_txns_from_recent_proof_tree t =
           , `Border_block_continued_in_the_next_tree true )
   in
   (proof, txns)
+
+(** The registers that the scan state currently ends at: the target of the most
+    recently enqueued transaction, or of the last emitted proof if nothing is
+    pending. New base statements have to chain from these. *)
+let latest_target_registers t =
+  let pending =
+    Parallel_scan.pending_data t.scan_state
+    |> List.filter ~f:(Fn.non List.is_empty)
+  in
+  match List.last pending with
+  | Some txns ->
+      Option.map (List.last txns) ~f:(fun (txn : Transaction_with_witness.t) ->
+          txn.statement.target )
+  | None ->
+      Option.map (latest_ledger_proof t) ~f:(fun p ->
+          (Ledger_proof.Cached.statement p).target )
 
 let staged_transactions t =
   let ( previous_incomplete

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -682,6 +682,10 @@ struct
         clarify_error
           (Fee_excess.equal reg1.fee_excess reg2.fee_excess)
           "did not connect with fee excess"
+      and () =
+        clarify_error
+          (Currency.Amount.equal reg1.total_currency reg2.total_currency)
+          "did not connect with total currency"
       in
       ()
     in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -95,6 +95,11 @@ val fill_work_and_enqueue_transactions :
 
 val latest_ledger_proof : t -> Ledger_proof.Cached.t option
 
+(** The registers the scan state currently ends at; new base statements chain
+    from these. [None] when the scan state is empty and no proof has been
+    emitted. *)
+val latest_target_registers : t -> Mina_state.Registers.Value.t option
+
 (** Apply transactions coorresponding to the last emitted proof based on the
     two-pass system- first pass includes legacy transactions and zkapp payments
     and the second pass includes account updates. [ignore_incomplete] is to

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -61,6 +61,7 @@ let extract_zkapp_segment_works ~m:(module M : S)
             (*The segment statements have to chain from the excess that the
               transaction's own statement starts at, not from zero.*)
           ~fee_excess:(Currency.Amount.Signed.of_fee input.source.fee_excess)
+          ~total_currency:input.source.total_currency
           [ ( `Pending_coinbase_init_stack witness.init_stack
             , `Pending_coinbase_of_statement
                 { Transaction_snark.Pending_coinbase_stack_state.source =

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -58,7 +58,9 @@ let extract_zkapp_segment_works ~m:(module M : S)
           ~constraint_constants:M.constraint_constants
           ~global_slot:witness.block_global_slot
           ~state_body:witness.protocol_state_body
-          ~fee_excess:Currency.Amount.Signed.zero
+            (*The segment statements have to chain from the excess that the
+              transaction's own statement starts at, not from zero.*)
+          ~fee_excess:(Currency.Amount.Signed.of_fee input.source.fee_excess)
           [ ( `Pending_coinbase_init_stack witness.init_stack
             , `Pending_coinbase_of_statement
                 { Transaction_snark.Pending_coinbase_stack_state.source =


### PR DESCRIPTION
> **Stacked on #19302.** This PR targets `feat/fee-excess-drop-tokens`, not `develop`. Review #19302 first; the diff here is the two commits on top of it.

## ⚠️ Hard fork — breaks circuit and wire compatibility

Like the PR it stacks on, **this cannot be deployed to an existing network without a hard fork.** On top of #19302 it further changes:

- **The transaction SNARK and blockchain SNARK circuits**, so all verification keys change again. The `dev_*_vk.json` files regenerated in #19302 are stale for this branch and need regenerating before merge.
- **The protocol state hash.** The statement's `to_input` loses two top-level fields and gains two per register, so every state hash differs.
- **The shape of the snark statement and everything containing it**, so nodes either side cannot exchange blocks, snark work or RPCs.
- **The GraphQL schema** (see below).

Both PRs are intended to land in the same hard fork.

## What this does

Two lifts, one per commit, turning accumulated deltas in the snark statement into before/after registers.

### 1. Fee excess

The statement carried the net fee excess of the transition it covered, and merges summed the two. It now lives in the source and target registers:

- a base statement requires `target.fee_excess = source.fee_excess + the transaction's fees`;
- a merge requires the two statements to agree on the excess where they meet.

The guarantees are deliberately unchanged. The blockchain SNARK required the emitted ledger proof's excess to be zero and now requires both its source and target to be zero, which is the same requirement given the scan state starts at zero. `check_zero_fee_excess` still rejects a diff whose partitions do not settle their own fees. **Relaxing that is the point of the exercise, but it is a later change.**

### 2. Total currency, and the consensus accumulator

The statement's `supply_increase` is replaced by a `total_currency` register either side:

- a base statement requires `target.total_currency = source.total_currency + the transaction's supply increase`;
- a merge requires the two statements to agree on the total where they meet.

`Consensus_state.update{,_var}` no longer accumulates. It took a supply increase and did `add_signed_flagged` against the previous `total_currency`, asserting the result stayed in range; it now takes the new total directly. **The range check is not lost** — it moves to where the register is updated, in the base and zkApp circuits, so an update that would take the total out of range is rejected by the transaction snark instead of by consensus.

What ties the two together is in the blockchain SNARK: when a proof is emitted it requires `txn_snark.source.total_currency` to be the total currency consensus already carries, and the new consensus value is `txn_snark.target.total_currency`. When no proof is emitted the total is carried forward unchanged, as before. That assert lives inside `txn_snark_input_correct`, so it is only required when something actually changed.

## The parts that were not mechanical

**Threading.** Both registers have to be threaded through the staged ledger so consecutive base statements chain. The fee excess can be threaded in the first pass, since it is a pure function of the transaction; the supply increase is only known once a transaction has been applied, so the total currency is threaded through the second pass instead.

**Seeding.** The fee excess seeds at zero, which `check_zero_fee_excess` guarantees is correct at partition boundaries — it is threaded between the two partitions rather than assumed. The total currency has no such anchor. Folding the ledger's balances is both expensive and wrong (it overflows `Amount` on test ledgers). The seed is instead the scan state's own end state, via the new `Scan_state.latest_target_registers`; when the scan state is empty there are no pending transactions, so the staged ledger *is* the snarked ledger and the value consensus already carries is the right one.

**Snark worker.** Segment witnesses have to be generated from the transaction statement's own source registers, not from zero, or the segment statements will not chain back to the statement being proved. `zkapp_command_witnesses_exn` now takes the total currency the witnesses start from, alongside the fee excess.

## Versioned types

**No version bumps here, deliberately.** #19302 already moved `Snarked_ledger_state` and everything above it to versions that do not exist on `develop`, and the first commit here bumped `Registers` V1 → V2 and `Snarked_ledger_state.Poly` V2 → V3 for the same reason. Since none of those versions have ever existed outside this stack, the shapes are being *defined* rather than *redefined*, and bumping again would burn version numbers for states that never shipped.

This is only sound while the stack is unmerged and lands together. If #19302 merges to `develop` on its own, this PR must bump the whole tree again before it can follow.

## Circuit stats

| Circuit | Constraints | Δ |
|---|---|---|
| transaction-merge | 568 | +4 |
| transaction-base | 12,877 | +13 |
| zkapp-opt_signed-opt_signed | 16,334 | +13 |
| zkapp-opt_signed | 8,926 | +13 |
| zkapp-proved | 5,149 | +13 |
| blockchain-step | 9,267 | +1 |

Public input is unchanged at 298: the two top-level fields removed are replaced by one each in the two registers.

Dev expected values and the profile-independent merge row are measured and updated. Devnet, lightnet and mainnet still hold stale base and zkApp rows, from #19302 onwards; those runs are not exercised in the PR pipeline.

## GraphQL

The `Registers` object gains `feeExcess` and `totalCurrency`. A work statement reports `sourceFeeExcess`/`targetFeeExcess` in place of `feeExcess`, and `sourceTotalCurrency`/`targetTotalCurrency` in place of `supplyIncrease`/`supplyChange`. `mina client pending-snark-work` reports the differences, which is what its `fee_excess` and `supply_increase` meant before.

## Testing

- `dune build @src/lib/check @src/app/check` green.
- All 31 staged ledger tests pass — they build real scan states and exercise the threading, merging and invariant checks.
- All 34 `transaction_union` tests pass, including the real base and merge proofs.
- Constraint count and blockchain-step stats tests pass with the updated dev values.
- `make check-format` clean.

## Known follow-ups

- Regenerate `dev_transaction_snark_vk.json` and `dev_blockchain_snark_vk.json` for this branch.
- Regenerate the devnet/lightnet/mainnet constraint-count rows if those profile runs are ever re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
