### PR TITLE
[HARD FORK] Record the ledger and total supply as of the latest coinbase

### DIFF
--- a/changes/19304.md
+++ b/changes/19304.md
@@ -1,0 +1,5 @@
+Record the ledger and total supply as of the most recent coinbase in transaction proofs
+
+Transaction proof statements now carry the second-pass ledger hash and the total currency as they stood after the most recent coinbase, alongside the state before and after the transition itself. A coinbase moves those values on to where it ends; every other transaction carries them through unchanged. This is a hard-fork change: verification keys, protocol state hashes, block formats and peer-to-peer RPCs all differ from earlier releases, so a node built from this change cannot exchange blocks or snark work with one that is not.
+
+In the GraphQL API the `Registers` type gains `ledgerAfterCoinbase` and `totalSupplyAfterCoinbase`.

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11306,6 +11306,38 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "ledgerAfterCoinbase",
+              "description": "Second-pass ledger hash as of the most recent coinbase",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "LedgerHash",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalSupplyAfterCoinbase",
+              "description": "Total currency as of the most recent coinbase",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Amount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/app/cli/src/init/test_ledger_application.ml
+++ b/src/app/cli/src/init/test_ledger_application.ml
@@ -160,8 +160,13 @@ let apply_txs ~transfer_parties_get_actions_events ~action_elements
       ~first_partition_slots ~is_new_stack:(not no_new_stack)
       ~no_second_partition:(not has_second_partition) ~constraint_constants
       ~logger ~global_slot ~signature_kind:Mina_signature_kind.Testnet
-      ~init_total_currency:Currency.Amount.zero ledger pending_coinbase zkapps'
-      prev_state_view
+      ~init_carried:
+        { Staged_ledger.Carried_registers.total_currency = Currency.Amount.zero
+        ; ledger_after_coinbase =
+            Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
+        ; total_supply_after_coinbase = Currency.Amount.zero
+        }
+      ledger pending_coinbase zkapps' prev_state_view
       (prev_protocol_state_hash, prev_protocol_state_body_hash)
   with
   | Ok (b, _, _, _, _, _) ->

--- a/src/app/disk_caching_stats/disk_caching_stats.ml
+++ b/src/app/disk_caching_stats/disk_caching_stats.ml
@@ -384,6 +384,8 @@ module Values (S : Sample) = struct
             ; local_state = local_state ()
             ; fee_excess = fee_excess ()
             ; total_currency = Currency.Amount.zero
+            ; ledger_after_coinbase = field ()
+            ; total_supply_after_coinbase = Currency.Amount.zero
             }
         ; target =
             { first_pass_ledger = field ()
@@ -392,6 +394,8 @@ module Values (S : Sample) = struct
             ; local_state = local_state ()
             ; fee_excess = fee_excess ()
             ; total_currency = Currency.Amount.zero
+            ; ledger_after_coinbase = field ()
+            ; total_supply_after_coinbase = Currency.Amount.zero
             }
         ; connecting_ledger_left = field ()
         ; connecting_ledger_right = field ()

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -145,6 +145,10 @@ let gen_proof ?(zkapp_account = None) (zkapp_command : Zkapp_command.t)
       ~constraint_constants ~global_slot ~state_body
       ~fee_excess:Currency.Amount.Signed.zero
       ~total_currency:Currency.Amount.zero
+      ~ledger_after_coinbase:
+        (Frozen_ledger_hash.of_ledger_hash
+           (Mina_ledger.Ledger.merkle_root ledger) )
+      ~total_supply_after_coinbase:Currency.Amount.zero
       [ ( `Pending_coinbase_init_stack pending_coinbase_init_stack
         , `Pending_coinbase_of_statement pending_coinbase_state_stack
         , `Ledger ledger
@@ -236,6 +240,10 @@ let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
       ~constraint_constants ~global_slot ~state_body
       ~fee_excess:Currency.Amount.Signed.zero
       ~total_currency:Currency.Amount.zero
+      ~ledger_after_coinbase:
+        (Frozen_ledger_hash.of_ledger_hash
+           (Mina_ledger.Ledger.merkle_root ledger) )
+      ~total_supply_after_coinbase:Currency.Amount.zero
       [ ( `Pending_coinbase_init_stack pending_coinbase_init_stack
         , `Pending_coinbase_of_statement pending_coinbase_state_stack
         , `Ledger ledger

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -82,6 +82,8 @@ let non_pc_registers_equal_var t1 t2 =
           Local_state.Checked.equal' (F.get f t1) (F.get f t2) @ acc )
         ~fee_excess:(f !Fee_excess.equal_checked)
         ~total_currency:(f !Currency.Amount.equal_var)
+        ~ledger_after_coinbase:(f !Frozen_ledger_hash.equal_var)
+        ~total_supply_after_coinbase:(f !Currency.Amount.equal_var)
       |> Impl.Boolean.all )
 
 let txn_statement_ledger_hashes_equal

--- a/src/lib/blockchain_snark/tests/test_blockchain_snark.ml
+++ b/src/lib/blockchain_snark/tests/test_blockchain_snark.ml
@@ -27,10 +27,10 @@ type circuit_stats =
   }
 
 let dev_expected_values =
-  { constraints = 9267
+  { constraints = 9347
   ; public_input_size = 1
-  ; auxiliary_input_size = 31740
-  ; digest = "d3f022cc66f8f30b27d661e2a6c87d78"
+  ; auxiliary_input_size = 32372
+  ; digest = "dd1a8230ed8912a2a0704abeae0fbe0f"
   }
 
 let devnet_expected_values =

--- a/src/lib/graphql/mina_graphql/types.ml
+++ b/src/lib/graphql/mina_graphql/types.ml
@@ -832,6 +832,18 @@ let registers : (Mina_lib.t, Mina_state.Registers.Value.t option) typ =
           ~doc:"Total currency in the ledger at this point"
           ~typ:(non_null amount)
           ~resolve:(fun _ ({ total_currency; _ } : _ M.t) -> total_currency)
+      ; field "ledgerAfterCoinbase"
+          ~args:Arg.[]
+          ~doc:"Second-pass ledger hash as of the most recent coinbase"
+          ~typ:(non_null ledger_hash)
+          ~resolve:(fun _ ({ ledger_after_coinbase; _ } : _ M.t) ->
+            ledger_after_coinbase )
+      ; field "totalSupplyAfterCoinbase"
+          ~args:Arg.[]
+          ~doc:"Total currency as of the most recent coinbase"
+          ~typ:(non_null amount)
+          ~resolve:(fun _ ({ total_supply_after_coinbase; _ } : _ M.t) ->
+            total_supply_after_coinbase )
       ]
 
 let snarked_ledger_state :

--- a/src/lib/mina_state/registers.ml
+++ b/src/lib/mina_state/registers.ml
@@ -23,6 +23,8 @@ module Stable = struct
       ; local_state : 'local_state
       ; fee_excess : 'fee_excess
       ; total_currency : 'amount
+      ; ledger_after_coinbase : 'ledger
+      ; total_supply_after_coinbase : 'amount
       }
     [@@deriving compare, equal, hash, sexp, yojson, hlist, fields]
   end
@@ -35,13 +37,17 @@ let gen =
   and pending_coinbase_stack = Pending_coinbase.Stack.gen
   and local_state = Local_state.gen
   and fee_excess = Fee_excess.gen
-  and total_currency = Currency.Amount.gen in
+  and total_currency = Currency.Amount.gen
+  and ledger_after_coinbase = Frozen_ledger_hash.gen
+  and total_supply_after_coinbase = Currency.Amount.gen in
   { first_pass_ledger
   ; second_pass_ledger
   ; pending_coinbase_stack
   ; local_state
   ; fee_excess
   ; total_currency
+  ; ledger_after_coinbase
+  ; total_supply_after_coinbase
   }
 
 let to_input
@@ -51,6 +57,8 @@ let to_input
     ; local_state
     ; fee_excess
     ; total_currency
+    ; ledger_after_coinbase
+    ; total_supply_after_coinbase
     } =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [| Frozen_ledger_hash.to_input first_pass_ledger
@@ -59,6 +67,8 @@ let to_input
      ; Local_state.to_input local_state
      ; Fee_excess.to_input fee_excess
      ; Currency.Amount.to_input total_currency
+     ; Frozen_ledger_hash.to_input ledger_after_coinbase
+     ; Currency.Amount.to_input total_supply_after_coinbase
     |]
 
 let typ spec =
@@ -109,6 +119,8 @@ module Checked = struct
       ; local_state
       ; fee_excess
       ; total_currency
+      ; ledger_after_coinbase
+      ; total_supply_after_coinbase
       } =
     let open Snark_params.Tick.Checked.Let_syntax in
     let%map fee_excess = Fee_excess.to_input_checked fee_excess in
@@ -119,6 +131,8 @@ module Checked = struct
        ; Local_state.Checked.to_input local_state
        ; fee_excess
        ; Currency.Amount.var_to_input total_currency
+       ; Frozen_ledger_hash.var_to_input ledger_after_coinbase
+       ; Currency.Amount.var_to_input total_supply_after_coinbase
       |]
 
   let equal t1 t2 =
@@ -132,5 +146,7 @@ module Checked = struct
         Local_state.Checked.equal' (Field.get f t1) (Field.get f t2) @ acc )
       ~fee_excess:(f !Fee_excess.equal_checked)
       ~total_currency:(f !Currency.Amount.equal_var)
+      ~ledger_after_coinbase:(f !Frozen_ledger_hash.equal_var)
+      ~total_supply_after_coinbase:(f !Currency.Amount.equal_var)
     |> Impl.Boolean.all
 end

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -141,6 +141,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     end]
 
     let with_empty_local_state ~source_total_currency ~target_total_currency
+        ~source_ledger_after_coinbase ~target_ledger_after_coinbase
+        ~source_total_supply_after_coinbase ~target_total_supply_after_coinbase
         ~source_fee_excess ~target_fee_excess ~sok_digest
         ~source_first_pass_ledger ~target_first_pass_ledger
         ~source_second_pass_ledger ~target_second_pass_ledger
@@ -157,6 +159,8 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; local_state = Local_state.empty ()
           ; fee_excess = source_fee_excess
           ; total_currency = source_total_currency
+          ; ledger_after_coinbase = source_ledger_after_coinbase
+          ; total_supply_after_coinbase = source_total_supply_after_coinbase
           }
       ; target =
           { first_pass_ledger = target_first_pass_ledger
@@ -165,6 +169,8 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; local_state = Local_state.empty ()
           ; fee_excess = target_fee_excess
           ; total_currency = target_total_currency
+          ; ledger_after_coinbase = target_ledger_after_coinbase
+          ; total_supply_after_coinbase = target_total_supply_after_coinbase
           }
       }
 
@@ -179,6 +185,8 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; pending_coinbase
           ; local_state_typ
           ; fee_excess
+          ; amount
+          ; ledger_hash
           ; amount
           ]
           ~var_to_hlist:Registers.to_hlist ~var_of_hlist:Registers.of_hlist
@@ -240,6 +248,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       ; fee_excess = Fee_excess.to_yojson t.fee_excess |> Yojson.Safe.to_string
       ; total_currency =
           Currency.Amount.to_yojson t.total_currency |> Yojson.Safe.to_string
+      ; ledger_after_coinbase = display_ledger_hash t.ledger_after_coinbase
+      ; total_supply_after_coinbase =
+          Currency.Amount.to_yojson t.total_supply_after_coinbase
+          |> Yojson.Safe.to_string
       }
     in
     { Poly.source = display_register t.source
@@ -257,6 +269,8 @@ module Make_str (A : Wire_types.Concrete) = struct
       ; local_state = Local_state.dummy ()
       ; fee_excess = Fee_excess.empty
       ; total_currency = genesis_total_currency
+      ; ledger_after_coinbase = genesis_ledger_hash
+      ; total_supply_after_coinbase = genesis_total_currency
       }
     in
     { source = registers
@@ -622,9 +636,17 @@ module Make_str (A : Wire_types.Concrete) = struct
     let connecting_ledger_left = s1.connecting_ledger_left in
     let connecting_ledger_right = s2.connecting_ledger_right in
     (*The total currency is a register: [s1] must end where [s2] begins.*)
-    let%map () =
+    let%bind () =
       or_error_of_bool ~error:"Total currency is not connected"
         (Currency.Amount.equal s1.target.total_currency s2.source.total_currency)
+    in
+    (*So are the values recorded as of the most recent coinbase.*)
+    let%map () =
+      or_error_of_bool ~error:"Post-coinbase state is not connected"
+        ( Frozen_ledger_hash.equal s1.target.ledger_after_coinbase
+            s2.source.ledger_after_coinbase
+        && Currency.Amount.equal s1.target.total_supply_after_coinbase
+             s2.source.total_supply_after_coinbase )
     in
     ( { source = s1.source
       ; target = s2.target

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -96,6 +96,10 @@ module type Full = sig
     val with_empty_local_state :
          source_total_currency:'amount
       -> target_total_currency:'amount
+      -> source_ledger_after_coinbase:'ledger_hash
+      -> target_ledger_after_coinbase:'ledger_hash
+      -> source_total_supply_after_coinbase:'amount
+      -> target_total_supply_after_coinbase:'amount
       -> source_fee_excess:'fee_excess
       -> target_fee_excess:'fee_excess
       -> sok_digest:'sok_digest

--- a/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_registers.ml
@@ -6,5 +6,7 @@ module V2 = struct
     ; local_state : 'local_state
     ; fee_excess : 'fee_excess
     ; total_currency : 'amount
+    ; ledger_after_coinbase : 'ledger
+    ; total_supply_after_coinbase : 'amount
     }
 end

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -141,6 +141,10 @@ module Transaction_key = struct
         ~state_body:Transaction_snark_tests.Util.genesis_state_body
         ~fee_excess:Currency.Amount.Signed.zero
         ~total_currency:Currency.Amount.zero
+        ~ledger_after_coinbase:
+          (Frozen_ledger_hash.of_ledger_hash
+             (Mina_ledger.Ledger.merkle_root ledger) )
+        ~total_supply_after_coinbase:Currency.Amount.zero
         [ ( `Pending_coinbase_init_stack Pending_coinbase.Stack.empty
           , `Pending_coinbase_of_statement
               { Transaction_snark.Pending_coinbase_stack_state.source =
@@ -602,6 +606,9 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                      ; local_state = Mina_state.Local_state.empty ()
                      ; fee_excess = Fee_excess.zero
                      ; total_currency = Currency.Amount.zero
+                     ; ledger_after_coinbase =
+                         Sparse_ledger.merkle_root source_ledger
+                     ; total_supply_after_coinbase = Currency.Amount.zero
                      }
                  ; target =
                      { first_pass_ledger = target_hash
@@ -613,6 +620,10 @@ let profile_user_command (module T : Transaction_snark.S) ~genesis_constants
                      ; fee_excess =
                          Transaction.fee_excess txn |> Or_error.ok_exn
                      ; total_currency =
+                         Transaction.expected_supply_increase txn
+                         |> Or_error.ok_exn
+                     ; ledger_after_coinbase = target_hash
+                     ; total_supply_after_coinbase =
                          Transaction.expected_supply_increase txn
                          |> Or_error.ok_exn
                      }

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -328,9 +328,25 @@ module T = struct
   let pending_coinbase_collection { pending_coinbase_collection; _ } =
     pending_coinbase_collection
 
+  (*The register values a base statement carries forward from the one before
+    it, as opposed to those that follow from the ledger or the transaction.*)
+  module Carried_registers = struct
+    type t =
+      { total_currency : Currency.Amount.t
+      ; ledger_after_coinbase : Frozen_ledger_hash.t
+      ; total_supply_after_coinbase : Currency.Amount.t
+      }
+
+    let of_registers (r : Mina_state.Registers.Value.t) =
+      { total_currency = r.total_currency
+      ; ledger_after_coinbase = r.ledger_after_coinbase
+      ; total_supply_after_coinbase = r.total_supply_after_coinbase
+      }
+  end
+
   let verify_scan_state_after_apply ~constraint_constants
       ~pending_coinbase_stack ~first_pass_ledger_end ~second_pass_ledger_end
-      ~total_currency_end (scan_state : Scan_state.t) =
+      ~(carried_end : Carried_registers.t) (scan_state : Scan_state.t) =
     let error_prefix =
       "Error verifying the parallel scan state after applying the diff."
     in
@@ -340,7 +356,9 @@ module T = struct
       ; local_state = Mina_state.Local_state.empty ()
       ; pending_coinbase_stack
       ; fee_excess = Fee_excess.zero
-      ; total_currency = total_currency_end
+      ; total_currency = carried_end.total_currency
+      ; ledger_after_coinbase = carried_end.ledger_after_coinbase
+      ; total_supply_after_coinbase = carried_end.total_supply_after_coinbase
       }
     in
     let statement_check = `Partial in
@@ -352,20 +370,19 @@ module T = struct
       ~statement_check ~verifier:() ~error_prefix ~registers_end
       ~last_proof_statement
 
-  (*The scan state's end total currency: there is no independent source for it
-    outside the proofs themselves, so it is read back from the scan state. What
-    verifies it is the chaining between statements in [scan_statement] and, at
-    the block level, the blockchain snark tying the emitted proof's source to
-    the consensus total currency.*)
-  let scan_state_total_currency ~default scan_state =
+  (*What the scan state ends at: there is no independent source for these
+    outside the proofs themselves, so they are read back from the scan state.
+    What verifies them is the chaining between statements in [scan_statement]
+    and, at the block level, the blockchain snark tying the emitted proof's
+    source to the consensus total currency.*)
+  let scan_state_carried_registers ~default scan_state =
     match Scan_state.latest_target_registers scan_state with
-    | Some (r : Mina_state.Registers.Value.t) ->
-        r.total_currency
+    | Some r ->
+        Carried_registers.of_registers r
     | None ->
-        (*An empty scan state has no statement to read the total currency from.
-          It also means there are no pending transactions, so the staged ledger
-          is the snarked ledger and the value consensus already carries is the
-          right one.*)
+        (*An empty scan state has no statement to read these from. It also means
+          there are no pending transactions, so the staged ledger is the snarked
+          ledger and what the caller already has is right.*)
         default
 
   let of_scan_state_and_ledger ~logger
@@ -388,20 +405,31 @@ module T = struct
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~last_proof_statement
         ~registers_end:
-          { local_state = Mina_state.Local_state.empty ()
-          ; fee_excess = Fee_excess.zero
-          ; total_currency =
-              scan_state_total_currency scan_state
-                ~default:
-                  (Option.value_map last_proof_statement
-                     ~default:Currency.Amount.zero
-                     ~f:(fun (stmt : Transaction_snark.Statement.t) ->
-                       stmt.target.total_currency ) )
-          ; first_pass_ledger = first_pass_ledger_target
-          ; second_pass_ledger =
-              Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
-          ; pending_coinbase_stack
-          }
+          (let ({ total_currency
+                ; ledger_after_coinbase
+                ; total_supply_after_coinbase
+                }
+                 : Carried_registers.t ) =
+             scan_state_carried_registers scan_state
+               ~default:
+                 (Option.value_map last_proof_statement
+                    ~default:
+                      { Carried_registers.total_currency = Currency.Amount.zero
+                      ; ledger_after_coinbase = first_pass_ledger_target
+                      ; total_supply_after_coinbase = Currency.Amount.zero
+                      } ~f:(fun (stmt : Transaction_snark.Statement.t) ->
+                      Carried_registers.of_registers stmt.target ) )
+           in
+           { local_state = Mina_state.Local_state.empty ()
+           ; fee_excess = Fee_excess.zero
+           ; total_currency
+           ; ledger_after_coinbase
+           ; total_supply_after_coinbase
+           ; first_pass_ledger = first_pass_ledger_target
+           ; second_pass_ledger =
+               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
+           ; pending_coinbase_stack
+           } )
     in
     return t
 
@@ -422,20 +450,31 @@ module T = struct
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~last_proof_statement
         ~registers_end:
-          { local_state = Mina_state.Local_state.empty ()
-          ; fee_excess = Fee_excess.zero
-          ; total_currency =
-              scan_state_total_currency scan_state
-                ~default:
-                  (Option.value_map last_proof_statement
-                     ~default:Currency.Amount.zero
-                     ~f:(fun (stmt : Transaction_snark.Statement.t) ->
-                       stmt.target.total_currency ) )
-          ; first_pass_ledger = first_pass_ledger_target
-          ; second_pass_ledger =
-              Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
-          ; pending_coinbase_stack
-          }
+          (let ({ total_currency
+                ; ledger_after_coinbase
+                ; total_supply_after_coinbase
+                }
+                 : Carried_registers.t ) =
+             scan_state_carried_registers scan_state
+               ~default:
+                 (Option.value_map last_proof_statement
+                    ~default:
+                      { Carried_registers.total_currency = Currency.Amount.zero
+                      ; ledger_after_coinbase = first_pass_ledger_target
+                      ; total_supply_after_coinbase = Currency.Amount.zero
+                      } ~f:(fun (stmt : Transaction_snark.Statement.t) ->
+                      Carried_registers.of_registers stmt.target ) )
+           in
+           { local_state = Mina_state.Local_state.empty ()
+           ; fee_excess = Fee_excess.zero
+           ; total_currency
+           ; ledger_after_coinbase
+           ; total_supply_after_coinbase
+           ; first_pass_ledger = first_pass_ledger_target
+           ; second_pass_ledger =
+               Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
+           ; pending_coinbase_stack
+           } )
     in
     return
       { ledger; scan_state; constraint_constants; pending_coinbase_collection }
@@ -641,8 +680,7 @@ module T = struct
 
   let apply_single_transaction_second_pass ~constraint_constants
       ~connecting_ledger ledger state_and_body_hash ~global_slot
-      ~(source_total_currency : Currency.Amount.t) (pre_stmt : Pre_statement.t)
-      =
+      ~(carried : Carried_registers.t) (pre_stmt : Pre_statement.t) =
     let open Result.Let_syntax in
     let empty_local_state = Mina_state.Local_state.empty () in
     let second_pass_ledger_source_hash = Ledger.merkle_root ledger in
@@ -667,13 +705,33 @@ module T = struct
       from.*)
     let%bind target_total_currency =
       match
-        Currency.Amount.add_signed_flagged source_total_currency supply_increase
+        Currency.Amount.add_signed_flagged carried.total_currency
+          supply_increase
       with
       | total, `Overflow false ->
           return total
       | _, `Overflow true ->
           to_staged_ledger_or_error
             (Or_error.error_string "Total currency out of range")
+    in
+    (*A coinbase moves the recorded post-coinbase state on to where this
+      transition ends; anything else carries it through.*)
+    let is_coinbase =
+      match
+        Mina_transaction_logic.Transaction_applied.transaction applied_txn
+      with
+      | Mina_transaction.Transaction.Coinbase _ ->
+          true
+      | Command _ | Fee_transfer _ ->
+          false
+    in
+    let target_ledger_after_coinbase =
+      if is_coinbase then second_pass_ledger_target_hash
+      else carried.ledger_after_coinbase
+    in
+    let target_total_supply_after_coinbase =
+      if is_coinbase then target_total_currency
+      else carried.total_supply_after_coinbase
     in
     let%map () =
       let actual_status = Ledger.status_of_applied applied_txn in
@@ -697,7 +755,9 @@ module T = struct
           ; pending_coinbase_stack = pre_stmt.pending_coinbase_stack_source
           ; local_state = empty_local_state
           ; fee_excess = pre_stmt.source_fee_excess
-          ; total_currency = source_total_currency
+          ; total_currency = carried.total_currency
+          ; ledger_after_coinbase = carried.ledger_after_coinbase
+          ; total_supply_after_coinbase = carried.total_supply_after_coinbase
           }
       ; target =
           { first_pass_ledger = pre_stmt.first_pass_ledger_target_hash
@@ -706,6 +766,8 @@ module T = struct
           ; local_state = empty_local_state
           ; fee_excess = pre_stmt.target_fee_excess
           ; total_currency = target_total_currency
+          ; ledger_after_coinbase = target_ledger_after_coinbase
+          ; total_supply_after_coinbase = target_total_supply_after_coinbase
           }
       ; connecting_ledger_left = connecting_ledger
       ; connecting_ledger_right = connecting_ledger
@@ -755,31 +817,30 @@ module T = struct
     (List.rev res_rev, pending_coinbase_stack_state.pc.target)
 
   let apply_transactions_second_pass ~constraint_constants ~yield ~global_slot
-      ~init_total_currency ledger state_and_body_hash pre_stmts =
+      ~init_carried ledger state_and_body_hash pre_stmts =
     let open Deferred.Result.Let_syntax in
     let connecting_ledger = Ledger.merkle_root ledger in
-    let%map res_rev, total_currency_end =
-      Mina_stdlib.Deferred.Result.List.fold pre_stmts
-        ~init:([], init_total_currency)
-        ~f:(fun (acc, source_total_currency) pre_stmt ->
+    let%map res_rev, carried_end =
+      Mina_stdlib.Deferred.Result.List.fold pre_stmts ~init:([], init_carried)
+        ~f:(fun (acc, carried) pre_stmt ->
           let%bind result =
             apply_single_transaction_second_pass ~constraint_constants
-              ~connecting_ledger ~global_slot ~source_total_currency ledger
+              ~connecting_ledger ~global_slot ~carried ledger
               state_and_body_hash pre_stmt
             |> Deferred.return
           in
           let%map () = yield () in
           let txn_with_witness, _ = result in
           ( result :: acc
-          , txn_with_witness.Scan_state.Transaction_with_witness.statement
-              .target
-              .total_currency ) )
+          , Carried_registers.of_registers
+              txn_with_witness.Scan_state.Transaction_with_witness.statement
+                .target ) )
     in
-    (List.rev res_rev, total_currency_end)
+    (List.rev res_rev, carried_end)
 
   let update_ledger_and_get_statements ~constraint_constants ~global_slot
-      ~signature_kind ~init_total_currency ledger current_stack tss
-      current_state_view state_and_body_hash =
+      ~signature_kind ~init_carried ledger current_stack tss current_state_view
+      state_and_body_hash =
     let open Deferred.Result.Let_syntax in
     let state_body_hash = snd state_and_body_hash in
     let ts, ts_opt = tss in
@@ -825,15 +886,15 @@ module T = struct
             current_stack2 ts
     in
     let first_pass_ledger_end = Ledger.merkle_root ledger in
-    let%map txns_with_witnesses, total_currency_end =
+    let%map txns_with_witnesses, carried_end =
       apply_transactions_second_pass ~constraint_constants ~yield ~global_slot
-        ~init_total_currency ledger state_and_body_hash (pre_stmts1 @ pre_stmts2)
+        ~init_carried ledger state_and_body_hash (pre_stmts1 @ pre_stmts2)
     in
     ( txns_with_witnesses
     , updated_stack1
     , updated_stack2
     , first_pass_ledger_end
-    , total_currency_end )
+    , carried_end )
 
   (** Checks if the work has already been verified before by the snark pool logic *)
   let work_already_verified_check ~get_completed_work jobs work =
@@ -962,7 +1023,7 @@ module T = struct
 
   let update_coinbase_stack_and_get_data_impl ~logger ~constraint_constants
       ~global_slot ~first_partition_slots:slots ~no_second_partition
-      ~is_new_stack ~signature_kind ~init_total_currency ledger
+      ~is_new_stack ~signature_kind ~init_carried ledger
       pending_coinbase_collection transactions current_state_view
       state_and_body_hash =
     let open Deferred.Result.Let_syntax in
@@ -986,10 +1047,9 @@ module T = struct
       in
       [%log internal] "Update_ledger_and_get_statements"
         ~metadata:[ ("partition", `String "single") ] ;
-      let%map data, updated_stack, _, first_pass_ledger_end, total_currency_end
-          =
+      let%map data, updated_stack, _, first_pass_ledger_end, carried_end =
         update_ledger_and_get_statements ~constraint_constants ~global_slot
-          ~signature_kind ~init_total_currency ledger working_stack
+          ~signature_kind ~init_carried ledger working_stack
           (transactions, None) current_state_view state_and_body_hash
       in
       [%log internal] "Update_ledger_and_get_statements_done" ;
@@ -1004,7 +1064,7 @@ module T = struct
       , Pending_coinbase.Update.Action.Update_one
       , `Update_one updated_stack
       , `First_pass_ledger_end first_pass_ledger_end
-      , `Total_currency_end total_currency_end ) )
+      , `Carried_end carried_end ) )
     else
       (*Two partition:
         Assumption: Only one of the partition will have coinbase transaction(s)in it.
@@ -1029,9 +1089,9 @@ module T = struct
           , updated_stack1
           , updated_stack2
           , first_pass_ledger_end
-          , total_currency_end ) =
+          , carried_end ) =
         update_ledger_and_get_statements ~constraint_constants ~global_slot
-          ~signature_kind ~init_total_currency ledger working_stack1
+          ~signature_kind ~init_carried ledger working_stack1
           (txns_for_partition1, Some txns_for_partition2)
           current_state_view state_and_body_hash
       in
@@ -1073,16 +1133,27 @@ module T = struct
       , pending_coinbase_action
       , stack_update
       , `First_pass_ledger_end first_pass_ledger_end
-      , `Total_currency_end total_currency_end )
+      , `Carried_end carried_end )
 
   let update_coinbase_stack_and_get_data ~logger ~constraint_constants
       ~global_slot ~signature_kind scan_state ledger pending_coinbase_collection
       transactions current_state_view state_and_body_hash =
-    let init_total_currency =
-      scan_state_total_currency scan_state
+    (*Nothing pending means the staged ledger is the snarked ledger, so the
+      values consensus already carries are the ones to continue from. There is
+      no consensus field for the post-coinbase state, so it starts from the
+      ledger the block is being applied to.*)
+    let init_carried =
+      scan_state_carried_registers scan_state
         ~default:
-          current_state_view
-            .Zkapp_precondition.Protocol_state.Poly.total_currency
+          { Carried_registers.total_currency =
+              current_state_view
+                .Zkapp_precondition.Protocol_state.Poly.total_currency
+          ; ledger_after_coinbase =
+              Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger)
+          ; total_supply_after_coinbase =
+              current_state_view
+                .Zkapp_precondition.Protocol_state.Poly.total_currency
+          }
     in
     let { Scan_state.Space_partition.first = slots, _; second } =
       Scan_state.partition_if_overflowing scan_state
@@ -1092,7 +1163,7 @@ module T = struct
       update_coinbase_stack_and_get_data_impl ~logger ~constraint_constants
         ~global_slot ~first_partition_slots:slots
         ~no_second_partition:(Option.is_none second) ~is_new_stack
-        ~signature_kind ~init_total_currency ledger pending_coinbase_collection
+        ~signature_kind ~init_carried ledger pending_coinbase_collection
         transactions current_state_view state_and_body_hash
     else (
       [%log internal] "Update_coinbase_stack_done" ;
@@ -1103,7 +1174,7 @@ module T = struct
            , Pending_coinbase.Update.Action.Update_none
            , `Update_none
            , `First_pass_ledger_end (Ledger.merkle_root ledger)
-           , `Total_currency_end init_total_currency ) ) )
+           , `Carried_end init_carried ) ) )
 
   (* Update the pending_coinbase tree with the updated/new stack and delete the
      oldest stack if a proof was emitted *)
@@ -1228,7 +1299,7 @@ module T = struct
         , stack_update_in_snark
         , stack_update
         , `First_pass_ledger_end first_pass_ledger_end
-        , `Total_currency_end total_currency_end ) =
+        , `Carried_end carried_end ) =
       O1trace.thread "update_coinbase_stack_start_time" (fun () ->
           update_coinbase_stack_and_get_data ~logger ~constraint_constants
             ~global_slot ~signature_kind t.scan_state new_ledger
@@ -1321,7 +1392,7 @@ module T = struct
         O1trace.thread "verify_scan_state_after_apply" (fun () ->
             Deferred.(
               verify_scan_state_after_apply ~constraint_constants ~logger
-                ~total_currency_end ~first_pass_ledger_end
+                ~carried_end ~first_pass_ledger_end
                 ~second_pass_ledger_end:
                   (Frozen_ledger_hash.of_ledger_hash
                      (Ledger.merkle_root new_ledger) )

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -343,6 +343,16 @@ module For_tests : sig
   module Application_state = Application_state
 end
 
+(** The register values a base statement carries forward from the one before
+    it, as opposed to those that follow from the ledger or the transaction. *)
+module Carried_registers : sig
+  type t =
+    { total_currency : Currency.Amount.t
+    ; ledger_after_coinbase : Frozen_ledger_hash.t
+    ; total_supply_after_coinbase : Currency.Amount.t
+    }
+end
+
 module Test_helpers : sig
   val dummy_state_and_view :
        ?global_slot:Mina_numbers.Global_slot_since_genesis.t
@@ -363,7 +373,7 @@ module Test_helpers : sig
     -> no_second_partition:bool
     -> is_new_stack:bool
     -> signature_kind:Mina_signature_kind.t
-    -> init_total_currency:Currency.Amount.t
+    -> init_carried:Carried_registers.t
     -> Ledger.t
     -> Pending_coinbase.t
     -> Transaction.t With_status.t list
@@ -380,7 +390,7 @@ module Test_helpers : sig
              Pending_coinbase.Stack_versioned.t
              * Pending_coinbase.Stack_versioned.t ]
          * [> `First_pass_ledger_end of Frozen_ledger_hash.t ]
-         * [> `Total_currency_end of Currency.Amount.t ]
+         * [> `Carried_end of Carried_registers.t ]
        , Staged_ledger_error.t )
        Deferred.Result.t
 end

--- a/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
+++ b/src/lib/transaction_snark/test/constraint_count/test_constraint_count.ml
@@ -50,65 +50,65 @@ type profile_expected_values =
 
 let dev_expected_values =
   { transaction_merge =
-      { constraints = 568
-      ; public_input_size = 298
-      ; auxiliary_input_size = 1843
-      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
+      { constraints = 592
+      ; public_input_size = 302
+      ; auxiliary_input_size = 2115
+      ; digest = "7ecc7b899362c3bfbd5dbd58c2cbb40f"
       }
   ; transaction_base =
-      { constraints = 12877
-      ; public_input_size = 298
-      ; auxiliary_input_size = 37511
-      ; digest = "8bfa307456fa9dd8e674059a412eb414"
+      { constraints = 12910
+      ; public_input_size = 302
+      ; auxiliary_input_size = 37863
+      ; digest = "4429055a113a3234c651b725f7c1dc9c"
       }
   ; zkapp_opt_signed_opt_signed =
-      { constraints = 16334
-      ; public_input_size = 298
-      ; auxiliary_input_size = 73489
-      ; digest = "29933b2934ac2be1d2ad971192f29612"
+      { constraints = 16364
+      ; public_input_size = 302
+      ; auxiliary_input_size = 73839
+      ; digest = "d48a98fe5ebef2a470cb4a2959c4c6b5"
       }
   ; zkapp_opt_signed =
-      { constraints = 8926
-      ; public_input_size = 298
-      ; auxiliary_input_size = 40599
-      ; digest = "578e94634eb8ce36409a7e47aa7a2057"
+      { constraints = 8956
+      ; public_input_size = 302
+      ; auxiliary_input_size = 40949
+      ; digest = "2e98fc2d0ee076a58b336191eaf78881"
       }
   ; zkapp_proved =
-      { constraints = 5149
-      ; public_input_size = 298
-      ; auxiliary_input_size = 39165
-      ; digest = "175f595e71ac83ebca6043c50974fc9f"
+      { constraints = 5179
+      ; public_input_size = 302
+      ; auxiliary_input_size = 39515
+      ; digest = "0a71d318e1c862cae29da74075f770bb"
       }
   }
 
 let devnet_expected_values =
   { transaction_merge =
-      { constraints = 568
-      ; public_input_size = 298
-      ; auxiliary_input_size = 1843
-      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
+      { constraints = 592
+      ; public_input_size = 302
+      ; auxiliary_input_size = 2115
+      ; digest = "7ecc7b899362c3bfbd5dbd58c2cbb40f"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 63807
       ; digest = "3bf6bb8a97665fe7a9df6fc146e4f942"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 91179
       ; digest = "614aec09ed5e4068f46d010f0070226b"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 49639
       ; digest = "0fe3381f501f432744727c296be464b0"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 48205
       ; digest = "cad581432831f10fee99161532504937"
       }
@@ -116,32 +116,32 @@ let devnet_expected_values =
 
 let lightnet_expected_values =
   { transaction_merge =
-      { constraints = 568
-      ; public_input_size = 298
-      ; auxiliary_input_size = 1843
-      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
+      { constraints = 592
+      ; public_input_size = 302
+      ; auxiliary_input_size = 2115
+      ; digest = "7ecc7b899362c3bfbd5dbd58c2cbb40f"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 63807
       ; digest = "3bf6bb8a97665fe7a9df6fc146e4f942"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 91179
       ; digest = "614aec09ed5e4068f46d010f0070226b"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 49639
       ; digest = "0fe3381f501f432744727c296be464b0"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 48205
       ; digest = "cad581432831f10fee99161532504937"
       }
@@ -149,32 +149,32 @@ let lightnet_expected_values =
 
 let mainnet_expected_values =
   { transaction_merge =
-      { constraints = 568
-      ; public_input_size = 298
-      ; auxiliary_input_size = 1843
-      ; digest = "b69d1b6cd6804c77a3ecaa1dcc0b8aee"
+      { constraints = 592
+      ; public_input_size = 302
+      ; auxiliary_input_size = 2115
+      ; digest = "7ecc7b899362c3bfbd5dbd58c2cbb40f"
       }
   ; transaction_base =
       { constraints = 15357
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 63807
       ; digest = "d31948e661cc662675b0c079458f714a"
       }
   ; zkapp_opt_signed_opt_signed =
       { constraints = 18001
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 91179
       ; digest = "ddaa38405c20a8f7a7cf5235c1ed1713"
       }
   ; zkapp_opt_signed =
       { constraints = 9781
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 49639
       ; digest = "d048877d85e30a1ff9ff4cbdfcc33639"
       }
   ; zkapp_proved =
       { constraints = 6003
-      ; public_input_size = 298
+      ; public_input_size = 302
       ; auxiliary_input_size = 48205
       ; digest = "2d8810bdbda316e4b1f9f41ae1b28f6c"
       }

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -44,6 +44,8 @@ let%test_module "Transaction union tests" =
 
     let of_user_command' ?(source_fee_excess = Fee_excess.zero)
         ?(source_total_currency = Currency.Amount.zero)
+        ?source_ledger_after_coinbase
+        ?(source_total_supply_after_coinbase = Currency.Amount.zero)
         (sok_digest : Sok_message.Digest.t) ledger
         (user_command : Signed_command.With_valid_signature.t) init_stack
         pending_coinbase_stack_state state_body handler =
@@ -64,6 +66,11 @@ let%test_module "Transaction union tests" =
         }
       in
       let user_command_supply_increase = Currency.Amount.Signed.zero in
+      (*These fixtures only build signed-command statements, never coinbases,
+        so the post-coinbase state passes straight through.*)
+      let source_ledger_after_coinbase =
+        Option.value source_ledger_after_coinbase ~default:source
+      in
       let target_total_currency =
         match
           Currency.Amount.add_signed_flagged source_total_currency
@@ -91,7 +98,11 @@ let%test_module "Transaction union tests" =
                    (Fee_excess.combine source_fee_excess
                       (Or_error.ok_exn (Transaction.fee_excess txn)) ) )
               ~source_total_currency ~target_total_currency
-              ~pending_coinbase_stack_state
+              ~source_ledger_after_coinbase
+              ~target_ledger_after_coinbase:source_ledger_after_coinbase
+              ~source_total_supply_after_coinbase
+              ~target_total_supply_after_coinbase:
+                source_total_supply_after_coinbase ~pending_coinbase_stack_state
           in
           T.of_user_command ~init_stack ~statement user_command_in_block handler )
 
@@ -542,10 +553,14 @@ let%test_module "Transaction union tests" =
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;
               let proof23 =
-                of_user_command'
-                  ~source_fee_excess:
-                    (Transaction_snark.statement proof12).target.fee_excess
-                  sok_digest ledger t2 pending_coinbase_stack_state2.init_stack
+                let stmt12 = Transaction_snark.statement proof12 in
+                of_user_command' ~source_fee_excess:stmt12.target.fee_excess
+                  ~source_total_currency:stmt12.target.total_currency
+                  ~source_ledger_after_coinbase:
+                    stmt12.target.ledger_after_coinbase
+                  ~source_total_supply_after_coinbase:
+                    stmt12.target.total_supply_after_coinbase sok_digest ledger
+                  t2 pending_coinbase_stack_state2.init_stack
                   pending_coinbase_stack_state2.pc state_body2
                   (unstage @@ Sparse_ledger.handler sparse_ledger)
               in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -159,6 +159,9 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                 Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
                   ~constraint_constants ~global_slot ~state_body
                   ~fee_excess:Amount.Signed.zero ~total_currency:Amount.zero
+                  ~ledger_after_coinbase:
+                    (Sparse_ledger.merkle_root first_pass_ledger_witness)
+                  ~total_supply_after_coinbase:Amount.zero
                   [ ( `Pending_coinbase_init_stack init_stack
                     , `Pending_coinbase_of_statement
                         (pending_coinbase_state_stack ~state_body_hash
@@ -216,6 +219,9 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                         ; local_state = Mina_state.Local_state.empty ()
                         ; fee_excess = Fee_excess.zero
                         ; total_currency = Currency.Amount.zero
+                        ; ledger_after_coinbase =
+                            Sparse_ledger.merkle_root first_pass_ledger_witness
+                        ; total_supply_after_coinbase = Currency.Amount.zero
                         }
                     ; target =
                         { first_pass_ledger = first_pass_ledger_target_hash
@@ -235,6 +241,10 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                              fst
                                (Currency.Amount.add_signed_flagged
                                   Currency.Amount.zero supply_increase ) )
+                            (*A zkApp command is never a coinbase.*)
+                        ; ledger_after_coinbase =
+                            Sparse_ledger.merkle_root first_pass_ledger_witness
+                        ; total_supply_after_coinbase = Currency.Amount.zero
                         }
                     ; connecting_ledger_left = connecting_ledger
                     ; connecting_ledger_right = connecting_ledger

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2120,6 +2120,18 @@ module Make_str (A : Wire_types.Concrete) = struct
                  the excess it ends with is the target register's. *)
               (Fee_excess.assert_equal_checked statement.target.fee_excess
                  (Amount.Signed.Checked.to_fee global.fee_excess) ) ) ;
+        with_label __LOC__ (fun () ->
+            run_checked
+              (* A zkApp command is never a coinbase, so the state recorded as
+                 of the latest coinbase passes through untouched. *)
+              (Tick.Checked.all_unit
+                 [ Frozen_ledger_hash.assert_equal
+                     statement.source.ledger_after_coinbase
+                     statement.target.ledger_after_coinbase
+                 ; Amount.Checked.assert_equal
+                     statement.source.total_supply_after_coinbase
+                     statement.target.total_supply_after_coinbase
+                 ] ) ) ;
         (Stdlib.( ! ) zkapp_input, `Must_verify (Stdlib.( ! ) must_verify))
 
       (* Horrible hack :( *)
@@ -3138,6 +3150,9 @@ module Make_str (A : Wire_types.Concrete) = struct
           statement.target.pending_coinbase_stack state_body t
       in
       let fee_excess = Amount.Signed.Checked.to_fee fee_excess in
+      let is_coinbase =
+        Transaction_union.Tag.Unpacked.is_coinbase t.payload.body.tag
+      in
       let%bind () =
         [%with_label_ "local state check"] (fun () ->
             make_checked (fun () ->
@@ -3177,6 +3192,28 @@ module Make_str (A : Wire_types.Concrete) = struct
               in
               Fee_excess.assert_equal_checked target_fee_excess
                 statement.target.fee_excess )
+          (*A coinbase moves the recorded post-coinbase state on to where this
+            transition ends; anything else carries it through untouched.*)
+        ; [%with_label_ "post-coinbase state tracks the latest coinbase"]
+            (fun () ->
+              let open Tick.Checked.Let_syntax in
+              let%bind ledger_after_coinbase =
+                Frozen_ledger_hash.if_ is_coinbase
+                  ~then_:statement.target.second_pass_ledger
+                  ~else_:statement.source.ledger_after_coinbase
+              in
+              let%bind total_supply_after_coinbase =
+                Currency.Amount.Checked.if_ is_coinbase
+                  ~then_:statement.target.total_currency
+                  ~else_:statement.source.total_supply_after_coinbase
+              in
+              Checked.all_unit
+                [ Frozen_ledger_hash.assert_equal ledger_after_coinbase
+                    statement.target.ledger_after_coinbase
+                ; Currency.Amount.Checked.assert_equal
+                    total_supply_after_coinbase
+                    statement.target.total_supply_after_coinbase
+                ] )
         ]
 
     let rule ~signature_kind ~constraint_constants : _ Pickles.Inductive_rule.t
@@ -3312,6 +3349,34 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; [%with_label_ "equal target total currency"] (fun () ->
                 Amount.Checked.assert_equal s.target.total_currency
                   s2.target.total_currency )
+          ; [%with_label_ "post-coinbase state connects at the merge point"]
+              (fun () ->
+                Tick.Checked.all_unit
+                  [ Frozen_ledger_hash.assert_equal
+                      s1.Statement.Poly.target.ledger_after_coinbase
+                      s2.Statement.Poly.source.ledger_after_coinbase
+                  ; Amount.Checked.assert_equal
+                      s1.Statement.Poly.target.total_supply_after_coinbase
+                      s2.Statement.Poly.source.total_supply_after_coinbase
+                  ] )
+          ; [%with_label_ "equal source post-coinbase state"] (fun () ->
+                Tick.Checked.all_unit
+                  [ Frozen_ledger_hash.assert_equal
+                      s.source.ledger_after_coinbase
+                      s1.source.ledger_after_coinbase
+                  ; Amount.Checked.assert_equal
+                      s.source.total_supply_after_coinbase
+                      s1.source.total_supply_after_coinbase
+                  ] )
+          ; [%with_label_ "equal target post-coinbase state"] (fun () ->
+                Tick.Checked.all_unit
+                  [ Frozen_ledger_hash.assert_equal
+                      s.target.ledger_after_coinbase
+                      s2.target.ledger_after_coinbase
+                  ; Amount.Checked.assert_equal
+                      s.target.total_supply_after_coinbase
+                      s2.target.total_supply_after_coinbase
+                  ] )
           ; [%with_label_ "equal source fee payment ledger hashes"] (fun () ->
                 Frozen_ledger_hash.assert_equal s.source.first_pass_ledger
                   s1.source.first_pass_ledger )
@@ -3469,9 +3534,30 @@ module Make_str (A : Wire_types.Concrete) = struct
           ( Currency.Amount.zero
           , Currency.Amount.Signed.magnitude supply_increase )
     in
+    (*The second pass ledger does not move for a transaction union, so a
+      coinbase records the ledger this transition ends at.*)
+    let source_ledger_after_coinbase = source_first_pass_ledger in
+    let source_total_supply_after_coinbase = source_total_currency in
+    let is_coinbase =
+      match transaction.payload.body.tag with
+      | Transaction_union_tag.Coinbase ->
+          true
+      | Payment | Stake_delegation | Fee_transfer ->
+          false
+    in
+    let target_ledger_after_coinbase =
+      if is_coinbase then target_first_pass_ledger
+      else source_ledger_after_coinbase
+    in
+    let target_total_supply_after_coinbase =
+      if is_coinbase then target_total_currency
+      else source_total_supply_after_coinbase
+    in
     let statement : Statement.With_sok.t =
       Statement.Poly.with_empty_local_state ~source_total_currency
-        ~target_total_currency ~source_first_pass_ledger
+        ~target_total_currency ~source_ledger_after_coinbase
+        ~target_ledger_after_coinbase ~source_total_supply_after_coinbase
+        ~target_total_supply_after_coinbase ~source_first_pass_ledger
         ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
         ~target_second_pass_ledger:target_first_pass_ledger
@@ -3559,9 +3645,28 @@ module Make_str (A : Wire_types.Concrete) = struct
           ( Currency.Amount.zero
           , Currency.Amount.Signed.magnitude supply_increase )
     in
+    let source_ledger_after_coinbase = source_first_pass_ledger in
+    let source_total_supply_after_coinbase = source_total_currency in
+    let is_coinbase =
+      match transaction.payload.body.tag with
+      | Transaction_union_tag.Coinbase ->
+          true
+      | Payment | Stake_delegation | Fee_transfer ->
+          false
+    in
+    let target_ledger_after_coinbase =
+      if is_coinbase then target_first_pass_ledger
+      else source_ledger_after_coinbase
+    in
+    let target_total_supply_after_coinbase =
+      if is_coinbase then target_total_currency
+      else source_total_supply_after_coinbase
+    in
     let statement : Statement.With_sok.t =
       Statement.Poly.with_empty_local_state ~source_total_currency
-        ~target_total_currency ~source_fee_excess:Fee_excess.zero
+        ~target_total_currency ~source_ledger_after_coinbase
+        ~target_ledger_after_coinbase ~source_total_supply_after_coinbase
+        ~target_total_supply_after_coinbase ~source_fee_excess:Fee_excess.zero
         ~target_fee_excess:(Transaction_union.fee_excess transaction)
         ~sok_digest ~source_first_pass_ledger ~target_first_pass_ledger
         ~source_second_pass_ledger:target_first_pass_ledger
@@ -3720,6 +3825,7 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   let zkapp_command_witnesses_exn ~signature_kind ~constraint_constants
       ~global_slot ~state_body ~fee_excess ~total_currency
+      ~ledger_after_coinbase ~total_supply_after_coinbase
       (zkapp_commands_with_context :
         ( [ `Pending_coinbase_init_stack of Pending_coinbase.Stack.t ]
         * [ `Pending_coinbase_of_statement of Pending_coinbase_stack_state.t ]
@@ -4042,7 +4148,11 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; ledger = source_local_ledger
                   }
               ; fee_excess = source_fee_excess
-              ; total_currency = source_total_currency
+              ; total_currency =
+                  source_total_currency
+                  (*A zkApp command is never a coinbase, so these pass through.*)
+              ; ledger_after_coinbase
+              ; total_supply_after_coinbase
               }
           ; target =
               { first_pass_ledger = target_first_pass_ledger_root
@@ -4058,6 +4168,8 @@ module Make_str (A : Wire_types.Concrete) = struct
                   }
               ; fee_excess = target_fee_excess
               ; total_currency = target_total_currency
+              ; ledger_after_coinbase
+              ; total_supply_after_coinbase
               }
           ; connecting_ledger_left = connecting_ledger
           ; connecting_ledger_right = connecting_ledger

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -37,44 +37,44 @@
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 568         | 298          | 1,843           |
-    | transaction-base            | 12,877      | 298          | 37,511          |
-    | zkapp-opt_signed-opt_signed | 16,334      | 298          | 73,489          |
-    | zkapp-opt_signed            | 8,926       | 298          | 40,599          |
-    | zkapp-proved                | 5,149       | 298          | 39,165          |
+    | transaction-merge           | 592         | 302          | 2,115           |
+    | transaction-base            | 12,910      | 302          | 37,863          |
+    | zkapp-opt_signed-opt_signed | 16,364      | 302          | 73,839          |
+    | zkapp-opt_signed            | 8,956       | 302          | 40,949          |
+    | zkapp-proved                | 5,179       | 302          | 39,515          |
     v}
 
     {b Devnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 568         | 298          | 1,843           |
-    | transaction-base            | 15,357      | 298          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
-    | zkapp-proved                | 5,106       | 298          | 39,736          |
+    | transaction-merge           | 592         | 302          | 2,115           |
+    | transaction-base            | 15,357      | 302          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 302          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 302          | 41,170          |
+    | zkapp-proved                | 5,106       | 302          | 39,736          |
     v}
 
     {b Lightnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 568         | 298          | 1,843           |
-    | transaction-base            | 15,357      | 298          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
-    | zkapp-proved                | 5,106       | 298          | 39,736          |
+    | transaction-merge           | 592         | 302          | 2,115           |
+    | transaction-base            | 15,357      | 302          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 302          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 302          | 41,170          |
+    | zkapp-proved                | 5,106       | 302          | 39,736          |
     v}
 
     {b Mainnet profile:}
     {v
     | Circuit                     | Constraints | Public Input | Auxiliary Input |
     |-----------------------------|-------------|--------------|-----------------|
-    | transaction-merge           | 568         | 298          | 1,843           |
-    | transaction-base            | 15,357      | 298          | 63,806          |
-    | zkapp-opt_signed-opt_signed | 16,206      | 298          | 74,242          |
-    | zkapp-opt_signed            | 8,883       | 298          | 41,170          |
-    | zkapp-proved                | 5,106       | 298          | 39,736          |
+    | transaction-merge           | 592         | 302          | 2,115           |
+    | transaction-base            | 15,357      | 302          | 63,806          |
+    | zkapp-opt_signed-opt_signed | 16,206      | 302          | 74,242          |
+    | zkapp-opt_signed            | 8,883       | 302          | 41,170          |
+    | zkapp-proved                | 5,106       | 302          | 39,736          |
     v}
 
     If these values change, update the tables above and the expected values in
@@ -275,6 +275,8 @@ module type Full = sig
     -> state_body:Transaction_protocol_state.Block_data.t
     -> fee_excess:Currency.Amount.Signed.t
     -> total_currency:Currency.Amount.t
+    -> ledger_after_coinbase:Frozen_ledger_hash.t
+    -> total_supply_after_coinbase:Currency.Amount.t
     -> ( [ `Pending_coinbase_init_stack of Pending_coinbase.Stack.t ]
        * [ `Pending_coinbase_of_statement of Pending_coinbase_stack_state.t ]
        * [ `Ledger of Mina_ledger.Ledger.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -385,6 +385,27 @@ let create_expected_statement ~constraint_constants
     | _, `Overflow true ->
         Or_error.error_string "Total currency out of range"
   in
+  (*A coinbase moves the recorded post-coinbase state on to where this
+    transition ends; anything else carries it through.*)
+  let source_ledger_after_coinbase = statement.source.ledger_after_coinbase in
+  let source_total_supply_after_coinbase =
+    statement.source.total_supply_after_coinbase
+  in
+  let is_coinbase =
+    match transaction with
+    | Mina_transaction.Transaction.Coinbase _ ->
+        true
+    | Command _ | Fee_transfer _ ->
+        false
+  in
+  let target_ledger_after_coinbase =
+    if is_coinbase then target_second_pass_merkle_root
+    else source_ledger_after_coinbase
+  in
+  let target_total_supply_after_coinbase =
+    if is_coinbase then target_total_currency
+    else source_total_supply_after_coinbase
+  in
   { Transaction_snark.Statement.Poly.source =
       { first_pass_ledger = source_first_pass_merkle_root
       ; second_pass_ledger = source_second_pass_merkle_root
@@ -392,6 +413,8 @@ let create_expected_statement ~constraint_constants
       ; local_state = empty_local_state
       ; fee_excess = source_fee_excess
       ; total_currency = source_total_currency
+      ; ledger_after_coinbase = source_ledger_after_coinbase
+      ; total_supply_after_coinbase = source_total_supply_after_coinbase
       }
   ; target =
       { first_pass_ledger = target_first_pass_merkle_root
@@ -400,6 +423,8 @@ let create_expected_statement ~constraint_constants
       ; local_state = empty_local_state
       ; fee_excess = target_fee_excess
       ; total_currency = target_total_currency
+      ; ledger_after_coinbase = target_ledger_after_coinbase
+      ; total_supply_after_coinbase = target_total_supply_after_coinbase
       }
   ; connecting_ledger_left = connecting_merkle_root
   ; connecting_ledger_right = connecting_merkle_root
@@ -686,6 +711,13 @@ struct
         clarify_error
           (Currency.Amount.equal reg1.total_currency reg2.total_currency)
           "did not connect with total currency"
+      and () =
+        clarify_error
+          ( Frozen_ledger_hash.equal reg1.ledger_after_coinbase
+              reg2.ledger_after_coinbase
+          && Currency.Amount.equal reg1.total_supply_after_coinbase
+               reg2.total_supply_after_coinbase )
+          "did not connect with the post-coinbase state"
       in
       ()
     in

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -62,6 +62,8 @@ let extract_zkapp_segment_works ~m:(module M : S)
               transaction's own statement starts at, not from zero.*)
           ~fee_excess:(Currency.Amount.Signed.of_fee input.source.fee_excess)
           ~total_currency:input.source.total_currency
+          ~ledger_after_coinbase:input.source.ledger_after_coinbase
+          ~total_supply_after_coinbase:input.source.total_supply_after_coinbase
           [ ( `Pending_coinbase_init_stack witness.init_stack
             , `Pending_coinbase_of_statement
                 { Transaction_snark.Pending_coinbase_stack_state.source =


### PR DESCRIPTION
> **Third in a stack.** This targets `feat/fee-excess-registers` (#19303), which targets `feat/fee-excess-drop-tokens` (#19302), which targets `develop`. Review them in that order; the diff here is the single commit on top of #19303.

## ⚠️ Hard fork — breaks circuit and wire compatibility

Like the two PRs beneath it, **this cannot be deployed to an existing network without a hard fork.** On top of #19303 it further changes:

- **The transaction SNARK and blockchain SNARK circuits**, so all verification keys change again. The `dev_*_vk.json` files are now stale for two reasons; they need regenerating before this stack merges.
- **The protocol state hash**, since two more fields per register enter the statement's `to_input`.
- **The snark statement's shape and everything containing it**, so nodes either side cannot exchange blocks, snark work or RPCs.
- **The GraphQL schema** (see below).

All three PRs are intended to land in the same hard fork.

## What this does

Adds `ledger_after_coinbase` and `total_supply_after_coinbase` to the registers, recording the second-pass ledger and the total currency as of the most recent coinbase.

The base circuit selects between them:

```
target.ledger_after_coinbase =
  if is_coinbase then target.second_pass_ledger
  else source.ledger_after_coinbase

target.total_supply_after_coinbase =
  if is_coinbase then target.total_currency
  else source.total_supply_after_coinbase
```

A zkApp segment carries both through unconditionally — a zkApp command is never a coinbase. Merges connect them in the middle and propagate the ends, as with the other registers.

Neither field needs a new type parameter: the ledger reuses `'ledger` and the supply reuses `'amount`, so `Registers` keeps its arity, and (as in #19303) its version, since that version does not exist on `develop`.

## Wiring, which is most of the diff

Every `Registers` value is built as a record literal, so the compiler refused to build until all 21 construction sites set both fields. What it could not check is whether the *values* were right, and two of those mattered:

- **`create_expected_statement`** recomputes a statement from its stored witness and compares. It has to apply the same selection, or a statement claiming a post-coinbase state its transaction did not produce would pass. It now takes the source values from the statement under test and derives the targets.
- **The snark worker** has to generate segment witnesses from the transaction statement's own values, not defaults, or the segment statements will not chain back to the statement being proved. `zkapp_command_witnesses_exn` takes both as seeds.

The staged ledger now threads three carried values through the second pass rather than one, so they are bundled into `Carried_registers`. The seed still comes from `Scan_state.latest_target_registers`.

**One judgement call worth a reviewer's eye:** when the scan state is empty there is no statement to seed from, and unlike the total currency there is no consensus field holding a post-coinbase ledger. It falls back to the ledger the block is being applied to. That is correct at genesis and after any fully-settled scan state, but it is an assumption rather than something derived, and it is noted in the code.

## Circuit stats

| Circuit | Constraints | Δ |
|---|---|---|
| transaction-merge | 592 | +24 |
| transaction-base | 12,910 | +33 |
| zkapp-opt_signed-opt_signed | 16,364 | +30 |
| zkapp-opt_signed | 8,956 | +30 |
| zkapp-proved | 5,179 | +30 |
| blockchain-step | 9,347 | +80 |

Public input grows 298 → 302: two fields in each of the two registers.

Dev expected values and the profile-independent merge row are measured and updated. Devnet, lightnet and mainnet still hold stale base and zkApp rows, from #19302 onwards; those runs are not exercised in the PR pipeline.

## GraphQL

The `Registers` object gains `ledgerAfterCoinbase` and `totalSupplyAfterCoinbase`.

## Testing

- `dune build @src/lib/check @src/app/check` green.
- All 31 staged ledger tests pass.
- All 34 `transaction_union` tests pass, including the seven coinbase tests — those are what exercise the `is_coinbase = true` branch of the new selection, and the base-and-merge tests which exercise the chaining.
- Constraint count and blockchain-step stats tests pass with the updated dev values.
- `make check-format` clean.

## Known follow-ups

- Regenerate `dev_transaction_snark_vk.json` and `dev_blockchain_snark_vk.json` once the stack settles.
- Regenerate the devnet/lightnet/mainnet constraint-count rows if those profile runs are re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
