### PR TITLE
nix: bump nixpkgs to nixos-25.11-small

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -329,16 +329,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747187171,
-        "narHash": "sha256-heMv6zpxnLYhdcMtUxSn8PWaDLKlJCvQwhbarTNrXYI=",
+        "lastModified": 1782841183,
+        "narHash": "sha256-Ndt/5R7UN4rBdhFR1lxHZZZ42cD6vGlnuxC2VvvsKE4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97bd66213bef339d11520ee2e84e3907394b16c7",
+        "rev": "c9bfd86ed684d27e63b0ff9ebb18699f84f27a3b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11-small",
+        "ref": "nixos-25.11-small",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   };
 
   inputs.utils.url = "github:gytis-ivaskevicius/flake-utils-plus";
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11-small";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11-small";
   inputs.nixpkgs-old.url = "github:nixos/nixpkgs/nixos-23.05-small";
   inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -81,6 +81,15 @@ let
 
       core =
         super.core.overrideAttrs { propagatedBuildInputs = [ pkgs.tzdata ]; };
+
+      # nixpkgs removes `pg_config` from the `postgresql` output and ships it as
+      # a separate package, but conf-postgresql's depext only pulls in
+      # `postgresql`. Without this, this package's dune `discover` rule fails
+      # with "/bin/sh: pg_config: not found".
+      postgresql = super.postgresql.overrideAttrs (oa: {
+        nativeBuildInputs = oa.nativeBuildInputs
+          ++ [ pkgs.postgresql.pg_config ];
+      });
     };
 
   scope =


### PR DESCRIPTION
Fixes #19305.

## Problem

crates.io enforces its crawler policy on `https://crates.io/api/v1/crates/...` and answers 403 to any `User-Agent` starting with `curl/` — which is exactly what nixpkgs' `fetchurl` sends (`curl/<version> Nixpkgs/<version>`):

| User-Agent sent | crates.io |
|---|---|
| `curl/8.12.1` | 403 |
| `curl/8.12.1 Nixpkgs/24.11` | 403 |
| `Nixpkgs/24.11` | 302 |

Every crate pulled in by `importCargoLock` goes through that endpoint, so any crate not already warm in `mina-nix-cache` fails the build outright:

```
building crate-compiler_builtins-0.1.123.tar.gz:
  curl: (22) The requested URL returned error: 403
error: cannot download crate-compiler_builtins-0.1.123.tar.gz from any mirror
error: 1 dependencies of derivation '.../cargo-vendor-dir.drv' failed to build
error: 1 dependencies of derivation '.../kimchi_wasm-0.1.0.drv' failed to build
error: 1 dependencies of derivation '.../mina-devnet-release.drv' failed to build
```

That is what broke the nightly hard fork tests for **every** branch: step 1 of `scripts/hardfork/build-and-test.sh` builds `origin/compatible`, and the crate FODs it needs stopped being served by the cache.

## Fix

nixpkgs `f830e6112` points `importCargoLock` and `fetchCrate` at `static.crates.io`, which has no such gate. That fix is in `nixos-25.11`, so move the pin from `nixos-24.11-small` to `nixos-25.11-small`.

Confirmed present in the newly locked nixpkgs:

```
pkgs/build-support/rust/import-cargo-lock.nix:
  "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
pkgs/build-support/rust/fetchcrate.nix:
  registryDl ? "https://static.crates.io/crates",
```

Crate fetches are fixed-output derivations, so the URL change moves no store paths and leaves existing binary-cache entries valid.

## Verification

- Reproduced the gate directly: with UA `curl/8.12.1 Nixpkgs/24.11`, `https://crates.io/api/v1/crates/serde/1.0.210/download` returns **403**, while `https://static.crates.io/crates/serde/1.0.210/download` returns **200**.
- `.#devnet` — the attribute the hard fork script builds — evaluates cleanly on the new pin, down to `mina-devnet-release.drv`.
- A full build has not been run locally; CI covers that.

## Note

`develop` is exposed to the same failure mode; only cache warmth is currently hiding it. It needs the same pin move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6qchPxa9F6dvRvpDWGNQJ