### PR TITLE
nix: fetch crates from static.crates.io

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,7 @@
           '';
     in {
       overlays = {
+        crates-io = import ./nix/crates-io.nix;
         misc = import ./nix/misc.nix;
         rust = import ./nix/rust.nix;
         go = import ./nix/go.nix;

--- a/nix/README.md
+++ b/nix/README.md
@@ -363,6 +363,17 @@ taken from nixpkgs with some overlays applied. All the dependencies are then
 provided to the final Mina derivation. See [./ocaml.nix](./ocaml.nix) for more
 details.
 
+### Crate downloads go through `static.crates.io`
+
+crates.io answers 403 to any `User-Agent` starting with `curl/`, which is what
+nixpkgs' `fetchurl` sends, so every crate fetched through
+`https://crates.io/api/v1/crates/...` fails on a binary-cache miss. The
+[./crates-io.nix](./crates-io.nix) overlay rewrites those URLs to
+`static.crates.io`, which has no such gate — the same change upstream nixpkgs
+made in `f830e6112` (nixos-25.11). Crate fetches are fixed-output derivations,
+so the rewrite moves no store paths and keeps existing cache entries valid. The
+overlay can be dropped once the nixpkgs pin moves past the upstream fix.
+
 ### Why are Rust, Go and OCaml bits built separately?
 
 In order to enforce reproducibility, Nix doesn't generally allow networking from

--- a/nix/crates-io.nix
+++ b/nix/crates-io.nix
@@ -1,0 +1,45 @@
+# An overlay making crate tarballs downloadable again.
+#
+# crates.io enforces its crawler policy on `https://crates.io/api/v1/crates/…`
+# and answers 403 to any User-Agent starting with `curl/`, which is exactly
+# what nixpkgs' `fetchurl` sends (`curl/<version> Nixpkgs/<version>`). Every
+# crate fetched by `importCargoLock` (i.e. by every `buildRustPackage` here)
+# goes through that endpoint, so a cache miss on any crate fails the build:
+#
+#     trying https://crates.io/api/v1/crates/ansi_term/0.12.1/download
+#     curl: (22) The requested URL returned error: 403
+#     error: cannot download crate-ansi_term-0.12.1.tar.gz from any mirror
+#
+# `static.crates.io` is the CDN crates.io points cargo itself at: no User-Agent
+# gate, and no 1 req/sec crawler rate limit either. Upstream nixpkgs made the
+# same switch in f830e6112, which landed in nixos-25.11; we pin
+# nixos-24.11-small, so rewrite the URL here instead.
+#
+# Crate fetches are fixed-output derivations, so their output paths depend only
+# on the derivation name and the hash: rewriting the URL moves nothing and
+# leaves every existing binary-cache entry valid.
+#
+# Remove this overlay once the nixpkgs pin moves past the upstream fix.
+final: prev:
+let
+  inherit (prev.lib) hasPrefix removePrefix;
+
+  apiPrefix = "https://crates.io/api/v1/crates/";
+  staticPrefix = "https://static.crates.io/crates/";
+
+  toStaticUrl = url:
+    if hasPrefix apiPrefix url then
+      staticPrefix + removePrefix apiPrefix url
+    else
+      url;
+
+  toStaticUrls = args:
+    args // (if args ? url then { url = toStaticUrl args.url; } else { })
+    // (if args ? urls then { urls = map toStaticUrl args.urls; } else { });
+in {
+  # `prev.fetchurl` is a functor carrying `override`; keep those attributes and
+  # only replace how it is applied.
+  fetchurl = prev.fetchurl // {
+    __functor = _: args: prev.fetchurl (toStaticUrls args);
+  };
+}


### PR DESCRIPTION
Fixes #19305.

## Problem

crates.io enforces its crawler policy on `https://crates.io/api/v1/crates/...` and answers 403 to any `User-Agent` starting with `curl/` — exactly what nixpkgs' `fetchurl` sends (`curl/<version> Nixpkgs/<version>`):

| User-Agent sent | crates.io |
|---|---|
| `curl/8.12.1` | 403 |
| `curl/8.12.1 Nixpkgs/24.11` | 403 |
| `Nixpkgs/24.11` | 302 |

Every crate pulled in by `importCargoLock` goes through that endpoint, so any crate not already warm in `mina-nix-cache` fails the build outright. That is what broke the nightly hard fork tests for **every** branch: step 1 of `scripts/hardfork/build-and-test.sh` builds `origin/compatible`, and the crate FODs it needs stopped being served by the cache.

## Fix

nixpkgs `f830e6112` points `importCargoLock` and `fetchCrate` at `static.crates.io` — the CDN crates.io points cargo itself at, with neither the User-Agent gate nor the 1 req/sec crawler rate limit. That fix is only in `nixos-25.11`. Rather than move a release branch's whole nixpkgs pin, this applies the same URL rewrite as a small overlay over `fetchurl`.

The overlay is ~20 lines, touches only URLs matching the crates.io API prefix, and preserves `fetchurl`'s functor attributes (`override`, `__functionArgs`). It documents its own removal condition: drop it once the pin moves past the upstream fix.

## Why not just bump the pin

I tried that first (nixos-24.11-small -> nixos-25.11-small) and measured the cost on a clean machine:

- **Every store path moves.** `cargo-vendor-dir` went `2v6a39j9…` -> `xpi2as8v…`. `mina-nix-cache` has nothing for the 25.11 world, so CI and the nightly would do a full from-scratch rebuild of the entire closure.
- **It breaks `compatible`'s frozen opam set.** Two failures before I stopped:
  - `postgresql.5.0.0` — 25.11 removes `bin/pg_config` from the `postgresql` output (`generic.nix:466` does `rm "$out/bin/pg_config"`); that opam version calls `pg_config` unconditionally with no fallback.
  - `num.1.1` — `install: cannot create regular file '/nix/store/…-ocaml-base-compiler-4.14.2/lib/ocaml/nums.cma': Permission denied`

  #19301 bumps to the same nixpkgs without hitting these only because it also bumps opam-repository, which moves `postgresql` 5.0.0 -> 5.2.0 (5.2.0 tries `pkg-config libpq` first and only falls back to `pg_config`). `compatible` can't take that opam bump.

The pin bump is the right eventual answer, but it belongs on `develop` paired with an opam bump — not on a release branch as collateral for a 403.

## Verification

On a clean machine, `--no-substitute`, against a lock whose crates were not yet in the store:

| | result | `cargo-vendor-dir` |
|---|---|---|
| A: plain 24.11 | **403 on `aho-corasick/1.1.4`**, fails | *wanted* `gbgnm4wy…` |
| B: 24.11 + this overlay | success | **`gbgnm4wy…`** |
| C: plain 24.11, after B | success, instantly | `gbgnm4wy…` |

Case C is the important one: **unpatched** 24.11 consumes what the overlay produced as a drop-in. No store path moves, existing `mina-nix-cache` entries stay valid, and machines without the overlay can still substitute from a cache populated by one that has it.

Also confirmed the gate directly: with UA `curl/8.12.1 Nixpkgs/24.11`, `https://crates.io/api/v1/crates/serde/1.0.210/download` returns 403 while `https://static.crates.io/crates/serde/1.0.210/download` returns 200.

## Note

`develop` is exposed to the same failure mode; only cache warmth is currently hiding it. It needs the same overlay (or the pin bump, with the opam work that implies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6qchPxa9F6dvRvpDWGNQJ