### PR TITLE
Stop searching for an overflowing nonce in the zkApp nonce test

### DIFF
--- a/src/lib/mina_base/test/nonce_related.ml
+++ b/src/lib/mina_base/test/nonce_related.ml
@@ -9,17 +9,24 @@ let filter ((x, _y) : t * int) : bool =
   + List.length (Call_forest.to_list x.account_updates)
   <= Unsigned.UInt32.to_int Unsigned.UInt32.max_int
 
-let filter_overflow ((x, _y) : t * int) : bool =
-  Unsigned.UInt32.to_int x.fee_payer.body.nonce
-  + 1
-  + List.length (Call_forest.to_list x.account_updates)
-  > Unsigned.UInt32.to_int Unsigned.UInt32.max_int
-
 let filtered =
   Base_quickcheck.Generator.filter Valid_size.zkapp_type_gen ~f:filter
 
+(* [target_nonce_on_success] advances the fee payer's nonce past the end of its
+   range when [succ] alone overflows, which is to say when the nonce is at its
+   maximum. Searching a generated nonce for that does not terminate in
+   practice, and each draw builds a call forest of up to a thousand account
+   updates, so set the nonce rather than filtering for it. *)
+let with_overflowing_nonce ((x : t), y) =
+  let fee_payer =
+    { x.fee_payer with
+      body = { x.fee_payer.body with nonce = Account.Nonce.max_value }
+    }
+  in
+  (({ x with fee_payer } : t), y)
+
 let filtered_overflow =
-  Base_quickcheck.Generator.filter Valid_size.zkapp_type_gen ~f:filter_overflow
+  Quickcheck.Generator.map Valid_size.zkapp_type_gen ~f:with_overflowing_nonce
 
 (* target_nonce_on_success *)
 (* Check that the nonce after the function has been applied is higher *)


### PR DESCRIPTION
`dune runtest src/lib/mina_base` does not complete. It spins at 100% CPU in
`Nonce_related`, and the cause is rejection sampling for a case that generated
data essentially never produces.

`filtered_overflow` kept a generated zkApp command only when

```ocaml
nonce + 1 + List.length (Call_forest.to_list x.account_updates)
  > Unsigned.UInt32.max_int
```

Nonces come from `Account.Nonce.gen`, so satisfying that means landing within a
few hundred of `2^32`. `Quickcheck`'s `gen_incl` stresses boundaries, so it is
not literally impossible, but every rejected draw builds a call forest of 2 to
1000 account updates with their events, actions and proofs, and the test needs
fifty acceptances.

This sets the nonce instead of searching for it, which is also a more faithful
description of the overflow. `target_nonce_on_success` takes the successor of
the fee payer's nonce and then adds the account updates that belong to the fee
payer *and* set `increment_nonce`. With generated public keys almost none
qualify, so the old predicate — which counted every account update — could be
satisfied by a nonce that did not overflow at all. At `Account.Nonce.max_value`
the successor alone wraps, which is the behaviour the test is about.

### Why this was not noticed

The tests have not run since they were written in March 2023. They were left
out of `main.ml` when the suite moved to Alcotest, and were only registered
again in 3574d62922 ("fix: include nonce_related tests in mina_base test
suite").

### Testing

`nonce related` now completes:

```
  [OK]          nonce related    0   Check that the nonce after the function...
  [OK]          nonce related    1   Check that the nonce after the function...
  [OK]          nonce related    2   Check that the total in the Map is less...

Test Successful in 129.159s. 3 tests run.
```

Before the change the same suite ran for over 15 minutes without completing.

Test-only; no behaviour change outside the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)