### PR TITLE
Cap the trial count in the transaction application test

### DIFF
--- a/src/lib/staged_ledger/test/txn_application_test.ml
+++ b/src/lib/staged_ledger/test/txn_application_test.ml
@@ -51,7 +51,12 @@ let gen_application_state : Application_state.t Quickcheck.Generator.t =
   }
 
 let apply_against_non_empty_scan_state () =
-  Quickcheck.test
+  (* Each trial generates a zkApp command together with a ledger to apply it
+     against, which is far and away the expensive part of this test. The
+     property under test is how [try_applying_txn] accounts for the space
+     remaining, so a hundred trials exercise it as well as the default ten
+     thousand do. *)
+  Quickcheck.test ~trials:100
     (Quickcheck.Generator.tuple2 gen_apply_and_txn gen_application_state)
     ~f:(fun ((apply, txn), state) ->
       match Application_state.try_applying_txn ~apply state txn with


### PR DESCRIPTION
`apply_against_non_empty_scan_state` calls `Quickcheck.test` without `~trials`,
so it runs Core's `default_trial_count`, which is 10,000 on 64-bit. Each trial
generates a zkApp command *and* a ledger to apply it against, via
`User_command_generators.zkapp_command_with_ledger`.

That single test takes just over four minutes, which is more than half of the
staged ledger test suite's total execution time.

The property being checked is how `try_applying_txn` accounts for the space
remaining:

```ocaml
| Continue state' when state.total_space_remaining > 0 ->
    [%test_pred: int] (fun delta -> delta = 0 || delta = 1)
      (state.total_space_remaining - state'.total_space_remaining)
```

The rest of the generated state is fixed — `valid_seq`, `invalid` and
`skipped_by_fee_payer` are all empty — so the expensive part of each trial
contributes little to the coverage. Other quickcheck tests in these suites pass
an explicit `~trials`; this one just omits it.

### Testing

```
Test Successful in 4.585s. 1 test run.
```

Down from 250s, and still passing. Test-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)