### PR TITLE
[HARD FORK] Surface the ledger of the most recent completely-snarked block

### DIFF
--- a/changes/19312.md
+++ b/changes/19312.md
@@ -1,0 +1,12 @@
+Change the snarked ledger hash to the ledger of the most recent fully-snarked block
+
+The snarked ledger hash a block carries used to be the ledger part way through
+some earlier block, at whichever point the scan state's proof boundary happened
+to fall. It is now the ledger as of the most recent block whose transactions
+have all been proven. A block's coinbase is also now its last transaction, and
+pays out whatever the block's transaction fees did not spend on SNARK work.
+
+For anyone reading the chain -- bridges especially -- this makes the snarked
+ledger hash something that can be tied to a specific block, rather than to a
+position inside one. This is a hard-fork change: it alters the proof circuits
+and the wire format.

--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -146,6 +146,7 @@ let scan_state_base_node_coinbase =
     let coinbase =
       Mina_base.Coinbase.create ~amount:Currency.Amount.zero
         ~receiver:sample_pk_compressed ~fee_transfer:None
+        ~fee_remainder:Currency.Fee.zero
       |> Or_error.ok_exn
     in
     Coinbase

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -390,7 +390,13 @@ let internal_cmds_to_transaction ~logger ~pool (ic : Sql.Internal_command.t)
               ic.global_slot_since_genesis ic.sequence_no
               ic.secondary_sequence_no ;
           let%map receiver = Load_data.pk_of_id pool ic.receiver_id in
-          match Coinbase.create ~amount ~receiver ~fee_transfer with
+          match
+            (* The replayer reconstructs coinbases from archived events, where
+               any fee paid to the coinbase receiver is recorded as its own
+               internal command rather than as part of the coinbase. *)
+            Coinbase.create ~amount ~receiver ~fee_transfer
+              ~fee_remainder:Currency.Fee.zero
+          with
           | Ok cb ->
               (Some (Mina_transaction.Transaction.Coinbase cb), ics)
           | Error err ->

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -274,17 +274,6 @@ let%snarkydef_ step ~(logger : Logger.t)
     in
     let%bind txn_snark_input_correct =
       let open Checked in
-      let%bind () =
-        (* The fee excess is carried in the registers, so a ledger proof that
-           settles all of the fees it collects starts and ends at zero. This is
-           the same requirement as the previous accumulated excess being zero,
-           given that the scan state's excess starts at zero. *)
-        Fee_excess.(
-          Checked.all_unit
-            [ assert_equal_checked (var_of_t zero) txn_snark.source.fee_excess
-            ; assert_equal_checked (var_of_t zero) txn_snark.target.fee_excess
-            ] )
-      in
       let ledger_statement_valid =
         Impl.make_checked (fun () ->
             Snarked_ledger_state.(
@@ -300,6 +289,14 @@ let%snarkydef_ step ~(logger : Logger.t)
              left it, which is what makes [total_currency] above sound. *)
         ; Currency.Amount.equal_var txn_snark.source.total_currency
             previous_total_currency
+          (* A ledger proof no longer has to settle the fees of the
+             transactions it covers: its range can end part way through a
+             block, with the coinbase that pays them out falling in the next
+             proof. The transaction snark requires the excess to be zero at
+             every coinbase, so it is enough here that a proof picks up the
+             excess where the previous one put it down. *)
+        ; Fee_excess.equal_checked txn_snark.source.fee_excess
+            previous_ledger_statement.target.fee_excess
         ; Pending_coinbase.Stack.equal_var
             txn_snark.source.pending_coinbase_stack
             pending_coinbase_source_stack

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -184,9 +184,14 @@ let%snarkydef_ step ~(logger : Logger.t)
   let%bind total_currency =
     (* The total currency only moves when the txn statement represents a new
        ledger transition; the transaction snark is what proves the new value
-       follows from the old one, so consensus no longer accumulates it. *)
+       follows from the old one, so consensus no longer accumulates it.
+
+       It is the supply as of the latest coinbase, to match the ledger the
+       protocol surfaces: an epoch ledger and its total currency have to
+       describe the same state. *)
     Currency.Amount.Checked.if_ txn_stmt_ledger_hashes_didn't_change
-      ~then_:previous_total_currency ~else_:txn_snark.target.total_currency
+      ~then_:previous_total_currency
+      ~else_:txn_snark.target.total_supply_after_coinbase
   in
   let%bind `Success updated_consensus_state, consensus_state =
     with_label __LOC__ (fun () ->
@@ -287,7 +292,7 @@ let%snarkydef_ step ~(logger : Logger.t)
         [ ledger_statement_valid
           (* The proof has to continue the total currency from where consensus
              left it, which is what makes [total_currency] above sound. *)
-        ; Currency.Amount.equal_var txn_snark.source.total_currency
+        ; Currency.Amount.equal_var txn_snark.source.total_supply_after_coinbase
             previous_total_currency
           (* A ledger proof no longer has to settle the fees of the
              transactions it covers: its range can end part way through a

--- a/src/lib/filtered_external_transition/filtered_external_transition.ml
+++ b/src/lib/filtered_external_transition/filtered_external_transition.ml
@@ -207,7 +207,10 @@ let of_transition block tracked_participants
           { acc_transactions with
             fee_transfers = fee_transfers @ acc_transactions.fee_transfers
           }
-      | { data = Coinbase { Coinbase.amount; fee_transfer; receiver }; _ } ->
+      | { data =
+            Coinbase { Coinbase.amount; fee_transfer; receiver; fee_remainder }
+        ; _
+        } ->
           let fee_transfer =
             Option.map
               ~f:(fun ft ->
@@ -215,10 +218,22 @@ let of_transition block tracked_participants
                 , Fee_transfer_type.Fee_transfer_via_coinbase ) )
               fee_transfer
           in
+          (* The fee remainder is paid to the coinbase receiver by the coinbase
+             transaction, but it is a fee payment rather than newly minted
+             currency, so it is reported separately from the coinbase amount. *)
+          let remainder_transfer =
+            Option.some_if
+              (not (Currency.Fee.equal fee_remainder Currency.Fee.zero))
+              ( Mina_base.Fee_transfer.Single.create ~receiver_pk:receiver
+                  ~fee:fee_remainder ~fee_token:Mina_base.Token_id.default
+              , Fee_transfer_type.Fee_transfer_via_coinbase )
+          in
           let fee_transfers =
-            List.append
-              (Option.to_list fee_transfer)
-              acc_transactions.fee_transfers
+            List.concat
+              [ Option.to_list fee_transfer
+              ; Option.to_list remainder_transfer
+              ; acc_transactions.fee_transfers
+              ]
           in
           { acc_transactions with
             fee_transfers

--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -5,7 +5,7 @@ open Mina_base_import
 module Wire_types = Mina_wire_types.Mina_base.Coinbase
 
 module Make_sig (A : Wire_types.Types.S) = struct
-  module type S = Coinbase_intf.Full with type Stable.V1.t = A.V1.t
+  module type S = Coinbase_intf.Full with type Stable.V2.t = A.V2.t
 end
 
 module Make_str (A : Wire_types.Concrete) = struct
@@ -13,11 +13,12 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   [%%versioned
   module Stable = struct
-    module V1 = struct
-      type t = A.V1.t =
+    module V2 = struct
+      type t = A.V2.t =
         { receiver : Public_key.Compressed.Stable.V1.t
         ; amount : Currency.Amount.Stable.V1.t
         ; fee_transfer : Fee_transfer.Stable.V1.t option
+        ; fee_remainder : Currency.Fee.Stable.V1.t
         }
       [@@deriving sexp, compare, equal, hash, yojson]
 
@@ -48,6 +49,14 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   let fee_transfer t = t.fee_transfer
 
+  let fee_remainder t = t.fee_remainder
+
+  let total_credited { amount; fee_remainder; _ } =
+    Option.value_map
+      ~default:(Or_error.error_string "Coinbase amount overflow")
+      ~f:Or_error.return
+      (Currency.Amount.add amount (Currency.Amount.of_fee fee_remainder))
+
   let account_access_statuses t (status : Transaction_status.t) =
     let access_status =
       match status with Applied -> `Accessed | Failed _ -> `Not_accessed
@@ -68,15 +77,19 @@ module Make_str (A : Wire_types.Concrete) = struct
     List.map (account_access_statuses t Transaction_status.Applied)
       ~f:(fun (acct_id, _status) -> acct_id )
 
-  let is_valid { amount; fee_transfer; _ } =
-    match fee_transfer with
-    | None ->
+  (* The fee transfer is paid out of everything the coinbase credits, which
+     includes the fee excess it discharges as well as the minted amount. *)
+  let is_valid ({ fee_transfer; _ } as t) =
+    match (fee_transfer, total_credited t) with
+    | None, Ok _ ->
         true
-    | Some { fee; _ } ->
-        Currency.Amount.(of_fee fee <= amount)
+    | Some { fee; _ }, Ok credited ->
+        Currency.Amount.(of_fee fee <= credited)
+    | _, Error _ ->
+        false
 
-  let create ~amount ~receiver ~fee_transfer =
-    let t = { receiver; amount; fee_transfer } in
+  let create ~amount ~receiver ~fee_transfer ~fee_remainder =
+    let t = { receiver; amount; fee_transfer; fee_remainder } in
     if is_valid t then
       let adjusted_fee_transfer =
         Option.bind fee_transfer ~f:(fun fee_transfer ->
@@ -89,19 +102,25 @@ module Make_str (A : Wire_types.Concrete) = struct
       Ok { t with fee_transfer = adjusted_fee_transfer }
     else Or_error.error_string "Coinbase.create: invalid coinbase"
 
-  let expected_supply_increase { receiver = _; amount; fee_transfer } =
+  (* Only the minted [amount] adds to the supply; the fee remainder is currency
+     that already exists, moved out of the unsettled fee excess. *)
+  let expected_supply_increase ({ amount; fee_transfer; _ } as t) =
+    let open Or_error.Let_syntax in
+    let%bind credited = total_credited t in
     match fee_transfer with
     | None ->
         Ok amount
     | Some { fee; _ } ->
-        Currency.Amount.sub amount (Currency.Amount.of_fee fee)
+        Currency.Amount.sub credited (Currency.Amount.of_fee fee)
         |> Option.value_map
              ~f:(fun _ -> Ok amount)
              ~default:(Or_error.error_string "Coinbase underflow")
 
+  (* A coinbase discharges the excess it carries, so its own excess is the
+     negation of that remainder. *)
   let fee_excess t =
     Or_error.map (expected_supply_increase t) ~f:(fun _increase ->
-        Fee_excess.empty )
+        ({ magnitude = t.fee_remainder; sgn = Sgn.Neg } : Fee_excess.t) )
 
   module Gen = struct
     let gen ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
@@ -143,7 +162,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         | _ ->
             fee_transfer
       in
-      ( { receiver; amount; fee_transfer }
+      ( { receiver; amount; fee_transfer; fee_remainder = Currency.Fee.zero }
       , `Supercharged_coinbase supercharged_coinbase )
 
     let with_random_receivers ~keys ~min_amount ~max_amount ~fee_transfer =
@@ -168,7 +187,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         | _ ->
             fee_transfer
       in
-      { receiver; amount; fee_transfer }
+      { receiver; amount; fee_transfer; fee_remainder = Currency.Fee.zero }
   end
 end
 

--- a/src/lib/mina_base/coinbase.mli
+++ b/src/lib/mina_base/coinbase.mli
@@ -1,3 +1,3 @@
 include
   Coinbase_intf.Full
-    with type Stable.V1.t = Mina_wire_types.Mina_base.Coinbase.V1.t
+    with type Stable.V2.t = Mina_wire_types.Mina_base.Coinbase.V2.t

--- a/src/lib/mina_base/coinbase_intf.ml
+++ b/src/lib/mina_base/coinbase_intf.ml
@@ -5,16 +5,17 @@ module type Full = sig
   module Fee_transfer = Coinbase_fee_transfer
 
   module Stable : sig
-    module V1 : sig
+    module V2 : sig
       type t = private
         { receiver : Public_key.Compressed.Stable.V1.t
         ; amount : Currency.Amount.Stable.V1.t
         ; fee_transfer : Fee_transfer.Stable.V1.t option
+        ; fee_remainder : Currency.Fee.Stable.V1.t
         }
       [@@deriving sexp, bin_io, compare, equal, version, hash, yojson]
     end
 
-    module Latest = V1
+    module Latest = V2
   end
 
   (* bin_io intentionally omitted in deriving list *)
@@ -22,6 +23,7 @@ module type Full = sig
     { receiver : Public_key.Compressed.t
     ; amount : Currency.Amount.t
     ; fee_transfer : Fee_transfer.t option
+    ; fee_remainder : Currency.Fee.t
     }
   [@@deriving sexp, compare, equal, hash, yojson]
 
@@ -44,10 +46,17 @@ module type Full = sig
 
   val accounts_referenced : t -> Account_id.t list
 
+  val fee_remainder : t -> Currency.Fee.t
+
+  (** The total amount credited by the coinbase: the minted [amount] plus the
+      fee excess it discharges. *)
+  val total_credited : t -> Currency.Amount.t Or_error.t
+
   val create :
        amount:Currency.Amount.t
     -> receiver:Public_key.Compressed.t
     -> fee_transfer:Fee_transfer.t option
+    -> fee_remainder:Currency.Fee.t
     -> t Or_error.t
 
   val expected_supply_increase : t -> Currency.Amount.t Or_error.t

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -578,10 +578,6 @@ module Make_str (A : Wire_types.Concrete) = struct
     (* Total number of stacks *)
     let max_coinbase_stack_count ~depth = Int.pow 2 depth
 
-    let chain if_ b ~then_ ~else_ =
-      let%bind then_ = then_ and else_ = else_ in
-      if_ b ~then_ ~else_
-
     (*pair of coinbase and state stacks*)
     module Stack = struct
       module Poly = struct
@@ -910,14 +906,20 @@ module Make_str (A : Wire_types.Concrete) = struct
             Currency.Amount.Checked.if_ supercharge_coinbase
               ~then_:supercharged_coinbase ~else_:coinbase_amount
           in
-          let%bind rem_amount =
-            Currency.Amount.Checked.sub total_coinbase_amount amount
+          (*A block has at most one coinbase, and it may not exceed the
+            protocol's amount for the block. The subtraction is what enforces
+            that; its result is no longer a second coinbase to push.*)
+          let%bind () =
+            with_label __LOC__ (fun () ->
+                let%map (_ : Currency.Amount.var) =
+                  Currency.Amount.Checked.sub total_coinbase_amount amount
+                in
+                () )
           in
           let%bind no_coinbase_in_this_stack =
             Update.Action.Checked.update_two_stacks_coinbase_in_second action
           in
           let%bind amount1_equal_to_zero = equal_to_zero amount in
-          let%bind amount2_equal_to_zero = equal_to_zero rem_amount in
           (*if no update then coinbase amount has to be zero*)
           let%bind () =
             with_label __LOC__ (fun () ->
@@ -929,19 +931,10 @@ module Make_str (A : Wire_types.Concrete) = struct
           let%bind no_coinbase =
             Boolean.(no_update ||| no_coinbase_in_this_stack)
           in
-          (* TODO: Optimize here since we are pushing twice to the same stack *)
-          let%bind stack_with_amount1 =
+          let%bind stack_with_coinbase =
             Stack.Checked.push_coinbase (coinbase_receiver, amount) stack
           in
-          let%bind stack_with_amount2 =
-            Stack.Checked.push_coinbase
-              (coinbase_receiver, rem_amount)
-              stack_with_amount1
-          in
-          chain Stack.if_ no_coinbase ~then_:(return stack)
-            ~else_:
-              (Stack.if_ amount2_equal_to_zero ~then_:stack_with_amount1
-                 ~else_:stack_with_amount2 )
+          Stack.if_ no_coinbase ~then_:stack ~else_:stack_with_coinbase
         in
         (*This is for the second stack for when transactions in a block occupy
           two trees of the scan state; the second tree will carry-forward the state

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -1385,6 +1385,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~amount:
             (Option.value_exn (Amount.sub max_coinbase_amount coinbase.amount))
           ~receiver:coinbase.receiver ~fee_transfer:None
+          ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       let t_with_state =

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -411,12 +411,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     module Action = struct
       [%%versioned
       module Stable = struct
-        module V1 = struct
-          type t =
-            | Update_none
-            | Update_one
-            | Update_two_coinbase_in_first
-            | Update_two_coinbase_in_second
+        module V2 = struct
+          type t = Update_none | Update_one | Update_two_coinbase_in_second
           [@@deriving equal, sexp, to_yojson]
 
           let to_latest = Fn.id
@@ -430,20 +426,21 @@ module Make_str (A : Wire_types.Concrete) = struct
             (false, false)
         | Update_one ->
             (true, false)
-        | Update_two_coinbase_in_first ->
-            (false, true)
         | Update_two_coinbase_in_second ->
             (true, true)
 
+      (* [(false, true)] used to mean two stacks with the coinbase in the first
+         of them, which a block whose coinbase is its last transaction cannot
+         produce. [Checked.assert_valid] rules it out in-circuit. *)
       let of_bits = function
         | false, false ->
             Update_none
         | true, false ->
             Update_one
-        | false, true ->
-            Update_two_coinbase_in_first
         | true, true ->
             Update_two_coinbase_in_second
+        | false, true ->
+            failwith "Pending_coinbase.Update.Action: unused bit pattern"
 
       let var_of_t t =
         let x, y = to_bits t in
@@ -457,10 +454,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       module Checked = struct
         let no_update (b0, b1) = Boolean.((not b0) &&& not b1)
 
-        let update_two_stacks_coinbase_in_first (b0, b1) =
-          Boolean.((not b0) &&& b1)
-
         let update_two_stacks_coinbase_in_second (b0, b1) = Boolean.(b0 &&& b1)
+
+        (* Three of the four bit patterns name an action; reject the fourth. *)
+        let assert_valid (b0, b1) = Boolean.Assert.any [ b0; Boolean.not b1 ]
       end
     end
 
@@ -477,8 +474,8 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     [%%versioned
     module Stable = struct
-      module V1 = struct
-        type t = (Action.Stable.V1.t, Amount.Stable.V1.t) Poly.Stable.V1.t
+      module V2 = struct
+        type t = (Action.Stable.V2.t, Amount.Stable.V1.t) Poly.Stable.V1.t
         [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
@@ -880,6 +877,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   Find_index_of_newest_stacks act ) )
         in
         let equal_to_zero x = Amount.(equal_var x (var_of_t zero)) in
+        let%bind () = Update.Action.Checked.assert_valid action in
         let%bind no_update = Update.Action.Checked.no_update action in
         let update_state_stack (stack : Stack.var) =
           (*get previous stack to carry-forward the stack of state body hashes*)
@@ -952,12 +950,9 @@ module Make_str (A : Wire_types.Concrete) = struct
           let%bind add_coinbase =
             Update.Action.Checked.update_two_stacks_coinbase_in_second action
           in
-          let%bind update_state =
-            let%bind update_second_stack =
-              Update.Action.Checked.update_two_stacks_coinbase_in_first action
-            in
-            Boolean.(update_second_stack ||| add_coinbase)
-          in
+          (* The second stack is only touched when the block reaches it, which
+             is exactly when it carries the coinbase. *)
+          let update_state = add_coinbase in
           let%bind stack =
             let%bind stack_with_state =
               Stack.Checked.push_state state_body_hash global_slot

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -906,21 +906,26 @@ module Make_str (A : Wire_types.Concrete) = struct
             Currency.Amount.Checked.if_ supercharge_coinbase
               ~then_:supercharged_coinbase ~else_:coinbase_amount
           in
-          (*A block has at most one coinbase, and it may not exceed the
-            protocol's amount for the block. The subtraction is what enforces
-            that; its result is no longer a second coinbase to push.*)
+          (*A block has exactly one coinbase unless it has no transactions at
+            all, and that coinbase is for the protocol's whole amount for the
+            block. Note this is [no_update] rather than [no_coinbase]: a block
+            that reaches the second stack still has a coinbase, it is just not
+            in this stack.*)
           let%bind () =
             with_label __LOC__ (fun () ->
-                let%map (_ : Currency.Amount.var) =
-                  Currency.Amount.Checked.sub total_coinbase_amount amount
+                let%bind expected_amount =
+                  Currency.Amount.Checked.if_ no_update
+                    ~then_:Currency.Amount.(var_of_t zero)
+                    ~else_:total_coinbase_amount
                 in
-                () )
+                Currency.Amount.Checked.assert_equal amount expected_amount )
           in
           let%bind no_coinbase_in_this_stack =
             Update.Action.Checked.update_two_stacks_coinbase_in_second action
           in
           let%bind amount1_equal_to_zero = equal_to_zero amount in
-          (*if no update then coinbase amount has to be zero*)
+          (*Kept alongside the check above so that the no-coinbase case does not
+            rest on the configured coinbase amount being non-zero.*)
           let%bind () =
             with_label __LOC__ (fun () ->
                 let%bind check =

--- a/src/lib/mina_base/pending_coinbase_intf.ml
+++ b/src/lib/mina_base/pending_coinbase_intf.ml
@@ -209,12 +209,8 @@ module type S = sig
     module Action : sig
       [%%versioned:
       module Stable : sig
-        module V1 : sig
-          type t =
-            | Update_none
-            | Update_one
-            | Update_two_coinbase_in_first
-            | Update_two_coinbase_in_second
+        module V2 : sig
+          type t = Update_none | Update_one | Update_two_coinbase_in_second
           [@@deriving sexp, to_yojson]
         end
       end]
@@ -239,8 +235,8 @@ module type S = sig
 
     [%%versioned:
     module Stable : sig
-      module V1 : sig
-        type t = (Action.Stable.V1.t, Amount.Stable.V1.t) Poly.Stable.V1.t
+      module V2 : sig
+        type t = (Action.Stable.V2.t, Amount.Stable.V1.t) Poly.Stable.V1.t
         [@@deriving sexp, to_yojson]
       end
     end]

--- a/src/lib/mina_base/test/test_encoding_regression.ml
+++ b/src/lib/mina_base/test/test_encoding_regression.ml
@@ -118,7 +118,7 @@ let test_coinbase_encoding () =
   let t =
     Coinbase.create ~receiver:pk
       ~amount:(Currency.Amount.of_nanomina_int_exn 1_000_000_000)
-      ~fee_transfer:None
+      ~fee_transfer:None ~fee_remainder:Currency.Fee.zero
     |> Or_error.ok_exn
   in
   let got = Coinbase.to_base58_check t in

--- a/src/lib/mina_base/transaction_union_payload.ml
+++ b/src/lib/mina_base/transaction_union_payload.ml
@@ -275,7 +275,8 @@ let excess (payload : t) : Amount.Signed.t =
   | Coinbase ->
       Amount.Signed.zero
 
-let fee_excess ({ body = { tag; amount; _ }; common = { fee; _ } } : t) =
+let fee_excess ~fee_remainder
+    ({ body = { tag; amount; _ }; common = { fee; _ } } : t) =
   match tag with
   | Payment | Stake_delegation ->
       (* For all user commands, the fee excess is just the fee. *)
@@ -284,12 +285,16 @@ let fee_excess ({ body = { tag; amount; _ }; common = { fee; _ } } : t) =
       Option.value_exn (Amount.add_fee amount fee)
       |> Amount.to_fee |> Fee.Signed.of_unsigned |> Fee.Signed.negate
   | Coinbase ->
-      Fee.Signed.zero
+      (* A coinbase discharges the excess that it pays out to its receiver. *)
+      Fee.Signed.negate (Fee.Signed.of_unsigned fee_remainder)
 
-let expected_supply_increase (payload : payload) =
+let expected_supply_increase ~fee_remainder (payload : payload) =
   let tag = payload.body.tag in
   match tag with
   | Coinbase ->
-      payload.body.amount
+      (* [body.amount] is everything the coinbase credits; only the part that
+         was not taken from the fee excess is newly minted. *)
+      Option.value_exn
+        (Amount.sub payload.body.amount (Amount.of_fee fee_remainder))
   | Payment | Stake_delegation | Fee_transfer ->
       Amount.zero

--- a/src/lib/mina_block/block.mli
+++ b/src/lib/mina_block/block.mli
@@ -15,7 +15,7 @@ module Stable : sig
     val transactions :
          constraint_constants:Genesis_constants.Constraint_constants.t
       -> t
-      -> Transaction.Stable.V3.t With_status.t list
+      -> Transaction.Stable.V4.t With_status.t list
   end
 end]
 

--- a/src/lib/mina_block/legacy_format.ml
+++ b/src/lib/mina_block/legacy_format.ml
@@ -115,10 +115,10 @@ module Staged_ledger_diff = struct
         { diff :
             ( Transaction_snark_work.Stable.V4.t
             , User_command.Stable.V2.t Mina_base.With_status.Stable.V2.t )
-            Staged_ledger_diff.Pre_diff_two.Stable.V2.t
+            Staged_ledger_diff.Pre_diff_two.Stable.V3.t
             * ( Transaction_snark_work.Stable.V4.t
               , User_command.Stable.V2.t Mina_base.With_status.Stable.V2.t )
-              Staged_ledger_diff.Pre_diff_one.Stable.V2.t
+              Staged_ledger_diff.Pre_diff_one.Stable.V3.t
               option
         }
       [@@deriving sexp, yojson]

--- a/src/lib/mina_block/legacy_format.mli
+++ b/src/lib/mina_block/legacy_format.mli
@@ -25,10 +25,10 @@ module Staged_ledger_diff : sig
         { diff :
             ( Transaction_snark_work.Stable.V4.t
             , User_command.Stable.V2.t Mina_base.With_status.Stable.V2.t )
-            Staged_ledger_diff.Pre_diff_two.Stable.V2.t
+            Staged_ledger_diff.Pre_diff_two.Stable.V3.t
             * ( Transaction_snark_work.Stable.V4.t
               , User_command.Stable.V2.t Mina_base.With_status.Stable.V2.t )
-              Staged_ledger_diff.Pre_diff_one.Stable.V2.t
+              Staged_ledger_diff.Pre_diff_one.Stable.V3.t
               option
         }
       [@@deriving sexp, yojson]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -726,20 +726,9 @@ let get_snarked_ledger_full t state_hash_opt =
                     t.config.precomputed_values.constraint_constants
               in
               let apply_second_pass = Ledger.apply_transaction_second_pass in
-              let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
-                  sparse_ledger txn =
-                let open Or_error.Let_syntax in
-                let%map _ledger, partial_txn =
-                  Mina_ledger.Sparse_ledger.apply_transaction_first_pass
-                    ~constraint_constants:
-                      t.config.precomputed_values.constraint_constants
-                    ~global_slot ~txn_state_view sparse_ledger txn
-                in
-                partial_txn
-              in
               Staged_ledger.Scan_state.get_snarked_ledger_async ~ledger
                 ~get_protocol_state ~apply_first_pass ~apply_second_pass
-                ~apply_first_pass_sparse_ledger ~signature_kind
+                ~signature_kind
                 (Staged_ledger.scan_state
                    (Transition_frontier.Breadcrumb.staged_ledger b) )
               |> Deferred.Result.map_error ~f:(fun e ->

--- a/src/lib/mina_state/snark_transition.ml
+++ b/src/lib/mina_state/snark_transition.ml
@@ -25,7 +25,7 @@ module Value = struct
       type t =
         ( Blockchain_state.Value.Stable.V3.t
         , Consensus.Data.Consensus_transition.Value.Stable.V1.t
-        , Pending_coinbase.Update.Stable.V1.t )
+        , Pending_coinbase.Update.Stable.V2.t )
         Poly.Stable.V1.t
       [@@deriving sexp, to_yojson]
 

--- a/src/lib/mina_state/snark_transition.mli
+++ b/src/lib/mina_state/snark_transition.mli
@@ -34,7 +34,7 @@ module Value : sig
       type t =
         ( Blockchain_state.Value.Stable.V3.t
         , Consensus.Data.Consensus_transition.Value.Stable.V1.t
-        , Pending_coinbase.Update.Stable.V1.t )
+        , Pending_coinbase.Update.Stable.V2.t )
         Poly.Stable.V1.t
       [@@deriving sexp, to_yojson]
     end

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -510,7 +510,11 @@ module Make_str (A : Wire_types.Concrete) = struct
       }
   end
 
-  let snarked_ledger_hash (t : _ Poly.t) = Registers.first_pass_ledger t.target
+  (*The ledger the protocol surfaces is the one recorded as of the latest
+    coinbase, which is a block boundary, rather than the first pass ledger,
+    which is wherever the scan state's chunk happened to end.*)
+  let snarked_ledger_hash (t : _ Poly.t) =
+    Registers.ledger_after_coinbase t.target
 
   let validate_ledgers_at_merge (type a error bool)
       (module L : Ledger_hash_intf

--- a/src/lib/mina_wire_types/mina_base/mina_base_coinbase.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_coinbase.ml
@@ -2,32 +2,35 @@ open Utils
 
 module Types = struct
   module type S = sig
-    module V1 : sig
+    module V2 : sig
       type t = private
         { receiver : Public_key.Compressed.V1.t
         ; amount : Currency.Amount.V1.t
         ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+        ; fee_remainder : Currency.Fee.V1.t
         }
     end
   end
 end
 
 module M = struct
-  module V1 = struct
+  module V2 = struct
     type t =
       { receiver : Public_key.Compressed.V1.t
       ; amount : Currency.Amount.V1.t
       ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+      ; fee_remainder : Currency.Fee.V1.t
       }
   end
 end
 
 module type Concrete = sig
-  module V1 : sig
+  module V2 : sig
     type t =
       { receiver : Public_key.Compressed.V1.t
       ; amount : Currency.Amount.V1.t
       ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+      ; fee_remainder : Currency.Fee.V1.t
       }
   end
 end

--- a/src/lib/mina_wire_types/mina_base/mina_base_coinbase.mli
+++ b/src/lib/mina_wire_types/mina_base/mina_base_coinbase.mli
@@ -2,32 +2,35 @@ open Utils
 
 module Types : sig
   module type S = sig
-    module V1 : sig
+    module V2 : sig
       type t = private
         { receiver : Public_key.Compressed.V1.t
         ; amount : Currency.Amount.V1.t
         ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+        ; fee_remainder : Currency.Fee.V1.t
         }
     end
   end
 end
 
 module M : sig
-  module V1 : sig
+  module V2 : sig
     type t = private
       { receiver : Public_key.Compressed.V1.t
       ; amount : Currency.Amount.V1.t
       ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+      ; fee_remainder : Currency.Fee.V1.t
       }
   end
 end
 
 module type Concrete = sig
-  module V1 : sig
+  module V2 : sig
     type t =
       { receiver : Public_key.Compressed.V1.t
       ; amount : Currency.Amount.V1.t
       ; fee_transfer : Mina_base_coinbase_fee_transfer.V1.t option
+      ; fee_remainder : Currency.Fee.V1.t
       }
   end
 end
@@ -38,4 +41,4 @@ module Make
     (Signature : Local_sig)
     (F : functor (A : Concrete) -> Signature(A).S) : Signature(M).S
 
-include Types.S with module V1 = M.V1
+include Types.S with module V2 = M.V2

--- a/src/lib/mina_wire_types/mina_transaction.ml
+++ b/src/lib/mina_wire_types/mina_transaction.ml
@@ -1,12 +1,12 @@
 module Poly = struct
-  module V2 = struct
+  module V3 = struct
     type 'command t =
       | Command of 'command
       | Fee_transfer of Mina_base.Fee_transfer.V2.t
-      | Coinbase of Mina_base.Coinbase.V1.t
+      | Coinbase of Mina_base.Coinbase.V2.t
   end
 end
 
-module V3 = struct
-  type t = Mina_base.User_command.V3.t Poly.V2.t
+module V4 = struct
+  type t = Mina_base.User_command.V3.t Poly.V3.t
 end

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -254,7 +254,7 @@ module Mina_base = struct
   include Assert_equal0V2 (O.Fee_transfer.Stable) (W.Fee_transfer)
   include
     Assert_equal0V1 (O.Coinbase_fee_transfer.Stable) (W.Coinbase_fee_transfer)
-  include Assert_equal0V1 (O.Coinbase.Stable) (W.Coinbase)
+  include Assert_equal0V2 (O.Coinbase.Stable) (W.Coinbase)
   include Assert_equal2V1 (O.With_stack_hash.Stable) (W.With_stack_hash)
   include
     Assert_equal3V1
@@ -328,7 +328,7 @@ end
 module Mina_transaction = struct
   module O = Mina_transaction.Transaction
   module W = WT.Mina_transaction
-  include Assert_equal1V2 (O.Poly.Stable) (W.Poly)
+  include Assert_equal1V3 (O.Poly.Stable) (W.Poly)
 end
 
 module Mina_state = struct

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -78,7 +78,7 @@ let create_ledger_and_transactions ~signature_kind
       let coinbase =
         Coinbase.create ~amount:constraint_constants.coinbase_amount
           ~receiver:(Public_key.compress keys.(0).public_key)
-          ~fee_transfer:None
+          ~fee_transfer:None ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       let transactions =

--- a/src/lib/snark_work_lib/single_spec.mli
+++ b/src/lib/snark_work_lib/single_spec.mli
@@ -40,7 +40,7 @@ module Stable : sig
 
     val to_latest : t -> t
 
-    val transaction : t -> Mina_transaction.Transaction.Stable.V3.t option
+    val transaction : t -> Mina_transaction.Transaction.Stable.V4.t option
   end
 end]
 

--- a/src/lib/staged_ledger/diff_creation_log.ml
+++ b/src/lib/staged_ledger/diff_creation_log.ml
@@ -17,7 +17,7 @@ module Summary = struct
   type resources =
     { completed_work : count_and_fee
     ; commands : count_and_fee
-    ; coinbase_work_fees : Currency.Fee.t Staged_ledger_diff.At_most_two.t
+    ; coinbase_work_fees : Currency.Fee.t Staged_ledger_diff.At_most_one.t
     }
   [@@deriving sexp, to_yojson, lens]
 
@@ -41,25 +41,19 @@ module Summary = struct
   [@@deriving sexp, to_yojson, lens]
 
   let coinbase_fees
-      (coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
+      (coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t) =
     match coinbase with
     | One (Some x) ->
-        Staged_ledger_diff.At_most_two.One (Some x.fee)
-    | Two (Some (x, None)) ->
-        Two (Some (x.fee, None))
-    | Two (Some (x, Some x')) ->
-        Two (Some (x.fee, Some x'.fee))
+        Staged_ledger_diff.At_most_one.One (Some x.fee)
     | Zero ->
         Zero
     | One None ->
         One None
-    | Two None ->
-        Two None
 
   let init_resources
       ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(commands : User_command.Valid.t Sequence.t)
-      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
+      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t) =
     let completed_work =
       ( Sequence.length completed_work
       , Sequence.sum
@@ -78,7 +72,7 @@ module Summary = struct
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(commands : User_command.Valid.t Sequence.t)
-      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
+      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t)
       ~partition ~available_slots ~required_work_count =
     let start_resources = init_resources ~completed_work ~commands ~coinbase in
     let discarded_commands =
@@ -88,7 +82,7 @@ module Summary = struct
     let end_resources =
       { completed_work = (0, Currency.Fee.zero)
       ; commands = (0, Currency.Fee.zero)
-      ; coinbase_work_fees = Staged_ledger_diff.At_most_two.Zero
+      ; coinbase_work_fees = Staged_ledger_diff.At_most_one.Zero
       }
     in
     { partition
@@ -102,7 +96,7 @@ module Summary = struct
 
   let end_log t ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(commands : User_command.Valid.t Sequence.t)
-      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
+      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t) =
     end_resources.set (init_resources ~completed_work ~commands ~coinbase) t
 
   let incr (top : ('a, 'b) Lens.t) (nested : ('b, int) Lens.t) (t : 'a) =
@@ -140,7 +134,7 @@ module Detail = struct
         | `End ]
     ; commands : count_and_fee
     ; completed_work : count_and_fee
-    ; coinbase : Currency.Fee.t Staged_ledger_diff.At_most_two.t
+    ; coinbase : Currency.Fee.t Staged_ledger_diff.At_most_one.t
     }
   [@@deriving sexp, to_yojson, lens]
 
@@ -148,7 +142,7 @@ module Detail = struct
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(commands : User_command.Valid.t Sequence.t)
-      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
+      ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t) =
     let init = Summary.init_resources ~completed_work ~commands ~coinbase in
     [ { reason = `Init
       ; commands = init.commands
@@ -208,7 +202,7 @@ type detail_list = Detail.t list [@@deriving sexp, to_yojson]
 
 let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
     ~(commands : User_command.Valid.t Sequence.t)
-    ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
+    ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t)
     ~partition ~available_slots ~required_work_count =
   let summary =
     Summary.init ~completed_work ~commands ~coinbase ~partition ~available_slots
@@ -229,7 +223,7 @@ let discard_completed_work why completed_work t =
 
 let end_log ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
     ~(commands : User_command.Valid.t Sequence.t)
-    ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) t =
+    ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t) t =
   let summary = Summary.end_log (fst t) ~completed_work ~commands ~coinbase in
   let detailed = Detail.end_log coinbase (snd t) in
   (summary, detailed)

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -95,7 +95,7 @@ type ('t, 'w) t =
     part of the second prediff.
 *)
 let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
-    ~coinbase_amount =
+    ~coinbase_amount ~fee_remainder =
   let open Result.Let_syntax in
   let coinbase_or_error = function
     | Ok x ->
@@ -105,11 +105,15 @@ let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
   in
   match coinbase_parts with
   | `Zero ->
-      return []
+      if Currency.Fee.equal fee_remainder Currency.Fee.zero then return []
+      else
+        Error
+          (Error.Coinbase_error
+             "A block with no coinbase has no way to pay out its fee excess" )
   | `One x ->
       let%map cb =
         Coinbase.create ~amount:coinbase_amount ~receiver ~fee_transfer:x
-          ~fee_remainder:Currency.Fee.zero
+          ~fee_remainder
         |> coinbase_or_error
       in
       [ cb ]
@@ -136,11 +140,10 @@ module Transaction_data = struct
 end
 
 module Transaction_data_getter (T : Transaction_snark_work.S) = struct
-  let create_fee_transfers completed_works delta public_key coinbase_fts =
+  let create_fee_transfers completed_works coinbase_fts =
     let open Result.Let_syntax in
     let singles =
-      (if Currency.Fee.(equal zero delta) then [] else [ (public_key, delta) ])
-      @ List.filter_map completed_works ~f:(fun w ->
+      List.filter_map completed_works ~f:(fun w ->
           let fee = T.fee w in
           if Currency.Fee.equal fee Currency.Fee.zero then None
           else Some (T.prover w, fee) )
@@ -199,12 +202,8 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       (commands : c list) (completed_works : T.t list) :
       (c Transaction_data.t, Error.t) Result.t =
     let open Result.Let_syntax in
-    let%bind coinbases =
-      O1trace.sync_thread "create_coinbase" (fun () ->
-          create_coinbase coinbase_parts ~receiver ~coinbase_amount )
-    in
     let coinbase_fts =
-      List.concat_map coinbases ~f:(fun cb -> Option.to_list cb.fee_transfer)
+      match coinbase_parts with `Zero -> [] | `One x -> Option.to_list x
     in
     let coinbase_work_fees =
       sum_fees ~f:Coinbase.Fee_transfer.fee coinbase_fts |> Or_error.ok_exn
@@ -213,12 +212,20 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       List.filter completed_works ~f:(fun w ->
           not (Public_key.Compressed.equal receiver (T.prover w)) )
     in
+    (* Whatever the transaction fees do not spend on provers is paid to the
+       coinbase receiver by the coinbase itself, rather than by a fee transfer
+       of its own. *)
     let%bind delta =
       fee_remainder commands txn_works_others coinbase_work_fees
         ~to_user_command
     in
+    let%bind coinbases =
+      O1trace.sync_thread "create_coinbase" (fun () ->
+          create_coinbase coinbase_parts ~receiver ~coinbase_amount
+            ~fee_remainder:delta )
+    in
     let%map fee_transfers =
-      create_fee_transfers txn_works_others delta receiver coinbase_fts
+      create_fee_transfers txn_works_others coinbase_fts
     in
     { Transaction_data.commands; coinbases; fee_transfers }
 end

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -191,6 +191,18 @@ module Transaction_data = struct
     }
 end
 
+(* A padding transaction occupies a scan state slot without moving any funds, so
+   that a block can fill a partition it would otherwise leave short.
+
+   Its receiver must already exist in the ledger. A fee transfer that creates an
+   account pays the account creation fee out of the amount transferred, which a
+   zero-valued transfer cannot cover, and the resulting error aborts the whole
+   application rather than recording a failed status. *)
+let padding_transactions padding =
+  List.map (Option.to_list padding) ~f:(fun receiver_pk ->
+      Fee_transfer.create_single ~receiver_pk ~fee:Currency.Fee.zero
+        ~fee_token:Token_id.default )
+
 module Transaction_data_getter (T : Transaction_snark_work.S) = struct
   let create_fee_transfers completed_works delta public_key coinbase_fts =
     let open Result.Let_syntax in
@@ -300,7 +312,7 @@ let get_individual_info (type c)
        -> c With_status.t list
        -> 'work list
        -> (c With_status.t Transaction_data.t, Error.t) result )
-    ~constraint_constants coinbase_parts ~receiver ~coinbase_amount
+    ~constraint_constants coinbase_parts ~receiver ~coinbase_amount ~padding
     (commands : c With_status.t list) completed_works ~internal_command_statuses
     ~to_user_command =
   let open Result.Let_syntax in
@@ -311,7 +323,9 @@ let get_individual_info (type c)
   in
   let internal_commands =
     List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map
+        (fee_transfers @ padding_transactions padding)
+        ~f:(fun t -> Transaction.Fee_transfer t)
   in
   let%map internal_commands_with_statuses =
     Or_error.try_with (fun () ->
@@ -364,7 +378,7 @@ let compute_statuses
     (Staged_ledger_diff.With_valid_signatures_and_proofs.diff, _) result =
   let open Result.Let_syntax in
   (* project transactions into a sequence of transactions *)
-  let project_transactions ~coinbase_parts ~commands ~completed_works =
+  let project_transactions ~coinbase_parts ~commands ~completed_works ~padding =
     let%map { Transaction_data.commands; coinbases; fee_transfers } =
       Transaction_data_getter_checked.get_transaction_data ~constraint_constants
         coinbase_parts ~receiver:coinbase_receiver ~coinbase_amount commands
@@ -374,7 +388,9 @@ let compute_statuses
     List.map commands ~f:(fun t ->
         Transaction.Command (User_command.forget_check t) )
     @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map
+        (fee_transfers @ padding_transactions padding)
+        ~f:(fun t -> Transaction.Fee_transfer t)
   in
   let project_transactions_pre_diff_two
       (p :
@@ -384,7 +400,7 @@ let compute_statuses
       match p.coinbase with Zero -> `Zero | One x -> `One x | Two x -> `Two x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
-      ~completed_works:p.completed_works
+      ~completed_works:p.completed_works ~padding:p.padding
   in
   let project_transactions_pre_diff_one
       (p :
@@ -394,7 +410,7 @@ let compute_statuses
       match p.coinbase with Zero -> `Zero | One x -> `One x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
-      ~completed_works:p.completed_works
+      ~completed_works:p.completed_works ~padding:p.padding
   in
   (* partition a sequence of transactions with statuses into user commands with statuses and internal command statuses *)
   let split_transaction_statuses txns_with_statuses =
@@ -471,7 +487,7 @@ let get_impl (type c) ~get_transaction_data
     get_individual_info ~get_transaction_data coinbase_parts
       ~receiver:coinbase_receiver t1.commands t1.completed_works
       ~coinbase_amount ~internal_command_statuses:t1.internal_command_statuses
-      ~to_user_command
+      ~padding:t1.padding ~to_user_command
   in
   let apply_pre_diff_with_at_most_one (t2 : _ Staged_ledger_diff.Pre_diff_one.t)
       =
@@ -481,7 +497,7 @@ let get_impl (type c) ~get_transaction_data
     get_individual_info ~get_transaction_data coinbase_added
       ~receiver:coinbase_receiver t2.commands t2.completed_works
       ~coinbase_amount ~internal_command_statuses:t2.internal_command_statuses
-      ~to_user_command
+      ~padding:t2.padding ~to_user_command
   in
   let%bind () = check_coinbase diff in
   let%bind p1 =

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -90,53 +90,23 @@ type ('t, 'w) t =
     prover). One slot for the transaction and two slots for fee transfers.
 
     When the diff is split into two prediffs (why? refer to #687) and if after
-    adding transactions, the first prediff has two slots remaining which cannot
-    not accommodate transactions, then those slots are filled by splitting the
-    coinbase into two parts.
+    adding transactions, the first prediff has slots remaining which cannot
+    accommodate transactions, then one of them takes the coinbase and the rest
+    are filled with padding transactions.
 
-    If it has one slot, then we simply add one coinbase. It is also possible that
-    the first prediff may have no slots left after adding transactions (for
-    example, when there are three slots and maximum number of provers), in which case,
-    we simply add one coinbase as part of the second prediff.
+    It is also possible that the first prediff may have no slots left after
+    adding transactions (for example, when there are three slots and maximum
+    number of provers), in which case, we simply add one coinbase as part of the
+    second prediff.
 *)
-let create_coinbase
-    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    coinbase_parts ~(receiver : Public_key.Compressed.t) ~coinbase_amount =
+let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
+    ~coinbase_amount =
   let open Result.Let_syntax in
   let coinbase_or_error = function
     | Ok x ->
         Ok x
     | Error e ->
         Error (Error.Coinbase_error (Core.Error.to_string_hum e))
-  in
-  let underflow_err a1 a2 =
-    Option.value_map
-      ~default:
-        (Error
-           (Error.Coinbase_error
-              (sprintf
-                 !"underflow when splitting coinbase: Minuend: %{sexp: \
-                   Currency.Amount.t} Subtrahend: %{sexp: Currency.Amount.t} \n"
-                 a1 a2 ) ) )
-      (Currency.Amount.sub a1 a2)
-      ~f:(fun x -> Ok x)
-  in
-  let two_parts amt ft1 (ft2 : Coinbase.Fee_transfer.t option) =
-    let%bind rem_coinbase = underflow_err coinbase_amount amt in
-    let%bind _ =
-      underflow_err rem_coinbase
-        (Option.value_map ~default:Currency.Amount.zero ft2
-           ~f:(fun { fee; _ } -> Currency.Amount.of_fee fee ) )
-    in
-    let%bind cb1 =
-      coinbase_or_error
-        (Coinbase.create ~amount:amt ~receiver ~fee_transfer:ft1)
-    in
-    let%map cb2 =
-      Coinbase.create ~amount:rem_coinbase ~receiver ~fee_transfer:ft2
-      |> coinbase_or_error
-    in
-    [ cb1; cb2 ]
   in
   match coinbase_parts with
   | `Zero ->
@@ -147,28 +117,6 @@ let create_coinbase
         |> coinbase_or_error
       in
       [ cb ]
-  | `Two None ->
-      two_parts
-        (Currency.Amount.of_fee constraint_constants.account_creation_fee)
-        None None
-  | `Two (Some (({ Coinbase.Fee_transfer.fee; _ } as ft1), ft2)) ->
-      let%bind amount =
-        let%map fee =
-          Currency.Fee.add constraint_constants.account_creation_fee fee
-          |> Option.value_map
-               ~default:
-                 (Error
-                    (Error.Coinbase_error
-                       (sprintf
-                          !"Overflow when trying to add account_creation_fee \
-                            %{sexp: Currency.Fee.t} to a fee transfer %{sexp: \
-                            Currency.Fee.t}"
-                          constraint_constants.account_creation_fee fee ) ) )
-               ~f:(fun v -> Ok v)
-        in
-        Currency.Amount.of_fee fee
-      in
-      two_parts amount (Some ft1) ft2
 
 let sum_fees xs ~f =
   with_return (fun { return } ->
@@ -261,16 +209,15 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       ~f:(fun x -> Ok x)
       (Currency.Fee.sub budget total_work_fee)
 
-  let get_transaction_data (type update a b c) ~constraint_constants
-      coinbase_parts ~receiver ~coinbase_amount
+  let get_transaction_data (type update a b c) coinbase_parts ~receiver
+      ~coinbase_amount
       ~(to_user_command : c -> (update, a, b) User_command.with_forest)
       (commands : c list) (completed_works : T.t list) :
       (c Transaction_data.t, Error.t) Result.t =
     let open Result.Let_syntax in
     let%bind coinbases =
       O1trace.sync_thread "create_coinbase" (fun () ->
-          create_coinbase ~constraint_constants coinbase_parts ~receiver
-            ~coinbase_amount )
+          create_coinbase coinbase_parts ~receiver ~coinbase_amount )
     in
     let coinbase_fts =
       List.concat_map coinbases ~f:(fun cb -> Option.to_list cb.fee_transfer)
@@ -301,25 +248,20 @@ module Transaction_data_getter_stable =
 
 let get_individual_info (type c)
     ~(get_transaction_data :
-          constraint_constants:Genesis_constants.Constraint_constants.t
-       -> [< `One of Coinbase_fee_transfer.t option
-          | `Two of
-            (Coinbase_fee_transfer.t * Coinbase_fee_transfer.t option) option
-          | `Zero ]
+          [< `One of Coinbase_fee_transfer.t option | `Zero ]
        -> receiver:Public_key.Compressed.t
        -> coinbase_amount:Currency.Amount.t
        -> to_user_command:(c With_status.t -> (_, _, _) User_command.with_forest)
        -> c With_status.t list
        -> 'work list
-       -> (c With_status.t Transaction_data.t, Error.t) result )
-    ~constraint_constants coinbase_parts ~receiver ~coinbase_amount ~padding
-    (commands : c With_status.t list) completed_works ~internal_command_statuses
-    ~to_user_command =
+       -> (c With_status.t Transaction_data.t, Error.t) result ) coinbase_parts
+    ~receiver ~coinbase_amount ~padding (commands : c With_status.t list)
+    completed_works ~internal_command_statuses ~to_user_command =
   let open Result.Let_syntax in
   let%bind
       { Transaction_data.commands; coinbases = coinbase_parts; fee_transfers } =
-    get_transaction_data ~constraint_constants coinbase_parts ~receiver
-      ~coinbase_amount commands completed_works ~to_user_command
+    get_transaction_data coinbase_parts ~receiver ~coinbase_amount commands
+      completed_works ~to_user_command
   in
   let internal_commands =
     List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
@@ -359,7 +301,7 @@ let check_coinbase
     , Option.value_map ~default:Staged_ledger_diff.At_most_one.Zero (snd diff)
         ~f:(fun d -> d.coinbase ) )
   with
-  | Zero, Zero | Zero, One _ | One _, Zero | Two _, Zero ->
+  | Zero, Zero | Zero, One _ | One _, Zero ->
       Ok ()
   | x, y ->
       Error
@@ -367,7 +309,7 @@ let check_coinbase
            (sprintf
               !"Invalid coinbase value in staged ledger prediffs \
                 %{sexp:Coinbase.Fee_transfer.t \
-                Staged_ledger_diff.At_most_two.t} and \
+                Staged_ledger_diff.At_most_one.t} and \
                 %{sexp:Coinbase.Fee_transfer.t \
                 Staged_ledger_diff.At_most_one.t}"
               x y ) )
@@ -380,8 +322,8 @@ let compute_statuses
   (* project transactions into a sequence of transactions *)
   let project_transactions ~coinbase_parts ~commands ~completed_works ~padding =
     let%map { Transaction_data.commands; coinbases; fee_transfers } =
-      Transaction_data_getter_checked.get_transaction_data ~constraint_constants
-        coinbase_parts ~receiver:coinbase_receiver ~coinbase_amount commands
+      Transaction_data_getter_checked.get_transaction_data coinbase_parts
+        ~receiver:coinbase_receiver ~coinbase_amount commands
         (completed_works : Transaction_snark_work.Checked.t list)
         ~to_user_command:User_command.forget_check
     in
@@ -397,7 +339,7 @@ let compute_statuses
         (Transaction_snark_work.Checked.t, _) Staged_ledger_diff.Pre_diff_two.t
         ) =
     let coinbase_parts =
-      match p.coinbase with Zero -> `Zero | One x -> `One x | Two x -> `Two x
+      match p.coinbase with Zero -> `Zero | One x -> `One x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
       ~completed_works:p.completed_works ~padding:p.padding
@@ -482,7 +424,7 @@ let get_impl (type c) ~get_transaction_data
   let apply_pre_diff_with_at_most_two (t1 : _ Staged_ledger_diff.Pre_diff_two.t)
       =
     let coinbase_parts =
-      match t1.coinbase with Zero -> `Zero | One x -> `One x | Two x -> `Two x
+      match t1.coinbase with Zero -> `Zero | One x -> `One x
     in
     get_individual_info ~get_transaction_data coinbase_parts
       ~receiver:coinbase_receiver t1.commands t1.completed_works
@@ -500,12 +442,10 @@ let get_impl (type c) ~get_transaction_data
       ~padding:t2.padding ~to_user_command
   in
   let%bind () = check_coinbase diff in
-  let%bind p1 =
-    apply_pre_diff_with_at_most_two ~constraint_constants (fst diff)
-  in
+  let%bind p1 = apply_pre_diff_with_at_most_two (fst diff) in
   let%map p2 =
     Option.value_map
-      ~f:(fun d -> apply_pre_diff_with_at_most_one ~constraint_constants d)
+      ~f:(fun d -> apply_pre_diff_with_at_most_one d)
       (snd diff)
       ~default:
         (Ok { transactions = []; work = []; commands_count = 0; coinbases = [] })

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -254,9 +254,12 @@ let get_individual_info (type c)
     get_transaction_data coinbase_parts ~receiver ~coinbase_amount commands
       completed_works ~to_user_command
   in
+  (* The coinbase is the last transaction of the block: every fee payment
+     precedes it, so the fee excess it settles is the whole of what the block
+     collected, and the ledger it leaves behind is the block's final one. *)
   let internal_commands =
-    List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
   in
   let%map internal_commands_with_statuses =
     Or_error.try_with (fun () ->
@@ -318,8 +321,8 @@ let compute_statuses
     in
     List.map commands ~f:(fun t ->
         Transaction.Command (User_command.forget_check t) )
-    @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
     @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
   in
   let project_transactions_pre_diff_two
       (p :

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -85,19 +85,14 @@ type ('t, 'w) t =
     Unlike a transaction, a coinbase (including the fee transfer) just requires one slot
     in the jobs queue.
 
-    The minimum number of slots required to add a single transaction is three (at
-    worst case number of provers: when each pair of proofs is from a different
-    prover). One slot for the transaction and two slots for fee transfers.
+    Fee transfers pay up to two provers each, so the slots a transaction
+    occupies are one for itself plus, at worst, one shared fee transfer slot.
 
-    When the diff is split into two prediffs (why? refer to #687) and if after
-    adding transactions, the first prediff has slots remaining which cannot
-    accommodate transactions, then one of them takes the coinbase and the rest
-    are filled with padding transactions.
-
-    It is also possible that the first prediff may have no slots left after
-    adding transactions (for example, when there are three slots and maximum
-    number of provers), in which case, we simply add one coinbase as part of the
-    second prediff.
+    When the diff is split into two prediffs (why? refer to #687), exactly one
+    of them carries the coinbase. It is possible for the first prediff to have
+    no slots left after adding transactions (for example, when there are three
+    slots and maximum number of provers), in which case we add the coinbase as
+    part of the second prediff.
 *)
 let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
     ~coinbase_amount =
@@ -138,18 +133,6 @@ module Transaction_data = struct
     ; fee_transfers : Fee_transfer.t list
     }
 end
-
-(* A padding transaction occupies a scan state slot without moving any funds, so
-   that a block can fill a partition it would otherwise leave short.
-
-   Its receiver must already exist in the ledger. A fee transfer that creates an
-   account pays the account creation fee out of the amount transferred, which a
-   zero-valued transfer cannot cover, and the resulting error aborts the whole
-   application rather than recording a failed status. *)
-let padding_transactions padding =
-  List.map (Option.to_list padding) ~f:(fun receiver_pk ->
-      Fee_transfer.create_single ~receiver_pk ~fee:Currency.Fee.zero
-        ~fee_token:Token_id.default )
 
 module Transaction_data_getter (T : Transaction_snark_work.S) = struct
   let create_fee_transfers completed_works delta public_key coinbase_fts =
@@ -255,8 +238,8 @@ let get_individual_info (type c)
        -> c With_status.t list
        -> 'work list
        -> (c With_status.t Transaction_data.t, Error.t) result ) coinbase_parts
-    ~receiver ~coinbase_amount ~padding (commands : c With_status.t list)
-    completed_works ~internal_command_statuses ~to_user_command =
+    ~receiver ~coinbase_amount (commands : c With_status.t list) completed_works
+    ~internal_command_statuses ~to_user_command =
   let open Result.Let_syntax in
   let%bind
       { Transaction_data.commands; coinbases = coinbase_parts; fee_transfers } =
@@ -265,9 +248,7 @@ let get_individual_info (type c)
   in
   let internal_commands =
     List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map
-        (fee_transfers @ padding_transactions padding)
-        ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
   in
   let%map internal_commands_with_statuses =
     Or_error.try_with (fun () ->
@@ -320,7 +301,7 @@ let compute_statuses
     (Staged_ledger_diff.With_valid_signatures_and_proofs.diff, _) result =
   let open Result.Let_syntax in
   (* project transactions into a sequence of transactions *)
-  let project_transactions ~coinbase_parts ~commands ~completed_works ~padding =
+  let project_transactions ~coinbase_parts ~commands ~completed_works =
     let%map { Transaction_data.commands; coinbases; fee_transfers } =
       Transaction_data_getter_checked.get_transaction_data coinbase_parts
         ~receiver:coinbase_receiver ~coinbase_amount commands
@@ -330,9 +311,7 @@ let compute_statuses
     List.map commands ~f:(fun t ->
         Transaction.Command (User_command.forget_check t) )
     @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map
-        (fee_transfers @ padding_transactions padding)
-        ~f:(fun t -> Transaction.Fee_transfer t)
+    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
   in
   let project_transactions_pre_diff_two
       (p :
@@ -342,7 +321,7 @@ let compute_statuses
       match p.coinbase with Zero -> `Zero | One x -> `One x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
-      ~completed_works:p.completed_works ~padding:p.padding
+      ~completed_works:p.completed_works
   in
   let project_transactions_pre_diff_one
       (p :
@@ -352,7 +331,7 @@ let compute_statuses
       match p.coinbase with Zero -> `Zero | One x -> `One x
     in
     project_transactions ~coinbase_parts ~commands:p.commands
-      ~completed_works:p.completed_works ~padding:p.padding
+      ~completed_works:p.completed_works
   in
   (* partition a sequence of transactions with statuses into user commands with statuses and internal command statuses *)
   let split_transaction_statuses txns_with_statuses =
@@ -429,7 +408,7 @@ let get_impl (type c) ~get_transaction_data
     get_individual_info ~get_transaction_data coinbase_parts
       ~receiver:coinbase_receiver t1.commands t1.completed_works
       ~coinbase_amount ~internal_command_statuses:t1.internal_command_statuses
-      ~padding:t1.padding ~to_user_command
+      ~to_user_command
   in
   let apply_pre_diff_with_at_most_one (t2 : _ Staged_ledger_diff.Pre_diff_one.t)
       =
@@ -439,7 +418,7 @@ let get_impl (type c) ~get_transaction_data
     get_individual_info ~get_transaction_data coinbase_added
       ~receiver:coinbase_receiver t2.commands t2.completed_works
       ~coinbase_amount ~internal_command_statuses:t2.internal_command_statuses
-      ~padding:t2.padding ~to_user_command
+      ~to_user_command
   in
   let%bind () = check_coinbase diff in
   let%bind p1 = apply_pre_diff_with_at_most_two (fst diff) in

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -109,6 +109,7 @@ let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
   | `One x ->
       let%map cb =
         Coinbase.create ~amount:coinbase_amount ~receiver ~fee_transfer:x
+          ~fee_remainder:Currency.Fee.zero
         |> coinbase_or_error
       in
       [ cb ]

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -26,7 +26,7 @@ module type S = sig
     -> ( Transaction.Valid.t With_status.t list
          * Transaction_snark_work.t list
          * int
-         * Currency.Amount.t list
+         * Currency.Amount.t option
        , Error.t )
        result
 
@@ -76,7 +76,7 @@ type ('t, 'w) t =
   { transactions : 't list
   ; work : 'w list
   ; commands_count : int
-  ; coinbases : Currency.Amount.t list
+  ; coinbase : Currency.Amount.t option
   }
 
 (*A Coinbase is a single transaction that accommodates the coinbase amount
@@ -105,7 +105,7 @@ let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
   in
   match coinbase_parts with
   | `Zero ->
-      if Currency.Fee.equal fee_remainder Currency.Fee.zero then return []
+      if Currency.Fee.equal fee_remainder Currency.Fee.zero then return None
       else
         Error
           (Error.Coinbase_error
@@ -116,7 +116,7 @@ let create_coinbase coinbase_parts ~(receiver : Public_key.Compressed.t)
           ~fee_remainder
         |> coinbase_or_error
       in
-      [ cb ]
+      Some cb
 
 let sum_fees xs ~f =
   with_return (fun { return } ->
@@ -134,7 +134,7 @@ let to_staged_ledger_or_error =
 module Transaction_data = struct
   type 'a t =
     { commands : 'a list
-    ; coinbases : Coinbase.t list
+    ; coinbase : Coinbase.t option
     ; fee_transfers : Fee_transfer.t list
     }
 end
@@ -219,7 +219,7 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       fee_remainder commands txn_works_others coinbase_work_fees
         ~to_user_command
     in
-    let%bind coinbases =
+    let%bind coinbase =
       O1trace.sync_thread "create_coinbase" (fun () ->
           create_coinbase coinbase_parts ~receiver ~coinbase_amount
             ~fee_remainder:delta )
@@ -227,7 +227,7 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
     let%map fee_transfers =
       create_fee_transfers txn_works_others coinbase_fts
     in
-    { Transaction_data.commands; coinbases; fee_transfers }
+    { Transaction_data.commands; coinbase; fee_transfers }
 end
 
 module Transaction_data_getter_unchecked =
@@ -249,8 +249,7 @@ let get_individual_info (type c)
     ~receiver ~coinbase_amount (commands : c With_status.t list) completed_works
     ~internal_command_statuses ~to_user_command =
   let open Result.Let_syntax in
-  let%bind
-      { Transaction_data.commands; coinbases = coinbase_parts; fee_transfers } =
+  let%bind { Transaction_data.commands; coinbase; fee_transfers } =
     get_transaction_data coinbase_parts ~receiver ~coinbase_amount commands
       completed_works ~to_user_command
   in
@@ -259,7 +258,7 @@ let get_individual_info (type c)
      collected, and the ledger it leaves behind is the block's final one. *)
   let internal_commands =
     List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
-    @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
+    @ List.map (Option.to_list coinbase) ~f:(fun t -> Transaction.Coinbase t)
   in
   let%map internal_commands_with_statuses =
     Or_error.try_with (fun () ->
@@ -280,8 +279,7 @@ let get_individual_info (type c)
   { transactions
   ; work = completed_works
   ; commands_count = List.length commands
-  ; coinbases =
-      List.map coinbase_parts ~f:(fun Coinbase.{ amount; _ } -> amount)
+  ; coinbase = Option.map coinbase ~f:(fun Coinbase.{ amount; _ } -> amount)
   }
 
 let check_coinbase
@@ -313,7 +311,7 @@ let compute_statuses
   let open Result.Let_syntax in
   (* project transactions into a sequence of transactions *)
   let project_transactions ~coinbase_parts ~commands ~completed_works =
-    let%map { Transaction_data.commands; coinbases; fee_transfers } =
+    let%map { Transaction_data.commands; coinbase; fee_transfers } =
       Transaction_data_getter_checked.get_transaction_data coinbase_parts
         ~receiver:coinbase_receiver ~coinbase_amount commands
         (completed_works : Transaction_snark_work.Checked.t list)
@@ -322,7 +320,7 @@ let compute_statuses
     List.map commands ~f:(fun t ->
         Transaction.Command (User_command.forget_check t) )
     @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
-    @ List.map coinbases ~f:(fun t -> Transaction.Coinbase t)
+    @ List.map (Option.to_list coinbase) ~f:(fun t -> Transaction.Coinbase t)
   in
   let project_transactions_pre_diff_two
       (p :
@@ -438,12 +436,14 @@ let get_impl (type c) ~get_transaction_data
       ~f:(fun d -> apply_pre_diff_with_at_most_one d)
       (snd diff)
       ~default:
-        (Ok { transactions = []; work = []; commands_count = 0; coinbases = [] })
+        (Ok
+           { transactions = []; work = []; commands_count = 0; coinbase = None }
+        )
   in
   ( p1.transactions @ p2.transactions
   , p1.work @ p2.work
   , p1.commands_count + p2.commands_count
-  , p1.coinbases @ p2.coinbases )
+  , Option.first_some p1.coinbase p2.coinbase )
 
 (* TODO: This is important *)
 let get ~check ~constraint_constants ~coinbase_receiver ~supercharge_coinbase t

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -196,15 +196,38 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       ~f:(fun x -> Ok x)
       (Currency.Fee.sub budget total_work_fee)
 
-  let get_transaction_data (type update a b c) coinbase_parts ~receiver
-      ~coinbase_amount
-      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
-      (commands : c list) (completed_works : T.t list) :
+  let get_transaction_data (type c) coinbase_parts ~receiver ~coinbase_amount
+      ~fee_remainder (commands : c list) (completed_works : T.t list) :
       (c Transaction_data.t, Error.t) Result.t =
     let open Result.Let_syntax in
     let coinbase_fts =
       match coinbase_parts with `Zero -> [] | `One x -> Option.to_list x
     in
+    let txn_works_others =
+      List.filter completed_works ~f:(fun w ->
+          not (Public_key.Compressed.equal receiver (T.prover w)) )
+    in
+    let%bind coinbase =
+      O1trace.sync_thread "create_coinbase" (fun () ->
+          create_coinbase coinbase_parts ~receiver ~coinbase_amount
+            ~fee_remainder )
+    in
+    let%map fee_transfers =
+      create_fee_transfers txn_works_others coinbase_fts
+    in
+    { Transaction_data.commands; coinbase; fee_transfers }
+
+  (* Whatever the transaction fees do not spend on provers is paid to the
+     coinbase receiver by the coinbase itself, rather than by a fee transfer of
+     its own.
+
+     It is a property of the whole diff rather than of either pre-diff. A block
+     whose transactions span two scan state trees has its commands on one side
+     and, since the coinbase is its last transaction, the coinbase on the
+     other: only the side carrying the coinbase can pay the remainder out. *)
+  let total_fee_remainder (type update a b c) ~receiver
+      ~(to_user_command : c -> (update, a, b) User_command.with_forest)
+      ~coinbase_fts (commands : c list) (completed_works : T.t list) =
     let coinbase_work_fees =
       sum_fees ~f:Coinbase.Fee_transfer.fee coinbase_fts |> Or_error.ok_exn
     in
@@ -212,22 +235,7 @@ module Transaction_data_getter (T : Transaction_snark_work.S) = struct
       List.filter completed_works ~f:(fun w ->
           not (Public_key.Compressed.equal receiver (T.prover w)) )
     in
-    (* Whatever the transaction fees do not spend on provers is paid to the
-       coinbase receiver by the coinbase itself, rather than by a fee transfer
-       of its own. *)
-    let%bind delta =
-      fee_remainder commands txn_works_others coinbase_work_fees
-        ~to_user_command
-    in
-    let%bind coinbase =
-      O1trace.sync_thread "create_coinbase" (fun () ->
-          create_coinbase coinbase_parts ~receiver ~coinbase_amount
-            ~fee_remainder:delta )
-    in
-    let%map fee_transfers =
-      create_fee_transfers txn_works_others coinbase_fts
-    in
-    { Transaction_data.commands; coinbase; fee_transfers }
+    fee_remainder commands txn_works_others coinbase_work_fees ~to_user_command
 end
 
 module Transaction_data_getter_unchecked =
@@ -242,16 +250,16 @@ let get_individual_info (type c)
           [< `One of Coinbase_fee_transfer.t option | `Zero ]
        -> receiver:Public_key.Compressed.t
        -> coinbase_amount:Currency.Amount.t
-       -> to_user_command:(c With_status.t -> (_, _, _) User_command.with_forest)
+       -> fee_remainder:Currency.Fee.t
        -> c With_status.t list
        -> 'work list
        -> (c With_status.t Transaction_data.t, Error.t) result ) coinbase_parts
-    ~receiver ~coinbase_amount (commands : c With_status.t list) completed_works
-    ~internal_command_statuses ~to_user_command =
+    ~receiver ~coinbase_amount ~fee_remainder (commands : c With_status.t list)
+    completed_works ~internal_command_statuses =
   let open Result.Let_syntax in
   let%bind { Transaction_data.commands; coinbase; fee_transfers } =
-    get_transaction_data coinbase_parts ~receiver ~coinbase_amount commands
-      completed_works ~to_user_command
+    get_transaction_data coinbase_parts ~receiver ~coinbase_amount
+      ~fee_remainder commands completed_works
   in
   (* The coinbase is the last transaction of the block: every fee payment
      precedes it, so the fee excess it settles is the whole of what the block
@@ -309,13 +317,49 @@ let compute_statuses
     ~coinbase_receiver ~coinbase_amount ~global_slot ~txn_state_view ~ledger :
     (Staged_ledger_diff.With_valid_signatures_and_proofs.diff, _) result =
   let open Result.Let_syntax in
+  let ( (p1 :
+          ( Transaction_snark_work.Checked.t
+          , _ )
+          Staged_ledger_diff.Pre_diff_two.t )
+      , (p2 :
+          ( Transaction_snark_work.Checked.t
+          , _ )
+          Staged_ledger_diff.Pre_diff_one.t
+          option ) ) =
+    diff
+  in
+  let coinbase_fts =
+    let of_at_most_one = function
+      | Staged_ledger_diff.At_most_one.Zero ->
+          []
+      | One x ->
+          Option.to_list x
+    in
+    of_at_most_one p1.coinbase
+    @ Option.value_map p2 ~default:[] ~f:(fun d -> of_at_most_one d.coinbase)
+  in
+  let%bind total_fee_remainder =
+    Transaction_data_getter_checked.total_fee_remainder
+      ~receiver:coinbase_receiver ~to_user_command:User_command.forget_check
+      ~coinbase_fts
+      (p1.commands @ Option.value_map p2 ~default:[] ~f:(fun d -> d.commands))
+      ( p1.completed_works
+      @ Option.value_map p2 ~default:[] ~f:(fun d -> d.completed_works) )
+  in
+  (* Only the pre-diff carrying the coinbase can pay the remainder out. *)
+  let remainder_for = function
+    | Staged_ledger_diff.At_most_one.Zero ->
+        Currency.Fee.zero
+    | One _ ->
+        total_fee_remainder
+  in
   (* project transactions into a sequence of transactions *)
-  let project_transactions ~coinbase_parts ~commands ~completed_works =
+  let project_transactions ~coinbase_parts ~commands ~completed_works
+      ~fee_remainder =
     let%map { Transaction_data.commands; coinbase; fee_transfers } =
       Transaction_data_getter_checked.get_transaction_data coinbase_parts
-        ~receiver:coinbase_receiver ~coinbase_amount commands
+        ~receiver:coinbase_receiver ~coinbase_amount ~fee_remainder commands
         (completed_works : Transaction_snark_work.Checked.t list)
-        ~to_user_command:User_command.forget_check
     in
     List.map commands ~f:(fun t ->
         Transaction.Command (User_command.forget_check t) )
@@ -331,6 +375,7 @@ let compute_statuses
     in
     project_transactions ~coinbase_parts ~commands:p.commands
       ~completed_works:p.completed_works
+      ~fee_remainder:(remainder_for p.coinbase)
   in
   let project_transactions_pre_diff_one
       (p :
@@ -341,6 +386,7 @@ let compute_statuses
     in
     project_transactions ~coinbase_parts ~commands:p.commands
       ~completed_works:p.completed_works
+      ~fee_remainder:(remainder_for p.coinbase)
   in
   (* partition a sequence of transactions with statuses into user commands with statuses and internal command statuses *)
   let split_transaction_statuses txns_with_statuses =
@@ -359,7 +405,6 @@ let compute_statuses
         | Transaction.Fee_transfer _ | Transaction.Coinbase _ ->
             Either.Second status )
   in
-  let p1, p2 = diff in
   let%bind num_p1_txns, txns =
     let%map p1_txns = project_transactions_pre_diff_two p1
     and p2_txns =
@@ -391,7 +436,7 @@ let compute_statuses
   in
   (p1', p2')
 
-let get_impl (type c) ~get_transaction_data
+let get_impl (type c) ~get_transaction_data ~total_fee_remainder
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~(to_user_command : c With_status.t -> (_, _, _) User_command.with_forest)
     ~diff ~coinbase_receiver ~coinbase_amount =
@@ -409,6 +454,32 @@ let get_impl (type c) ~get_transaction_data
                  constraint_constants.coinbase_amount ) ) )
       ~f:(fun x -> Ok x)
   in
+  let t1, t2 = diff in
+  let coinbase_fts =
+    let of_at_most_one = function
+      | Staged_ledger_diff.At_most_one.Zero ->
+          []
+      | One x ->
+          Option.to_list x
+    in
+    of_at_most_one t1.Staged_ledger_diff.Pre_diff_two.coinbase
+    @ Option.value_map t2 ~default:[] ~f:(fun d ->
+        of_at_most_one d.Staged_ledger_diff.Pre_diff_one.coinbase )
+  in
+  let%bind total_fee_remainder =
+    total_fee_remainder ~receiver:coinbase_receiver ~to_user_command
+      ~coinbase_fts
+      (t1.commands @ Option.value_map t2 ~default:[] ~f:(fun d -> d.commands))
+      ( t1.completed_works
+      @ Option.value_map t2 ~default:[] ~f:(fun d -> d.completed_works) )
+  in
+  (* Only the pre-diff carrying the coinbase can pay the remainder out. *)
+  let remainder_for = function
+    | Staged_ledger_diff.At_most_one.Zero ->
+        Currency.Fee.zero
+    | One _ ->
+        total_fee_remainder
+  in
   let apply_pre_diff_with_at_most_two (t1 : _ Staged_ledger_diff.Pre_diff_two.t)
       =
     let coinbase_parts =
@@ -416,8 +487,9 @@ let get_impl (type c) ~get_transaction_data
     in
     get_individual_info ~get_transaction_data coinbase_parts
       ~receiver:coinbase_receiver t1.commands t1.completed_works
-      ~coinbase_amount ~internal_command_statuses:t1.internal_command_statuses
-      ~to_user_command
+      ~coinbase_amount
+      ~fee_remainder:(remainder_for t1.coinbase)
+      ~internal_command_statuses:t1.internal_command_statuses
   in
   let apply_pre_diff_with_at_most_one (t2 : _ Staged_ledger_diff.Pre_diff_one.t)
       =
@@ -426,8 +498,9 @@ let get_impl (type c) ~get_transaction_data
     in
     get_individual_info ~get_transaction_data coinbase_added
       ~receiver:coinbase_receiver t2.commands t2.completed_works
-      ~coinbase_amount ~internal_command_statuses:t2.internal_command_statuses
-      ~to_user_command
+      ~coinbase_amount
+      ~fee_remainder:(remainder_for t2.coinbase)
+      ~internal_command_statuses:t2.internal_command_statuses
   in
   let%bind () = check_coinbase diff in
   let%bind p1 = apply_pre_diff_with_at_most_two (fst diff) in
@@ -456,7 +529,7 @@ let get ~check ~constraint_constants ~coinbase_receiver ~supercharge_coinbase t
       Error (Error.Verification_failed e)
   | Ok (Ok diff) ->
       let open Transaction_data_getter_unchecked in
-      get_impl ~get_transaction_data ~constraint_constants
+      get_impl ~get_transaction_data ~total_fee_remainder ~constraint_constants
         ~to_user_command:(Fn.compose User_command.forget_check With_status.data)
         ~diff:diff.diff ~coinbase_receiver
         ~coinbase_amount:
@@ -467,8 +540,8 @@ let get_unchecked ~constraint_constants ~coinbase_receiver ~supercharge_coinbase
     (t : Staged_ledger_diff.With_valid_signatures_and_proofs.t) =
   let t = Staged_ledger_diff.forget_proof_checks t in
   let open Transaction_data_getter_unchecked in
-  get_impl ~get_transaction_data ~constraint_constants ~diff:t.diff
-    ~coinbase_receiver
+  get_impl ~get_transaction_data ~total_fee_remainder ~constraint_constants
+    ~diff:t.diff ~coinbase_receiver
     ~to_user_command:(Fn.compose User_command.forget_check With_status.data)
     ~coinbase_amount:
       (Staged_ledger_diff.With_valid_signatures.coinbase ~constraint_constants
@@ -479,7 +552,7 @@ let get_transactions_stable ~constraint_constants ~coinbase_receiver
   let open Result.Let_syntax in
   let open Transaction_data_getter_stable in
   let%map transactions, _, _, _ =
-    get_impl ~get_transaction_data ~constraint_constants
+    get_impl ~get_transaction_data ~total_fee_remainder ~constraint_constants
       ~to_user_command:With_status.data ~diff ~coinbase_receiver
       ~coinbase_amount:
         (Staged_ledger_diff.Diff.Stable.Latest.coinbase ~constraint_constants
@@ -492,7 +565,7 @@ let get_transactions ~constraint_constants ~coinbase_receiver
   let open Result.Let_syntax in
   let open Transaction_data_getter_unchecked in
   let%map transactions, _, _, _ =
-    get_impl ~get_transaction_data ~constraint_constants
+    get_impl ~get_transaction_data ~total_fee_remainder ~constraint_constants
       ~to_user_command:With_status.data ~diff ~coinbase_receiver
       ~coinbase_amount:
         (Staged_ledger_diff.Diff.coinbase ~constraint_constants

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -70,12 +70,10 @@ module T = struct
     [@@deriving to_yojson]
 
     let coinbase_parts = function
-      | Staged_ledger_diff.At_most_two.Zero ->
+      | Staged_ledger_diff.At_most_one.Zero ->
           0
       | One _ ->
           1
-      | Two _ ->
-          2
 
     let partition_of_summary (summary : Diff_creation_log.Summary.t) =
       let start_commands, _ = summary.start_resources.commands in
@@ -1575,7 +1573,7 @@ module T = struct
       ; completed_work_rev : Transaction_snark_work.Checked.t Sequence.t
       ; fee_transfers : Fee.t Public_key.Compressed.Map.t
       ; add_coinbase : bool
-      ; coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t
+      ; coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t
       ; supercharge_coinbase : bool
       ; receiver_pk : Public_key.Compressed.t
       ; budget : Fee.t Or_error.t
@@ -1611,10 +1609,10 @@ module T = struct
 
     let coinbase_work
         ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-        ?(is_two = false) (works : Transaction_snark_work.Checked.t Sequence.t)
+        (works : Transaction_snark_work.Checked.t Sequence.t)
         ~is_coinbase_receiver_new ~supercharge_coinbase =
       let open Option.Let_syntax in
-      let min1, min2 = cheapest_two_work works in
+      let min1, _min2 = cheapest_two_work works in
       let diff ws ws' =
         Sequence.filter ws ~f:(fun w ->
             Sequence.mem ws'
@@ -1635,61 +1633,14 @@ module T = struct
         else Some coinbase_amount
       in
       let stmt = Transaction_snark_work.Checked.statement in
-      if is_two then
-        match (min1, min2) with
-        | None, _ ->
-            None
-        | Some w, None ->
-            if Amount.(of_fee (Transaction_snark_work.Checked.fee w) <= budget)
-            then
-              let cb =
-                Staged_ledger_diff.At_most_two.Two
-                  (Option.map (coinbase_ft w) ~f:(fun ft -> (ft, None)))
-              in
-              Some (cb, diff works (Sequence.of_list [ stmt w ]))
-            else
-              let cb = Staged_ledger_diff.At_most_two.Two None in
-              Some (cb, works)
-        | Some w1, Some w2 ->
-            let%map sum =
-              Fee.add
-                (Transaction_snark_work.Checked.fee w1)
-                (Transaction_snark_work.Checked.fee w2)
-            in
-            if Amount.(of_fee sum <= budget) then
-              let cb =
-                Staged_ledger_diff.At_most_two.Two
-                  (Option.map (coinbase_ft w1) ~f:(fun ft ->
-                       (ft, coinbase_ft w2) ) )
-                (* Why add work without checking if work constraints are
-                   satisfied? If we reach here then it means that we are trying to
-                   fill the last two slots of the tree with coinbase trnasactions
-                   and if there's any work in [works] then that has to be included,
-                   either in the coinbase or as fee transfers that gets paid by
-                   the transaction fees. So having it as coinbase ft will at least
-                   reduce the slots occupied by fee transfers *)
-              in
-              (cb, diff works (Sequence.of_list [ stmt w1; stmt w2 ]))
-            else if
-              Amount.(of_fee (Transaction_snark_work.Checked.fee w1) <= budget)
-            then
-              let cb =
-                Staged_ledger_diff.At_most_two.Two
-                  (Option.map (coinbase_ft w1) ~f:(fun ft -> (ft, None)))
-              in
-              (cb, diff works (Sequence.of_list [ stmt w1 ]))
-            else
-              let cb = Staged_ledger_diff.At_most_two.Two None in
-              (cb, works)
-      else
-        Option.map min1 ~f:(fun w ->
-            if Amount.(of_fee (Transaction_snark_work.Checked.fee w) <= budget)
-            then
-              let cb = Staged_ledger_diff.At_most_two.One (coinbase_ft w) in
-              (cb, diff works (Sequence.of_list [ stmt w ]))
-            else
-              let cb = Staged_ledger_diff.At_most_two.One None in
-              (cb, works) )
+      Option.map min1 ~f:(fun w ->
+          if Amount.(of_fee (Transaction_snark_work.Checked.fee w) <= budget)
+          then
+            let cb = Staged_ledger_diff.At_most_one.One (coinbase_ft w) in
+            (cb, diff works (Sequence.of_list [ stmt w ]))
+          else
+            let cb = Staged_ledger_diff.At_most_one.One None in
+            (cb, works) )
 
     let init_coinbase_and_fee_transfers ~constraint_constants cw_seq
         ~add_coinbase ~job_count ~slots ~is_coinbase_receiver_new
@@ -1789,7 +1740,7 @@ module T = struct
       in
       let coinbase, rem_cw =
         match t.coinbase with
-        | Staged_ledger_diff.At_most_two.Zero ->
+        | Staged_ledger_diff.At_most_one.Zero ->
             (t.coinbase, t.completed_work_rev)
         | One _ -> (
             match
@@ -1801,19 +1752,6 @@ module T = struct
                 (One None, t.completed_work_rev)
             | Some (ft, rem_cw) ->
                 (ft, rem_cw) )
-        | Two _ -> (
-            match
-              coinbase_work ~constraint_constants t.completed_work_rev
-                ~is_two:true
-                ~is_coinbase_receiver_new:t.is_coinbase_receiver_new
-                ~supercharge_coinbase:t.supercharge_coinbase
-            with
-            | None ->
-                (Two None, t.completed_work_rev)
-                (* Check for work constraint will be done in
-                   [check_constraints_and_update] *)
-            | Some (fts', rem_cw) ->
-                (fts', rem_cw) )
       in
       let rem_cw = cw_unchecked rem_cw in
       let singles =
@@ -1852,12 +1790,10 @@ module T = struct
 
     let coinbase_added t =
       match t.coinbase with
-      | Staged_ledger_diff.At_most_two.Zero ->
+      | Staged_ledger_diff.At_most_one.Zero ->
           0
       | One _ ->
           1
-      | Two _ ->
-          2
 
     let slots_occupied t =
       let fee_for_self =
@@ -1938,18 +1874,12 @@ module T = struct
           { new_t with budget = updated_budget }
         in
         match t.coinbase with
-        | Staged_ledger_diff.At_most_two.Zero ->
+        | Staged_ledger_diff.At_most_one.Zero ->
             t
         | One None ->
-            { t with coinbase = Staged_ledger_diff.At_most_two.Zero }
-        | Two None ->
-            { t with coinbase = One None }
-        | Two (Some (ft, None)) ->
-            { t with coinbase = One (Some ft) }
+            { t with coinbase = Staged_ledger_diff.At_most_one.Zero }
         | One (Some ft) ->
             update_fee_transfers t ft Zero
-        | Two (Some (ft1, Some ft2)) ->
-            update_fee_transfers t ft2 (One (Some ft1))
       in
       match Sequence.next t.commands_rev with
       | None ->
@@ -1981,53 +1911,45 @@ module T = struct
       let r, _ = discard_last_work ~constraint_constants resources in
       more_work r
 
-    let incr_coinbase_part_by ~constraint_constants t count =
+    let incr_coinbase ~constraint_constants t =
       let open Or_error.Let_syntax in
       let incr = function
-        | Staged_ledger_diff.At_most_two.Zero ->
-            Ok (Staged_ledger_diff.At_most_two.One None)
-        | One None ->
-            Ok (Two None)
-        | One (Some ft) ->
-            Ok (Two (Some (ft, None)))
-        | _ ->
-            Or_error.error_string "Coinbase count cannot be more than two"
+        | Staged_ledger_diff.At_most_one.Zero ->
+            Ok (Staged_ledger_diff.At_most_one.One None)
+        | One _ ->
+            Or_error.error_string "Coinbase count cannot be more than one"
       in
-      let by_one res =
-        let res' =
-          match Sequence.next res.discarded.completed_work with
-          (* Add one from the discarded list to [completed_work_rev] and then
-             select a work from [completed_work_rev] except the one already used *)
-          | Some (w, rem_work) ->
-              let%map coinbase = incr res.coinbase in
-              let res' =
-                { res with
-                  completed_work_rev =
-                    Sequence.append (Sequence.singleton w)
-                      res.completed_work_rev
-                ; discarded = { res.discarded with completed_work = rem_work }
-                ; coinbase
-                }
-              in
-              reselect_coinbase_work ~constraint_constants res'
-          | None ->
-              let%bind coinbase = incr res.coinbase in
-              let res = { res with coinbase } in
-              if work_done res then Ok res
-              else
-                Or_error.error_string
-                  "Could not increment coinbase transaction count because of \
-                   insufficient work"
-        in
-        match res' with
-        | Ok res'' ->
-            res''
-        | Error e ->
-            [%log' error t.logger] "Error when increasing coinbase: $error"
-              ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
-            res
+      let res' =
+        match Sequence.next t.discarded.completed_work with
+        (* Add one from the discarded list to [completed_work_rev] and then
+           select a work from [completed_work_rev] except the one already used *)
+        | Some (w, rem_work) ->
+            let%map coinbase = incr t.coinbase in
+            let res' =
+              { t with
+                completed_work_rev =
+                  Sequence.append (Sequence.singleton w) t.completed_work_rev
+              ; discarded = { t.discarded with completed_work = rem_work }
+              ; coinbase
+              }
+            in
+            reselect_coinbase_work ~constraint_constants res'
+        | None ->
+            let%bind coinbase = incr t.coinbase in
+            let res = { t with coinbase } in
+            if work_done res then Ok res
+            else
+              Or_error.error_string
+                "Could not increment coinbase transaction count because of \
+                 insufficient work"
       in
-      match count with `One -> by_one t | `Two -> by_one (by_one t)
+      match res' with
+      | Ok res'' ->
+          res''
+      | Error e ->
+          [%log' error t.logger] "Error when increasing coinbase: $error"
+            ~metadata:[ ("error", Error_json.error_to_yojson e) ] ;
+          t
   end
 
   let rec check_constraints_and_update ~constraint_constants
@@ -2102,22 +2024,11 @@ module T = struct
         , User_command.Valid.t )
         Staged_ledger_diff.Pre_diff_one.t =
       O1trace.sync_thread "create_staged_ledger_pre_diff_with_one" (fun () ->
-          let to_at_most_one = function
-            | Staged_ledger_diff.At_most_two.Zero ->
-                Staged_ledger_diff.At_most_one.Zero
-            | One x ->
-                One x
-            | _ ->
-                [%log error]
-                  "Error creating staged ledger diff: Should have at most one \
-                   coinbase in the second pre_diff" ;
-                Zero
-          in
           (* We have to reverse here because we only know they work in THIS order *)
           { Staged_ledger_diff.Pre_diff_one.commands =
               Sequence.to_list_rev res.commands_rev
           ; completed_works = Sequence.to_list_rev res.completed_work_rev
-          ; coinbase = to_at_most_one res.coinbase
+          ; coinbase = res.coinbase
           ; internal_command_statuses =
               [] (*updated later based on application result*)
           ; padding = None
@@ -2176,10 +2087,8 @@ module T = struct
             partitions.first ~add_coinbase:false logger
             ~is_coinbase_receiver_new ~supercharge_coinbase `First
         in
-        let incr_coinbase_and_compute res count =
-          let new_res =
-            Resources.incr_coinbase_part_by ~constraint_constants res count
-          in
+        let incr_coinbase_and_compute res =
+          let new_res = Resources.incr_coinbase ~constraint_constants res in
           if Resources.space_available new_res then
             (* All slots could not be filled either because of budget
                constraints or not enough work done. Don't create the second
@@ -2216,16 +2125,17 @@ module T = struct
                 (* generate the next prediff with a coinbase at least *)
                 let res2 = second_pre_diff res y ~add_coinbase:true cw_seq_2 in
                 ((res, log1), Some res2)
-            | 1 ->
-                (* There's a slot available in the first partition, fill it with
-                   coinbase and create another pre_diff for the slots in the second
-                   partiton with the remaining user commands and work *)
-                incr_coinbase_and_compute res `One
-            | 2 ->
-                (* There are two slots which cannot be filled using user
-                   commands, so we split the coinbase into two parts and fill those
-                   two spots *)
-                incr_coinbase_and_compute res `Two
+            | 1 | 2 ->
+                (* There are slots available in the first partition which cannot
+                   be filled using user commands. Fill one with the coinbase and
+                   create another pre_diff for the slots in the second partition
+                   with the remaining user commands and work.
+
+                   Where two slots were free the first partition is still one
+                   short after adding the coinbase, and
+                   [incr_coinbase_and_compute] falls back to a diff that does
+                   not reach the partition boundary. *)
+                incr_coinbase_and_compute res
             | _ ->
                 (* Too many slots left in the first partition. Either there
                    wasn't enough work to add transactions or there weren't enough
@@ -2802,18 +2712,12 @@ let%test_module "staged ledger tests" =
            { fee; proofs = proofs ~fee ~prover stmts; prover } )
 
     let coinbase_first_prediff = function
-      | Staged_ledger_diff.At_most_two.Zero ->
+      | Staged_ledger_diff.At_most_one.Zero ->
           (0, [])
       | One None ->
           (1, [])
       | One (Some ft) ->
           (1, [ ft ])
-      | Two None ->
-          (2, [])
-      | Two (Some (ft, None)) ->
-          (2, [ ft ])
-      | Two (Some (ft1, Some ft2)) ->
-          (2, [ ft1; ft2 ])
 
     let coinbase_second_prediff = function
       | Staged_ledger_diff.At_most_one.Zero ->
@@ -3954,9 +3858,8 @@ let%test_module "staged ledger tests" =
                     ~default:Staged_ledger_diff.At_most_one.Zero ~f:(fun d ->
                       d.coinbase ) )
               with
-              | ( Staged_ledger_diff.At_most_two.Zero
-                , Staged_ledger_diff.At_most_one.Zero )
-              | Two None, Zero ->
+              | ( Staged_ledger_diff.At_most_one.Zero
+                , Staged_ledger_diff.At_most_one.Zero ) ->
                   ()
               | One ft_opt, Zero ->
                   Option.value_map ft_opt ~default:() ~f:(fun single ->
@@ -3969,13 +3872,6 @@ let%test_module "staged ledger tests" =
                       let work =
                         List.hd_exn (sorted_work_from_diff2 second_pre_diff_opt)
                       in
-                      assert_same_fee single work.fee )
-              | Two (Some (ft, ft_opt)), Zero ->
-                  let work_done = sorted_work_from_diff1 first_pre_diff in
-                  let work = List.hd_exn work_done in
-                  assert_same_fee ft work.fee ;
-                  Option.value_map ft_opt ~default:() ~f:(fun single ->
-                      let work = List.hd_exn (List.drop work_done 1) in
                       assert_same_fee single work.fee )
               | _ ->
                   failwith @@ "Incorrect coinbase in the diff "

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -846,9 +846,8 @@ module T = struct
         current_state_view
     in
     (*The excess a partition ends with is the one the next partition starts
-      from. Both are zero in practice, since [check_zero_fee_excess] requires
-      each partition's transactions to settle their own fees, but the excess is
-      threaded rather than assumed.*)
+      from. A block that spans the boundary leaves a non-zero excess behind it,
+      to be settled by the coinbase in the partition that follows.*)
     let end_fee_excess pre_stmts ~default =
       Option.value_map (List.last pre_stmts) ~default
         ~f:(fun (p : Pre_statement.t) -> p.target_fee_excess )
@@ -1004,10 +1003,11 @@ module T = struct
       if Fee_excess.is_zero fee_excess then Ok ()
       else Error (Non_zero_fee_excess (slots, txns))
     in
-    let%bind () = check (List.take data (fst partitions.first)) partitions in
-    Option.value_map ~default:(Result.return ())
-      ~f:(fun _ -> check (List.drop data (fst partitions.first)) partitions)
-      partitions.second
+    (*A block settles its own fees: the coinbase that ends it pays out whatever
+      its transaction fees did not spend on provers. That is a property of the
+      block, not of either side of a scan state boundary the block happens to
+      span, so it is checked across the whole of the diff.*)
+    check data partitions
 
   let update_coinbase_stack_and_get_data_impl ~logger ~constraint_constants
       ~global_slot ~first_partition_slots:slots ~no_second_partition
@@ -2741,17 +2741,6 @@ let%test_module "staged ledger tests" =
       |> Sequence.to_list
 
     (* Fee excess at top level ledger proofs should always be zero *)
-    let assert_fee_excess : Ledger_proof.Cached.t option -> unit =
-     fun proof_opt ->
-      let source_fee_excess, target_fee_excess =
-        Option.value_map ~default:(Fee_excess.zero, Fee_excess.zero) proof_opt
-          ~f:(fun proof ->
-            let stmt = Ledger_proof.Cached.statement proof in
-            (stmt.source.fee_excess, stmt.target.fee_excess) )
-      in
-      assert (Fee_excess.is_zero source_fee_excess) ;
-      assert (Fee_excess.is_zero target_fee_excess)
-
     let transaction_capacity =
       Int.pow 2 constraint_constants.transaction_capacity_log_2
 
@@ -2877,8 +2866,8 @@ let%test_module "staged ledger tests" =
                         !sl.scan_state
                     in
                     let target_snarked_ledger =
-                      let stmt = Ledger_proof.Cached.statement proof in
-                      stmt.target.first_pass_ledger
+                      Mina_state.Snarked_ledger_state.snarked_ledger_hash
+                        (Ledger_proof.Cached.statement proof)
                     in
                     [%test_eq: Ledger_hash.t] target_snarked_ledger
                       (Ledger.merkle_root snarked_ledger) ;
@@ -2926,7 +2915,6 @@ let%test_module "staged ledger tests" =
                 ~f:(fun _ -> proof_count + 1)
                 ledger_proof
             in
-            assert_fee_excess ledger_proof ;
             let cmds_applied_this_iter =
               List.length @@ Staged_ledger_diff.commands diff
             in
@@ -3599,7 +3587,7 @@ let%test_module "staged ledger tests" =
               ( state_hashes.state_hash
               , state_hashes.state_body_hash |> Option.value_exn )
             in
-            let%map proof, diff =
+            let%map _proof, diff =
               create_and_apply ~global_slot ~state_and_body_hash
                 ~protocol_state_view:current_state_view ~signature_kind sl
                 cmds_this_iter
@@ -3607,7 +3595,6 @@ let%test_module "staged ledger tests" =
                    (List.take work_list proofs_available_this_iter)
                    provers )
             in
-            assert_fee_excess proof ;
             let cmds_applied_this_iter =
               List.length @@ Staged_ledger_diff.commands diff
             in
@@ -4025,7 +4012,6 @@ let%test_module "staged ledger tests" =
             check_pending_coinbase proof ~supercharge_coinbase ~sl_before
               ~sl_after:!sl state_and_body_hash global_slot pc_update
               ~is_new_stack ;
-            assert_fee_excess proof ;
             let cmds_applied_this_iter =
               List.length @@ Staged_ledger_diff.commands diff
             in
@@ -4827,7 +4813,7 @@ let%test_module "staged ledger tests" =
                     Staged_ledger_diff.Pre_diff_with_at_most_two_coinbase.t =
                   { completed_works = []
                   ; commands = cmds
-                  ; coinbase = Zero
+                  ; coinbase = One None
                   ; internal_command_statuses = [ Applied ]
                   }
                 in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -485,21 +485,11 @@ module T = struct
       Ledger.apply_transaction_first_pass ~signature_kind ~constraint_constants
     in
     let apply_second_pass = Ledger.apply_transaction_second_pass in
-    let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
-        sparse_ledger txn =
-      let open Or_error.Let_syntax in
-      let%map _ledger, partial_txn =
-        Mina_ledger.Sparse_ledger.apply_transaction_first_pass
-          ~constraint_constants ~global_slot ~txn_state_view sparse_ledger txn
-      in
-      partial_txn
-    in
     let%bind (`First_pass_ledger_hash first_pass_ledger_target) =
       Scan_state.get_staged_ledger_async
         ~async_batch_size:transaction_application_scheduler_batch_size
         ~ledger:snarked_ledger ~get_protocol_state:get_state ~apply_first_pass
-        ~apply_second_pass ~apply_first_pass_sparse_ledger ~signature_kind
-        scan_state
+        ~apply_second_pass ~signature_kind scan_state
     in
     let staged_ledger_hash = Ledger.merkle_root snarked_ledger in
     let%bind () =
@@ -2873,15 +2863,6 @@ let%test_module "staged ledger tests" =
                   ~constraint_constants
               in
               let apply_second_pass = Ledger.apply_transaction_second_pass in
-              let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
-                  sparse_ledger txn =
-                let%map.Or_error _ledger, partial_txn =
-                  Mina_ledger.Sparse_ledger.apply_transaction_first_pass
-                    ~constraint_constants ~global_slot ~txn_state_view
-                    sparse_ledger txn
-                in
-                partial_txn
-              in
               let get_state state_hash =
                 Ok (Hashtbl.find_exn state_tbl state_hash)
               in
@@ -2892,8 +2873,7 @@ let%test_module "staged ledger tests" =
                     let%map res =
                       Sl.Scan_state.get_snarked_ledger_async
                         ~ledger:snarked_ledger ~get_protocol_state:get_state
-                        ~apply_first_pass ~apply_second_pass
-                        ~apply_first_pass_sparse_ledger ~signature_kind
+                        ~apply_first_pass ~apply_second_pass ~signature_kind
                         !sl.scan_state
                     in
                     let target_snarked_ledger =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1796,18 +1796,13 @@ module T = struct
           1
 
     let slots_occupied t =
-      let fee_for_self =
-        match t.budget with
-        | Error _ ->
-            0
-        | Ok b ->
-            if Fee.(b > Fee.zero) then 1 else 0
-      in
+      (* The receiver's own share of the transaction fees is paid by the
+         coinbase, so it costs no slot of its own. *)
       let other_provers =
         Map.filter_keys t.fee_transfers
           ~f:(Fn.compose not (Public_key.Compressed.equal t.receiver_pk))
       in
-      let total_fee_transfer_pks = Map.length other_provers + fee_for_self in
+      let total_fee_transfer_pks = Map.length other_provers in
       Sequence.length t.commands_rev
       + ((total_fee_transfer_pks + 1) / 2)
       + coinbase_added t

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2031,7 +2031,6 @@ module T = struct
           ; coinbase = res.coinbase
           ; internal_command_statuses =
               [] (*updated later based on application result*)
-          ; padding = None
           } )
     in
     let pre_diff_with_two (res : Resources.t) :
@@ -2044,7 +2043,6 @@ module T = struct
       ; coinbase = res.coinbase
       ; internal_command_statuses =
           [] (*updated later based on application result*)
-      ; padding = None
       }
     in
     let end_log ((res : Resources.t), (log : Diff_creation_log.t)) =
@@ -3407,7 +3405,6 @@ let%test_module "staged ledger tests" =
                  ; commands = List.take txns slots
                  ; coinbase = Zero
                  ; internal_command_statuses = []
-                 ; padding = None
                  }
                , None )
         | Some (_, _) ->
@@ -3417,7 +3414,6 @@ let%test_module "staged ledger tests" =
                 ; commands = List.take txns slots
                 ; coinbase = Zero
                 ; internal_command_statuses = []
-                ; padding = None
                 }
               , Some
                   { completed_works =
@@ -3426,7 +3422,6 @@ let%test_module "staged ledger tests" =
                   ; commands = txns_in_second_diff
                   ; coinbase = Zero
                   ; internal_command_statuses = []
-                  ; padding = None
                   } )
       in
       let empty_diff = Staged_ledger_diff.empty_diff in
@@ -4859,7 +4854,6 @@ let%test_module "staged ledger tests" =
                   ; commands = cmds
                   ; coinbase = Zero
                   ; internal_command_statuses = [ Applied ]
-                  ; padding = None
                   }
                 in
                 { diff = (pre_diff, None) }

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1082,7 +1082,7 @@ module T = struct
       let txns_for_partition2 = List.drop transactions slots in
       [%log internal] "Update_ledger_and_get_statements"
         ~metadata:[ ("partition", `String "both") ] ;
-      let%map
+      let%bind
           ( data
           , updated_stack1
           , updated_stack2
@@ -1095,28 +1095,37 @@ module T = struct
       in
       [%log internal] "Update_ledger_and_get_statements_done" ;
       let second_has_data = List.length txns_for_partition2 > 0 in
-      let pending_coinbase_action, stack_update =
+      let%map pending_coinbase_action, stack_update =
         match (coinbase_in_first_partition, second_has_data) with
         | true, true ->
-            ( Pending_coinbase.Update.Action.Update_two_coinbase_in_first
-            , `Update_two (updated_stack1, updated_stack2) )
-        (* updated_stack2 does not have coinbase and but has the state from the
-           previous stack *)
+            (* The coinbase is a block's last transaction, so a diff that puts
+               one in the first partition while the second still has
+               transactions of its own is malformed. There is no longer an
+               action that describes it. *)
+            Deferred.Result.fail
+              (Staged_ledger_error.Unexpected
+                 (Error.of_string
+                    "Coinbase in the first partition, but the second partition \
+                     has transactions" ) )
         | true, false ->
             (* updated_stack1 has some new coinbase but parition 2 has no
                data and so we have only one stack to update *)
-            (Update_one, `Update_one updated_stack1)
+            Deferred.Result.return
+              ( Pending_coinbase.Update.Action.Update_one
+              , `Update_one updated_stack1 )
         | false, true ->
             (* updated_stack1 just has the new state. [updated stack2] might
                have coinbase, definitely has some data and therefore will have a
                non-dummy state. *)
-            ( Update_two_coinbase_in_second
-            , `Update_two (updated_stack1, updated_stack2) )
+            Deferred.Result.return
+              ( Pending_coinbase.Update.Action.Update_two_coinbase_in_second
+              , `Update_two (updated_stack1, updated_stack2) )
         | false, false ->
             (* a diff consists of only non-coinbase transactions. This is
                currently not possible because a diff will have a coinbase at the
                very least, so don't update anything? *)
-            (Update_none, `Update_none)
+            Deferred.Result.return
+              (Pending_coinbase.Update.Action.Update_none, `Update_none)
       in
       [%log internal] "Update_coinbase_stack_done"
         ~metadata:

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2120,6 +2120,7 @@ module T = struct
           ; coinbase = to_at_most_one res.coinbase
           ; internal_command_statuses =
               [] (*updated later based on application result*)
+          ; padding = None
           } )
     in
     let pre_diff_with_two (res : Resources.t) :
@@ -2132,6 +2133,7 @@ module T = struct
       ; coinbase = res.coinbase
       ; internal_command_statuses =
           [] (*updated later based on application result*)
+      ; padding = None
       }
     in
     let end_log ((res : Resources.t), (log : Diff_creation_log.t)) =
@@ -3501,6 +3503,7 @@ let%test_module "staged ledger tests" =
                  ; commands = List.take txns slots
                  ; coinbase = Zero
                  ; internal_command_statuses = []
+                 ; padding = None
                  }
                , None )
         | Some (_, _) ->
@@ -3510,6 +3513,7 @@ let%test_module "staged ledger tests" =
                 ; commands = List.take txns slots
                 ; coinbase = Zero
                 ; internal_command_statuses = []
+                ; padding = None
                 }
               , Some
                   { completed_works =
@@ -3518,6 +3522,7 @@ let%test_module "staged ledger tests" =
                   ; commands = txns_in_second_diff
                   ; coinbase = Zero
                   ; internal_command_statuses = []
+                  ; padding = None
                   } )
       in
       let empty_diff = Staged_ledger_diff.empty_diff in
@@ -4958,6 +4963,7 @@ let%test_module "staged ledger tests" =
                   ; commands = cmds
                   ; coinbase = Zero
                   ; internal_command_statuses = [ Applied ]
+                  ; padding = None
                   }
                 in
                 { diff = (pre_diff, None) }

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1236,17 +1236,10 @@ module T = struct
         |> to_staged_ledger_or_error
 
   let coinbase_for_blockchain_snark = function
-    | [] ->
-        Ok Currency.Amount.zero
-    | [ amount ] ->
-        Ok amount
-    | [ amount1; _ ] ->
-        Ok amount1
-    | _ ->
-        Error
-          (Staged_ledger_error.Pre_diff
-             (Pre_diff_info.Error.Coinbase_error "More than two coinbase parts")
-          )
+    | None ->
+        Currency.Amount.zero
+    | Some amount ->
+        amount
 
   let apply_diff ?(skip_verification = false) ~logger ~constraint_constants
       ~global_slot ~current_state_view ~state_and_body_hash ~log_prefix
@@ -1262,7 +1255,7 @@ module T = struct
     in
     let new_mask = Ledger.Mask.create ~depth:(Ledger.depth t.ledger) () in
     let new_ledger = Ledger.register_mask t.ledger new_mask in
-    let transactions, works, commands_count, coinbases = pre_diff_info in
+    let transactions, works, commands_count, coinbase = pre_diff_info in
     let accounts_accessed =
       List.fold_left ~init:Account_id.Set.empty transactions ~f:(fun set txn ->
           Set.union set
@@ -1295,7 +1288,7 @@ module T = struct
         [ ("transactions", `Int (List.length transactions))
         ; ("works", `Int (List.length works))
         ; ("commands_count", `Int commands_count)
-        ; ("coinbases", `Int (List.length coinbases))
+        ; ("coinbases", `Int (if Option.is_some coinbase then 1 else 0))
         ; ("spots_available", `Int spots_available)
         ; ("proofs_waiting", `Int proofs_waiting)
         ; ("max_throughput", `Int max_throughput)
@@ -1383,9 +1376,7 @@ module T = struct
           |> Deferred.return )
     in
     let%bind () = yield_result () in
-    let%bind coinbase_amount =
-      Deferred.return (coinbase_for_blockchain_snark coinbases)
-    in
+    let coinbase_amount = coinbase_for_blockchain_snark coinbase in
     let%bind latest_pending_coinbase_stack =
       Pending_coinbase.latest_stack ~is_new_stack:false
         updated_pending_coinbase_collection'
@@ -1410,7 +1401,7 @@ module T = struct
     [%log debug]
       ~metadata:
         [ ("user_command_count", `Int commands_count)
-        ; ("coinbase_count", `Int (List.length coinbases))
+        ; ("coinbase_count", `Int (if Option.is_some coinbase then 1 else 0))
         ; ("spots_available", `Int spots_available)
         ; ("proof_bundles_waiting", `Int proofs_waiting)
         ; ("work_count", `Int (List.length works))

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -81,13 +81,6 @@ module Scan_state : sig
          (   Ledger.t
           -> Ledger.Transaction_partially_applied.t
           -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
-    -> apply_first_pass_sparse_ledger:
-         (   global_slot:Mina_numbers.Global_slot_since_genesis.t
-          -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
-          -> Mina_ledger.Sparse_ledger.t
-          -> Mina_transaction.Transaction.t
-          -> Mina_ledger.Sparse_ledger.T.Transaction_partially_applied.t
-             Or_error.t )
     -> signature_kind:Mina_signature_kind.t
     -> t
     -> unit Or_error.t
@@ -113,13 +106,6 @@ module Scan_state : sig
          (   Ledger.t
           -> Ledger.Transaction_partially_applied.t
           -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
-    -> apply_first_pass_sparse_ledger:
-         (   global_slot:Mina_numbers.Global_slot_since_genesis.t
-          -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
-          -> Mina_ledger.Sparse_ledger.t
-          -> Mina_transaction.Transaction.t
-          -> Mina_ledger.Sparse_ledger.T.Transaction_partially_applied.t
-             Or_error.t )
     -> signature_kind:Mina_signature_kind.t
     -> t
     -> unit Deferred.Or_error.t

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -165,7 +165,7 @@ module Diff_creation_diagnostics : sig
   [@@deriving to_yojson]
 
   val coinbase_parts :
-    Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t -> int
+    Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_one.t -> int
 end
 
 module Staged_ledger_error : sig

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -52,7 +52,6 @@ module Pre_diff_two = struct
         ; commands : 'b list
         ; coinbase : Ft.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
-        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -63,7 +62,6 @@ module Pre_diff_two = struct
     ; commands : 'b list
     ; coinbase : Ft.t At_most_one.t
     ; internal_command_statuses : Transaction_status.t list
-    ; padding : Signature_lib.Public_key.Compressed.t option
     }
   [@@deriving equal, compare, sexp, yojson]
 
@@ -72,7 +70,6 @@ module Pre_diff_two = struct
     ; commands = List.map t.commands ~f:f2
     ; coinbase = t.coinbase
     ; internal_command_statuses = t.internal_command_statuses
-    ; padding = t.padding
     }
 end
 
@@ -87,7 +84,6 @@ module Pre_diff_one = struct
         ; commands : 'b list
         ; coinbase : Ft.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
-        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -98,7 +94,6 @@ module Pre_diff_one = struct
     ; commands : 'b list
     ; coinbase : Ft.t At_most_one.t
     ; internal_command_statuses : Transaction_status.t list
-    ; padding : Signature_lib.Public_key.Compressed.t option
     }
   [@@deriving equal, compare, sexp, yojson]
 
@@ -107,7 +102,6 @@ module Pre_diff_one = struct
     ; commands = List.map t.commands ~f:f2
     ; coinbase = t.coinbase
     ; internal_command_statuses = t.internal_command_statuses
-    ; padding = t.padding
     }
 end
 
@@ -260,7 +254,6 @@ module Stable = struct
             ; commands = []
             ; coinbase = At_most_one.Zero
             ; internal_command_statuses = []
-            ; padding = None
             }
           , None )
       }
@@ -306,7 +299,6 @@ module With_valid_signatures_and_proofs = struct
           ; commands = []
           ; coinbase = At_most_one.Zero
           ; internal_command_statuses = []
-          ; padding = None
           }
         , None )
     }
@@ -378,7 +370,6 @@ let validate_commands (t : t)
         ; commands = commands1
         ; coinbase = d1.coinbase
         ; internal_command_statuses = d1.internal_command_statuses
-        ; padding = d1.padding
         }
       in
       let p2 =
@@ -388,7 +379,6 @@ let validate_commands (t : t)
               ; commands = commands2
               ; coinbase = d2.coinbase
               ; internal_command_statuses = d2.internal_command_statuses
-              ; padding = d2.padding
               } )
       in
       ({ diff = (p1, p2) } : With_valid_signatures.t) )
@@ -401,7 +391,6 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
     ; commands = d1.commands
     ; coinbase = d1.coinbase
     ; internal_command_statuses = d1.internal_command_statuses
-    ; padding = d1.padding
     }
   in
   let p2 =
@@ -411,7 +400,6 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
         ; commands = d2.commands
         ; coinbase = d2.coinbase
         ; internal_command_statuses = d2.internal_command_statuses
-        ; padding = d2.padding
         } )
   in
   { diff = (p1, p2) }
@@ -427,7 +415,6 @@ let forget_pre_diff_with_at_most_two
         pre_diff.commands
   ; coinbase = pre_diff.coinbase
   ; internal_command_statuses = pre_diff.internal_command_statuses
-  ; padding = pre_diff.padding
   }
 
 let forget_pre_diff_with_at_most_one
@@ -440,7 +427,6 @@ let forget_pre_diff_with_at_most_one
         pre_diff.commands
   ; coinbase = pre_diff.coinbase
   ; internal_command_statuses = pre_diff.internal_command_statuses
-  ; padding = pre_diff.padding
   }
 
 let forget (t : With_valid_signatures_and_proofs.t) =
@@ -486,7 +472,6 @@ let empty_diff : t =
         ; commands = []
         ; coinbase = At_most_one.Zero
         ; internal_command_statuses = []
-        ; padding = None
         }
       , None )
   }
@@ -497,7 +482,6 @@ let is_empty = function
           ; commands = []
           ; coinbase = At_most_one.Zero
           ; internal_command_statuses = []
-          ; padding = None
           }
         , None )
     } ->

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -1,39 +1,6 @@
 open Core
 open Mina_base
 
-module At_most_two = struct
-  [%%versioned
-  module Stable = struct
-    [@@@no_toplevel_latest_type]
-
-    module V1 = struct
-      type 'a t = Zero | One of 'a option | Two of ('a * 'a option) option
-      [@@deriving equal, compare, sexp, yojson]
-    end
-  end]
-
-  type 'a t = 'a Stable.Latest.t =
-    | Zero
-    | One of 'a option
-    | Two of ('a * 'a option) option
-  [@@deriving equal, compare, sexp, yojson]
-
-  let increase t ws =
-    match (t, ws) with
-    | Zero, [] ->
-        Ok (One None)
-    | Zero, [ a ] ->
-        Ok (One (Some a))
-    | One _, [] ->
-        Ok (Two None)
-    | One _, [ a ] ->
-        Ok (Two (Some (a, None)))
-    | One _, [ a; a' ] ->
-        Ok (Two (Some (a', Some a)))
-    | _ ->
-        Or_error.error_string "Error incrementing coinbase parts"
-end
-
 module At_most_one = struct
   [%%versioned
   module Stable = struct
@@ -83,7 +50,7 @@ module Pre_diff_two = struct
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
-        ; coinbase : Ft.Stable.V1.t At_most_two.Stable.V1.t
+        ; coinbase : Ft.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
         ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
@@ -94,7 +61,7 @@ module Pre_diff_two = struct
   type ('a, 'b) t = ('a, 'b) Stable.Latest.t =
     { completed_works : 'a list
     ; commands : 'b list
-    ; coinbase : Ft.t At_most_two.t
+    ; coinbase : Ft.t At_most_one.t
     ; internal_command_statuses : Transaction_status.t list
     ; padding : Signature_lib.Public_key.Compressed.t option
     }
@@ -232,7 +199,7 @@ module Diff = struct
       , Option.value_map second_pre_diff_opt ~default:At_most_one.Zero
           ~f:(fun d -> d.Pre_diff_one.coinbase ) )
     with
-    | At_most_two.Zero, At_most_one.Zero ->
+    | At_most_one.Zero, At_most_one.Zero ->
         Some Currency.Amount.zero
     | _ ->
         coinbase_amount
@@ -291,7 +258,7 @@ module Stable = struct
       { diff =
           ( { completed_works = []
             ; commands = []
-            ; coinbase = At_most_two.Zero
+            ; coinbase = At_most_one.Zero
             ; internal_command_statuses = []
             ; padding = None
             }
@@ -337,7 +304,7 @@ module With_valid_signatures_and_proofs = struct
     { diff =
         ( { completed_works = []
           ; commands = []
-          ; coinbase = At_most_two.Zero
+          ; coinbase = At_most_one.Zero
           ; internal_command_statuses = []
           ; padding = None
           }
@@ -380,7 +347,7 @@ module With_valid_signatures = struct
       , Option.value_map second_pre_diff_opt ~default:At_most_one.Zero
           ~f:(fun d -> d.coinbase ) )
     with
-    | At_most_two.Zero, At_most_one.Zero ->
+    | At_most_one.Zero, At_most_one.Zero ->
         Some Currency.Amount.zero
     | _ ->
         coinbase_amount
@@ -517,7 +484,7 @@ let empty_diff : t =
   { diff =
       ( { completed_works = []
         ; commands = []
-        ; coinbase = At_most_two.Zero
+        ; coinbase = At_most_one.Zero
         ; internal_command_statuses = []
         ; padding = None
         }
@@ -528,7 +495,7 @@ let is_empty = function
   | { diff =
         ( { completed_works = []
           ; commands = []
-          ; coinbase = At_most_two.Zero
+          ; coinbase = At_most_one.Zero
           ; internal_command_statuses = []
           ; padding = None
           }

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -79,12 +79,13 @@ module Pre_diff_two = struct
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
-    module V2 = struct
+    module V3 = struct
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
         ; coinbase : Ft.Stable.V1.t At_most_two.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
+        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -95,6 +96,7 @@ module Pre_diff_two = struct
     ; commands : 'b list
     ; coinbase : Ft.t At_most_two.t
     ; internal_command_statuses : Transaction_status.t list
+    ; padding : Signature_lib.Public_key.Compressed.t option
     }
   [@@deriving equal, compare, sexp, yojson]
 
@@ -103,6 +105,7 @@ module Pre_diff_two = struct
     ; commands = List.map t.commands ~f:f2
     ; coinbase = t.coinbase
     ; internal_command_statuses = t.internal_command_statuses
+    ; padding = t.padding
     }
 end
 
@@ -111,12 +114,13 @@ module Pre_diff_one = struct
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
-    module V2 = struct
+    module V3 = struct
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
         ; coinbase : Ft.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
+        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -127,6 +131,7 @@ module Pre_diff_one = struct
     ; commands : 'b list
     ; coinbase : Ft.t At_most_one.t
     ; internal_command_statuses : Transaction_status.t list
+    ; padding : Signature_lib.Public_key.Compressed.t option
     }
   [@@deriving equal, compare, sexp, yojson]
 
@@ -135,6 +140,7 @@ module Pre_diff_one = struct
     ; commands = List.map t.commands ~f:f2
     ; coinbase = t.coinbase
     ; internal_command_statuses = t.internal_command_statuses
+    ; padding = t.padding
     }
 end
 
@@ -147,7 +153,7 @@ module Pre_diff_with_at_most_two_coinbase = struct
       type t =
         ( Transaction_snark_work.Stable.V4.t
         , User_command.Stable.V3.t With_status.Stable.V2.t )
-        Pre_diff_two.Stable.V2.t
+        Pre_diff_two.Stable.V3.t
       [@@deriving equal, sexp, yojson]
 
       let to_latest = Fn.id
@@ -181,7 +187,7 @@ module Pre_diff_with_at_most_one_coinbase = struct
       type t =
         ( Transaction_snark_work.Stable.V4.t
         , User_command.Stable.V3.t With_status.Stable.V2.t )
-        Pre_diff_one.Stable.V2.t
+        Pre_diff_one.Stable.V3.t
       [@@deriving equal, sexp, yojson]
 
       let to_latest = Fn.id
@@ -287,6 +293,7 @@ module Stable = struct
             ; commands = []
             ; coinbase = At_most_two.Zero
             ; internal_command_statuses = []
+            ; padding = None
             }
           , None )
       }
@@ -332,6 +339,7 @@ module With_valid_signatures_and_proofs = struct
           ; commands = []
           ; coinbase = At_most_two.Zero
           ; internal_command_statuses = []
+          ; padding = None
           }
         , None )
     }
@@ -403,6 +411,7 @@ let validate_commands (t : t)
         ; commands = commands1
         ; coinbase = d1.coinbase
         ; internal_command_statuses = d1.internal_command_statuses
+        ; padding = d1.padding
         }
       in
       let p2 =
@@ -412,6 +421,7 @@ let validate_commands (t : t)
               ; commands = commands2
               ; coinbase = d2.coinbase
               ; internal_command_statuses = d2.internal_command_statuses
+              ; padding = d2.padding
               } )
       in
       ({ diff = (p1, p2) } : With_valid_signatures.t) )
@@ -424,6 +434,7 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
     ; commands = d1.commands
     ; coinbase = d1.coinbase
     ; internal_command_statuses = d1.internal_command_statuses
+    ; padding = d1.padding
     }
   in
   let p2 =
@@ -433,6 +444,7 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
         ; commands = d2.commands
         ; coinbase = d2.coinbase
         ; internal_command_statuses = d2.internal_command_statuses
+        ; padding = d2.padding
         } )
   in
   { diff = (p1, p2) }
@@ -448,6 +460,7 @@ let forget_pre_diff_with_at_most_two
         pre_diff.commands
   ; coinbase = pre_diff.coinbase
   ; internal_command_statuses = pre_diff.internal_command_statuses
+  ; padding = pre_diff.padding
   }
 
 let forget_pre_diff_with_at_most_one
@@ -460,6 +473,7 @@ let forget_pre_diff_with_at_most_one
         pre_diff.commands
   ; coinbase = pre_diff.coinbase
   ; internal_command_statuses = pre_diff.internal_command_statuses
+  ; padding = pre_diff.padding
   }
 
 let forget (t : With_valid_signatures_and_proofs.t) =
@@ -505,6 +519,7 @@ let empty_diff : t =
         ; commands = []
         ; coinbase = At_most_two.Zero
         ; internal_command_statuses = []
+        ; padding = None
         }
       , None )
   }
@@ -515,6 +530,7 @@ let is_empty = function
           ; commands = []
           ; coinbase = At_most_two.Zero
           ; internal_command_statuses = []
+          ; padding = None
           }
         , None )
     } ->

--- a/src/lib/staged_ledger_diff/diff.mli
+++ b/src/lib/staged_ledger_diff/diff.mli
@@ -25,7 +25,6 @@ module Pre_diff_two : sig
         ; commands : 'b list
         ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
-        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -43,7 +42,6 @@ module Pre_diff_one : sig
         ; commands : 'b list
         ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
-        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end

--- a/src/lib/staged_ledger_diff/diff.mli
+++ b/src/lib/staged_ledger_diff/diff.mli
@@ -34,12 +34,13 @@ end
 module Pre_diff_two : sig
   [%%versioned:
   module Stable : sig
-    module V2 : sig
+    module V3 : sig
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
         ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_two.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
+        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -51,12 +52,13 @@ end
 module Pre_diff_one : sig
   [%%versioned:
   module Stable : sig
-    module V2 : sig
+    module V3 : sig
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
         ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
+        ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }
       [@@deriving equal, compare, sexp, yojson]
     end
@@ -74,7 +76,7 @@ module Pre_diff_with_at_most_two_coinbase : sig
       type t =
         ( Transaction_snark_work.Stable.V4.t
         , User_command.Stable.V3.t With_status.Stable.V2.t )
-        Pre_diff_two.Stable.V2.t
+        Pre_diff_two.Stable.V3.t
       [@@deriving equal, sexp, yojson]
 
       val to_latest : t -> t
@@ -93,7 +95,7 @@ module Pre_diff_with_at_most_one_coinbase : sig
       type t =
         ( Transaction_snark_work.Stable.V4.t
         , User_command.Stable.V3.t With_status.Stable.V2.t )
-        Pre_diff_one.Stable.V2.t
+        Pre_diff_one.Stable.V3.t
       [@@deriving equal, sexp, yojson]
 
       val to_latest : t -> t

--- a/src/lib/staged_ledger_diff/diff.mli
+++ b/src/lib/staged_ledger_diff/diff.mli
@@ -1,21 +1,6 @@
 open Core
 open Mina_base
 
-module At_most_two : sig
-  type 'a t = Zero | One of 'a option | Two of ('a * 'a option) option
-  [@@deriving equal, compare, sexp, yojson]
-
-  module Stable : sig
-    module V1 : sig
-      type 'a t = Zero | One of 'a option | Two of ('a * 'a option) option
-      [@@deriving equal, compare, sexp, yojson, bin_io, version]
-    end
-  end
-  with type 'a V1.t = 'a t
-
-  val increase : 'a t -> 'a list -> 'a t Or_error.t
-end
-
 module At_most_one : sig
   type 'a t = Zero | One of 'a option
   [@@deriving equal, compare, sexp, yojson]
@@ -38,7 +23,7 @@ module Pre_diff_two : sig
       type ('a, 'b) t =
         { completed_works : 'a list
         ; commands : 'b list
-        ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_two.Stable.V1.t
+        ; coinbase : Coinbase.Fee_transfer.Stable.V1.t At_most_one.Stable.V1.t
         ; internal_command_statuses : Transaction_status.Stable.V2.t list
         ; padding : Signature_lib.Public_key.Compressed.Stable.V1.t option
         }

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -4,11 +4,11 @@ open Mina_base
 module Poly = struct
   [%%versioned
   module Stable = struct
-    module V2 = struct
-      type 'command t = 'command Mina_wire_types.Mina_transaction.Poly.V2.t =
+    module V3 = struct
+      type 'command t = 'command Mina_wire_types.Mina_transaction.Poly.V3.t =
         | Command of 'command
         | Fee_transfer of Fee_transfer.Stable.V2.t
-        | Coinbase of Coinbase.Stable.V1.t
+        | Coinbase of Coinbase.Stable.V2.t
       [@@deriving sexp, compare, equal, hash, yojson]
 
       let to_latest = Fn.id
@@ -33,8 +33,8 @@ end
 module Stable = struct
   [@@@no_toplevel_latest_type]
 
-  module V3 = struct
-    type t = User_command.Stable.V3.t Poly.Stable.V2.t
+  module V4 = struct
+    type t = User_command.Stable.V3.t Poly.Stable.V3.t
     [@@deriving sexp, compare, equal, hash, yojson]
 
     let to_latest = Fn.id

--- a/src/lib/transaction/transaction_union.ml
+++ b/src/lib/transaction/transaction_union.ml
@@ -6,17 +6,26 @@ open Currency
 module Tag = Transaction_union_tag
 module Payload = Transaction_union_payload
 
-type ('payload, 'pk, 'signature) t_ =
-  { payload : 'payload; signer : 'pk; signature : 'signature }
+(** [fee_remainder] is the part of the coinbase's credited amount that comes
+    from the block's unsettled fee excess rather than from minting. It is not
+    part of the payload, and so not covered by the signature: it is pinned
+    instead by the fee excess registers of the statement, which a coinbase moves
+    by exactly its negation. *)
+type ('payload, 'pk, 'signature, 'fee) t_ =
+  { payload : 'payload
+  ; signer : 'pk
+  ; signature : 'signature
+  ; fee_remainder : 'fee
+  }
 [@@deriving equal, sexp, hash, hlist]
 
-type t = (Payload.t, Public_key.t, Signature.t) t_
+type t = (Payload.t, Public_key.t, Signature.t, Fee.t) t_
 
-type var = (Payload.var, Public_key.var, Signature.var) t_
+type var = (Payload.var, Public_key.var, Signature.var, Fee.var) t_
 
 let typ : (var, t) Typ.t =
   Typ.of_hlistable
-    [ Payload.typ; Public_key.typ; Schnorr.Chunked.Signature.typ ]
+    [ Payload.typ; Public_key.typ; Schnorr.Chunked.Signature.typ; Fee.typ ]
     ~var_to_hlist:t__to_hlist ~var_of_hlist:t__of_hlist
     ~value_to_hlist:t__to_hlist ~value_of_hlist:t__of_hlist
 
@@ -37,8 +46,9 @@ let of_transaction : Signed_command.t Transaction.Poly.t -> t = function
       { payload = Transaction_union_payload.of_user_command_payload payload
       ; signer
       ; signature
+      ; fee_remainder = Fee.zero
       }
-  | Coinbase { receiver; fee_transfer; amount } ->
+  | Coinbase { receiver; fee_transfer; amount; fee_remainder } ->
       let { Coinbase.Fee_transfer.receiver_pk = other_pk; fee = other_amount } =
         Option.value
           ~default:
@@ -58,12 +68,16 @@ let of_transaction : Signed_command.t Transaction.Poly.t -> t = function
               { source_pk = other_pk
               ; receiver_pk = receiver
               ; token_id = Token_id.default
-              ; amount
+              ; (* The circuit works from the total credited to the receiver;
+                   [fee_remainder] says how much of it came from the excess
+                   rather than from minting. *)
+                amount = Option.value_exn (Amount.add_fee amount fee_remainder)
               ; tag = Tag.Coinbase
               }
           }
       ; signer = Public_key.decompress_exn other_pk
       ; signature = Signature.dummy
+      ; fee_remainder
       }
   | Fee_transfer tr -> (
       let two { Fee_transfer.receiver_pk = pk1; fee = fee1; fee_token }
@@ -88,6 +102,7 @@ let of_transaction : Signed_command.t Transaction.Poly.t -> t = function
             }
         ; signer = Public_key.decompress_exn pk2
         ; signature = Signature.dummy
+        ; fee_remainder = Fee.zero
         }
       in
       match Fee_transfer.to_singles tr with
@@ -97,7 +112,9 @@ let of_transaction : Signed_command.t Transaction.Poly.t -> t = function
       | `Two (t1, t2) ->
           two t1 t2 )
 
-let fee_excess (t : t) = Transaction_union_payload.fee_excess t.payload
+let fee_excess (t : t) =
+  Transaction_union_payload.fee_excess ~fee_remainder:t.fee_remainder t.payload
 
 let expected_supply_increase (t : t) =
-  Transaction_union_payload.expected_supply_increase t.payload
+  Transaction_union_payload.expected_supply_increase
+    ~fee_remainder:t.fee_remainder t.payload

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2069,9 +2069,12 @@ module Make (L : Ledger_intf.S) :
   *)
   let apply_coinbase ~constraint_constants ~txn_global_slot t
       (* TODO: Better system needed for making atomic changes. Could use a monad. *)
-        ({ receiver; fee_transfer; amount = coinbase_amount } as cb : Coinbase.t)
-      =
+        ({ receiver; fee_transfer; amount = _; fee_remainder = _ } as cb :
+          Coinbase.t ) =
     let open Or_error.Let_syntax in
+    (* Everything the coinbase credits: the minted amount plus the fee excess it
+       discharges to the same receiver. *)
+    let%bind coinbase_amount = Coinbase.total_credited cb in
     let%bind
         ( receiver_reward
         , new_accounts1

--- a/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
+++ b/src/lib/transaction_logic/test/transaction_logic/transaction_logic.ml
@@ -133,7 +133,9 @@ let coinbase_order_of_created_accounts_is_correct ~with_fee_transfer () =
     else None
   in
   let coinbase_txn =
-    Or_error.ok_exn @@ Coinbase.create ~amount ~receiver ~fee_transfer
+    Or_error.ok_exn
+    @@ Coinbase.create ~amount ~receiver ~fee_transfer
+         ~fee_remainder:Currency.Fee.zero
   in
   let accounts =
     []

--- a/src/lib/transaction_logic/transaction_applied.ml
+++ b/src/lib/transaction_logic/transaction_applied.ml
@@ -150,9 +150,9 @@ end
 module Coinbase_applied = struct
   [%%versioned
   module Stable = struct
-    module V2 = struct
+    module V3 = struct
       type t =
-        { coinbase : Coinbase.Stable.V1.t With_status.Stable.V2.t
+        { coinbase : Coinbase.Stable.V2.t With_status.Stable.V2.t
         ; new_accounts : Account_id.Stable.V2.t list
         ; burned_tokens : Currency.Amount.Stable.V1.t
         }
@@ -168,7 +168,7 @@ module Varying : sig
   module Stable : sig
     [@@@no_toplevel_latest_type]
 
-    module V3 : sig
+    module V4 : sig
       type t [@@deriving sexp, to_yojson]
     end
   end]
@@ -190,11 +190,11 @@ end = struct
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
-    module V3 = struct
+    module V4 = struct
       type t =
         | Command of Command_applied.Stable.V3.t
         | Fee_transfer of Fee_transfer_applied.Stable.V2.t
-        | Coinbase of Coinbase_applied.Stable.V2.t
+        | Coinbase of Coinbase_applied.Stable.V3.t
       [@@deriving sexp, to_yojson]
 
       let to_latest = Fn.id
@@ -230,9 +230,9 @@ end
 module Stable = struct
   [@@@no_toplevel_latest_type]
 
-  module V3 = struct
+  module V4 = struct
     type t =
-      { previous_hash : Ledger_hash.Stable.V1.t; varying : Varying.Stable.V3.t }
+      { previous_hash : Ledger_hash.Stable.V1.t; varying : Varying.Stable.V4.t }
     [@@deriving sexp, to_yojson]
 
     let to_latest = Fn.id

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -130,6 +130,7 @@ let%test_module "Transaction union tests" =
             (Some
                (Coinbase.Fee_transfer.create ~receiver_pk:other
                   ~fee:U.constraint_constants.account_creation_fee ) )
+          ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       let transaction = Mina_transaction.Transaction.Coinbase cb in
@@ -390,6 +391,7 @@ let%test_module "Transaction union tests" =
                         ~amount:(Currency.Amount.of_nanomina_int_exn reward)
                         ~receiver:receiver.account.public_key
                         ~fee_transfer:(List.hd fts)
+                        ~fee_remainder:Currency.Fee.zero
                       |> Or_error.ok_exn
                     in
                     (Option.value ~default:[] (List.tl fts), cb :: cbs) )
@@ -2058,10 +2060,12 @@ let%test_module "Transaction union tests" =
             ( Coinbase.create
                 ~amount:(Currency.Amount.of_mina_int_exn 10)
                 ~receiver:receivers.(1) ~fee_transfer:(Some ft)
+                ~fee_remainder:Currency.Fee.zero
               |> Or_error.ok_exn
             , Coinbase.create
                 ~amount:(Currency.Amount.of_mina_int_exn 10)
                 ~receiver:receivers.(1) ~fee_transfer:None
+                ~fee_remainder:Currency.Fee.zero
               |> Or_error.ok_exn )
           in
           let transactions : Mina_transaction.Transaction.Valid.t list =
@@ -2441,6 +2445,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let coinbase1 =
         let ft = Coinbase.Fee_transfer.create ~receiver_pk:spec.receiver ~fee in
         Coinbase.create ~amount ~receiver:snapp_pk ~fee_transfer:(Some ft)
+          ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       U.test_transaction_union ?expected_failure ledger
@@ -2449,6 +2454,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let coinbase2 =
         let ft = Coinbase.Fee_transfer.create ~receiver_pk:snapp_pk ~fee in
         Coinbase.create ~amount ~receiver:spec.receiver ~fee_transfer:(Some ft)
+          ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       U.test_transaction_union ?expected_failure ledger
@@ -2462,6 +2468,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let coinbase3 =
         let ft = Coinbase.Fee_transfer.create ~receiver_pk:snapp_pk ~fee in
         Coinbase.create ~amount ~receiver:snapp_pk2 ~fee_transfer:(Some ft)
+          ~fee_remainder:Currency.Fee.zero
         |> Or_error.ok_exn
       in
       U.test_transaction_union

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2396,9 +2396,15 @@ module Make_str (A : Wire_types.Concrete) = struct
                 current_global_slot pending_coinbase_stack_init
             in
             let%bind computed_pending_coinbase_stack_after =
-              let coinbase =
-                (Account_id.Checked.public_key receiver, payload.body.amount)
+              (* The stack records the minted coinbase, which is what the
+                 blockchain snark checks against the protocol's coinbase
+                 amount. The fee remainder is currency the block already
+                 collected, so it is not part of that. *)
+              let%bind minted =
+                Amount.Checked.sub payload.body.amount
+                  (Amount.Checked.of_fee fee_remainder)
               in
+              let coinbase = (Account_id.Checked.public_key receiver, minted) in
               let%bind stack' =
                 Pending_coinbase.Stack.Checked.push_coinbase coinbase
                   pending_coinbase_stack_with_state

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3224,6 +3224,17 @@ module Make_str (A : Wire_types.Concrete) = struct
               in
               Fee_excess.assert_equal_checked target_fee_excess
                 statement.target.fee_excess )
+          (*Every fee payment of a block precedes its coinbase, and the coinbase
+            pays out whatever they left over, so a coinbase leaves no unsettled
+            fees behind it. This is what ties the remainder a coinbase claims to
+            the excess the block actually accumulated.*)
+        ; [%with_label_ "a coinbase settles the fee excess"] (fun () ->
+              let open Tick.Checked.Let_syntax in
+              let%bind excess_is_zero =
+                Fee_excess.equal_checked statement.target.fee_excess
+                  (Fee_excess.var_of_t Fee_excess.zero)
+              in
+              Boolean.Assert.any [ Boolean.not is_coinbase; excess_is_zero ] )
           (*A coinbase moves the recorded post-coinbase state on to where this
             transition ends; anything else carries it through untouched.*)
         ; [%with_label_ "post-coinbase state tracks the latest coinbase"]

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -292,7 +292,8 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~(constraint_constants : Genesis_constants.Constraint_constants.t)
           ~txn_global_slot ~(fee_payer_account : Account.t)
           ~(receiver_account : Account.t) ~(source_account : Account.t)
-          ({ payload; signature = _; signer = _ } : Transaction_union.t) =
+          ({ payload; signature = _; signer = _; fee_remainder = _ } :
+            Transaction_union.t ) =
         match payload.body.tag with
         | Fee_transfer | Coinbase ->
             (* Not user commands, return no failure. *)
@@ -2249,7 +2250,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         (shifted : (module Inner_curve.Checked.Shifted.S with type t = shifted))
         fee_payment_root global_slot pending_coinbase_stack_init
         pending_coinbase_stack_before pending_coinbase_after state_body
-        ({ signer; signature; payload } as txn : Transaction_union.var) =
+        ({ signer; signature; payload; fee_remainder } as txn :
+          Transaction_union.var ) =
       let tag = payload.body.tag in
       let is_user_command =
         Transaction_union.Tag.Unpacked.is_user_command tag
@@ -3038,8 +3040,12 @@ module Make_str (A : Wire_types.Concrete) = struct
            - fee transfer:     - payload.body.amount - payload.common.fee
         *)
         let open Amount in
-        chain Signed.Checked.if_ is_coinbase
-          ~then_:(return (Signed.Checked.of_unsigned (var_of_t zero)))
+        let coinbase_excess =
+          (* A coinbase discharges the excess it pays out to its receiver. *)
+          Signed.Checked.negate
+            (Signed.Checked.of_unsigned (Checked.of_fee fee_remainder))
+        in
+        chain Signed.Checked.if_ is_coinbase ~then_:(return coinbase_excess)
           ~else_:
             (let user_command_excess =
                Signed.Checked.of_unsigned (Checked.of_fee payload.common.fee)
@@ -3067,8 +3073,15 @@ module Make_str (A : Wire_types.Concrete) = struct
       let%bind supply_increase =
         [%with_label_ "Calculate supply increase"] (fun () ->
             let%bind expected_supply_increase =
+              (* [payload.body.amount] is everything the coinbase credits; the
+                 part taken from the fee excess already exists, so only the
+                 remainder is newly minted. *)
+              let%bind minted =
+                Amount.Checked.sub payload.body.amount
+                  (Amount.Checked.of_fee fee_remainder)
+              in
               Amount.Signed.Checked.if_ is_coinbase
-                ~then_:(Amount.Signed.Checked.of_unsigned payload.body.amount)
+                ~then_:(Amount.Signed.Checked.of_unsigned minted)
                 ~else_:Amount.(Signed.Checked.of_unsigned (var_of_t zero))
             in
             let%bind amt0, `Overflow overflow0 =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2277,6 +2277,19 @@ module Make_str (A : Wire_types.Concrete) = struct
         Transaction_union.Tag.Unpacked.is_fee_transfer tag
       in
       let is_coinbase = Transaction_union.Tag.Unpacked.is_coinbase tag in
+      let%bind () =
+        (* [fee_remainder] is witnessed rather than carried in the payload, so
+           nothing but this constrains it for the transaction kinds that do not
+           use it. Pin it to zero there, so that it cannot be used to move the
+           fee excess or the supply increase of any other transaction. *)
+        [%with_label_ "Fee remainder is zero unless this is a coinbase"]
+          (fun () ->
+            let zero = Fee.var_of_t Fee.zero in
+            let%bind remainder_if_not_coinbase =
+              Fee.Checked.if_ is_coinbase ~then_:zero ~else_:fee_remainder
+            in
+            Fee.Checked.assert_equal remainder_if_not_coinbase zero )
+      in
       let fee_token = payload.common.fee_token in
       let%bind fee_token_default =
         make_checked (fun () ->

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -998,7 +998,26 @@ let staged_transactions t =
   List.concat txns
 
 (* written in continuation passing style so that implementation can be used both sync and async *)
-let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
+(*A block's coinbase is its last transaction, so a block that contains one is
+  wholly within the range being replayed. The ledger recorded as of the latest
+  coinbase is therefore the ledger after the last such block, and the trailing
+  transactions of a block the range cuts in half are not part of it. They are
+  replayed on the next round, when they arrive as that round's previous
+  incomplete transactions.*)
+let block_contains_coinbase (block : _ Transactions_ordered.Poly.t) =
+  List.exists block.first_pass ~f:(fun (txn : Transaction_with_witness.t) ->
+      match txn.transaction_with_status.data with
+      | Mina_transaction.Transaction.Coinbase _ ->
+          true
+      | _ ->
+          false )
+
+let up_to_last_coinbase ordered_txns =
+  List.rev ordered_txns
+  |> List.drop_while ~f:(fun block -> not (block_contains_coinbase block))
+  |> List.rev
+
+let apply_ordered_txns_stepwise ?(stop_at_last_coinbase = false) ordered_txns
     ~ledger ~get_protocol_state ~apply_first_pass ~apply_second_pass =
   let open Or_error.Let_syntax in
   let module Previous_incomplete_txns = struct
@@ -1085,15 +1104,6 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
         apply_previous_incomplete_txns
           ~k:(fun () -> Ok (`Complete first_pass_ledger_hash))
           previous_incomplete
-    | [ txns_per_block ] when stop_at_first_pass ->
-        (*Last block; don't apply second pass. This is for snarked ledgers which are first pass ledgers*)
-        apply_txns_first_pass txns_per_block.first_pass
-          ~k:(fun first_pass_ledger_hash _partially_applied_txns ->
-            (*Skip previous_incomplete: If there are previous_incomplete txns
-              then there’d be at least two sets of txns_per_block and the
-              previous_incomplete txns will be applied when processing the first
-              set. The subsequent sets shouldn’t have any previous-incomplete.*)
-            apply_txns (Unapplied []) [] ~first_pass_ledger_hash ~signature_kind )
     | txns_per_block :: ordered_txns' ->
         (*Apply first pass of a blocks transactions either new or continued from previous tree*)
         apply_txns_first_pass txns_per_block.first_pass
@@ -1126,6 +1136,10 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
                   apply_txns (Partially_applied partially_applied_txns)
                     ordered_txns' ~first_pass_ledger_hash ~signature_kind ) )
   in
+  let ordered_txns =
+    if stop_at_last_coinbase then up_to_last_coinbase ordered_txns
+    else ordered_txns
+  in
   let previous_incomplete =
     Option.value_map (List.hd ordered_txns)
       ~default:(Previous_incomplete_txns.Unapplied [])
@@ -1139,7 +1153,7 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
   in
   apply_txns previous_incomplete ordered_txns ~first_pass_ledger_hash
 
-let apply_ordered_txns_sync ?stop_at_first_pass ordered_txns ~ledger
+let apply_ordered_txns_sync ?stop_at_last_coinbase ordered_txns ~ledger
     ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind =
   let rec run = function
     | Ok (`Continue k) ->
@@ -1150,10 +1164,10 @@ let apply_ordered_txns_sync ?stop_at_first_pass ordered_txns ~ledger
         Error err
   in
   run
-  @@ apply_ordered_txns_stepwise ?stop_at_first_pass ordered_txns ~ledger
+  @@ apply_ordered_txns_stepwise ?stop_at_last_coinbase ordered_txns ~ledger
        ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
 
-let apply_ordered_txns_async ?stop_at_first_pass ordered_txns
+let apply_ordered_txns_async ?stop_at_last_coinbase ordered_txns
     ?(async_batch_size = 10) ~ledger ~get_protocol_state ~apply_first_pass
     ~apply_second_pass ~signature_kind =
   let open Deferred.Result.Let_syntax in
@@ -1172,7 +1186,7 @@ let apply_ordered_txns_async ?stop_at_first_pass ordered_txns
         Deferred.return (Error err)
   in
   run
-  @@ apply_ordered_txns_stepwise ?stop_at_first_pass ordered_txns ~ledger
+  @@ apply_ordered_txns_stepwise ?stop_at_last_coinbase ordered_txns ~ledger
        ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
 
 let get_snarked_ledger_sync ~ledger ~get_protocol_state ~apply_first_pass
@@ -1181,7 +1195,7 @@ let get_snarked_ledger_sync ~ledger ~get_protocol_state ~apply_first_pass
   | None ->
       Or_error.errorf "No transactions found"
   | Some (_, txns_per_block) ->
-      apply_ordered_txns_sync ~stop_at_first_pass:true txns_per_block ~ledger
+      apply_ordered_txns_sync ~stop_at_last_coinbase:true txns_per_block ~ledger
         ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
       |> Or_error.ignore_m
 
@@ -1191,7 +1205,7 @@ let get_snarked_ledger_async ?async_batch_size ~ledger ~get_protocol_state
   | None ->
       Deferred.Or_error.errorf "No transactions found"
   | Some (_, txns_per_block) ->
-      apply_ordered_txns_async ~stop_at_first_pass:true txns_per_block
+      apply_ordered_txns_async ~stop_at_last_coinbase:true txns_per_block
         ?async_batch_size ~ledger ~get_protocol_state ~apply_first_pass
         ~apply_second_pass ~signature_kind
       |> Deferred.Or_error.ignore_m

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -940,21 +940,59 @@ let latest_ledger_proof_and_txs' t =
   in
   (proof, txns)
 
+(*A block's coinbase is its last transaction, so a block that contains one is
+  finalised by the range that covers it. The ledger recorded as of the latest
+  coinbase is the ledger after the last such block; the blocks after it are
+  covered by the range but not finalised by it.*)
+let block_contains_coinbase (block : _ Transactions_ordered.Poly.t) =
+  List.exists block.first_pass ~f:(fun (txn : Transaction_with_witness.t) ->
+      match txn.transaction_with_status.data with
+      | Mina_transaction.Transaction.Coinbase _ ->
+          true
+      | _ ->
+          false )
+
+let up_to_last_coinbase ordered_txns =
+  List.rev ordered_txns
+  |> List.drop_while ~f:(fun block -> not (block_contains_coinbase block))
+  |> List.rev
+
+let after_last_coinbase ordered_txns =
+  List.rev ordered_txns
+  |> List.take_while ~f:(fun block -> not (block_contains_coinbase block))
+  |> List.rev
+
 let incomplete_txns_from_recent_proof_tree t =
   let open Option.Let_syntax in
   let%map proof, txns_per_block = latest_ledger_proof_and_txs' t in
-  let txns =
-    match List.last txns_per_block with
+  (*The snarked ledger is the one recorded as of the latest coinbase, so what
+    remains outstanding relative to it is what this range covers but does not
+    apply in full. That is two things. The blocks after the last coinbase are
+    not finalised by this range at all. And the last block that is finalised
+    may still have a second pass that falls in the next tree: a coinbase being
+    a block's last transaction puts the first pass boundary at the block
+    boundary, but it does not stop the second pass from lagging across a tree
+    edge.*)
+  let spillover =
+    match List.last (up_to_last_coinbase txns_per_block) with
     | None ->
+        []
+    | Some block ->
+        block.Transactions_ordered.Poly.current_incomplete
+  in
+  let txns =
+    match (spillover, after_last_coinbase txns_per_block) with
+    | [], [] ->
         ([], `Border_block_continued_in_the_next_tree false)
-    | Some txns_in_last_block ->
-        (*First pass ledger is considered as the snarked ledger, so any account update whether completed in the same tree or not should be included in the next tree *)
-        if not (List.is_empty txns_in_last_block.second_pass) then
-          ( txns_in_last_block.second_pass
-          , `Border_block_continued_in_the_next_tree false )
-        else
-          ( txns_in_last_block.current_incomplete
-          , `Border_block_continued_in_the_next_tree true )
+    | _, [] ->
+        (*Only the trailing second pass is left; its block's transactions are
+          otherwise applied, so it stands on its own rather than continuing.*)
+        (spillover, `Border_block_continued_in_the_next_tree false)
+    | _, unfinalised ->
+        ( spillover
+          @ List.concat_map unfinalised ~f:(fun block ->
+              block.Transactions_ordered.Poly.first_pass )
+        , `Border_block_continued_in_the_next_tree true )
   in
   (proof, txns)
 
@@ -1006,25 +1044,6 @@ let staged_transactions t =
   List.concat txns
 
 (* written in continuation passing style so that implementation can be used both sync and async *)
-(*A block's coinbase is its last transaction, so a block that contains one is
-  wholly within the range being replayed. The ledger recorded as of the latest
-  coinbase is therefore the ledger after the last such block, and the trailing
-  transactions of a block the range cuts in half are not part of it. They are
-  replayed on the next round, when they arrive as that round's previous
-  incomplete transactions.*)
-let block_contains_coinbase (block : _ Transactions_ordered.Poly.t) =
-  List.exists block.first_pass ~f:(fun (txn : Transaction_with_witness.t) ->
-      match txn.transaction_with_status.data with
-      | Mina_transaction.Transaction.Coinbase _ ->
-          true
-      | _ ->
-          false )
-
-let up_to_last_coinbase ordered_txns =
-  List.rev ordered_txns
-  |> List.drop_while ~f:(fun block -> not (block_contains_coinbase block))
-  |> List.rev
-
 let apply_ordered_txns_stepwise ?(stop_at_last_coinbase = false) ordered_txns
     ~ledger ~get_protocol_state ~apply_first_pass ~apply_second_pass =
   let open Or_error.Let_syntax in
@@ -1142,8 +1161,15 @@ let apply_ordered_txns_stepwise ?(stop_at_last_coinbase = false) ordered_txns
             apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
                 let continue_previous_tree's_txns =
                   (* If this is a continuation from previous tree for the same block (incomplete txns in both sets) then do second pass now*)
+                  (*The previous tree left transactions of this block
+                    pending, and this group defers nothing further, so the
+                    block's first pass finishes here and its second pass can
+                    run. A non-empty [current_incomplete] means the block
+                    carries on into the next tree -- with the coinbase last,
+                    that is where its first pass ends -- so the second pass has
+                    to keep waiting.*)
                   previous_not_empty
-                  && not (List.is_empty txns_per_block.current_incomplete)
+                  && List.is_empty txns_per_block.current_incomplete
                 in
                 let do_second_pass =
                   (*if transactions completed in the same tree; do second pass now*)

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -745,11 +745,19 @@ struct
               Transaction_snark.Statement.merge statement t |> Or_error.ignore_m )
         and () = check_registers registers_end target
         and () =
-          (*[check_registers] pins the excess the scan state ends with; the
-            excess it starts from must be settled too.*)
-          clarify_error
-            (Fee_excess.is_zero source.fee_excess)
-            "nonzero fee excess"
+          (*[check_registers] pins the excess the scan state ends with. The one
+            it starts from is whatever the last emitted proof left behind,
+            which the merge above pins; a block that spans the boundary leaves
+            it non-zero, to be settled by the coinbase in the next chunk. With
+            no proof emitted yet there is nothing to connect to, and the scan
+            state starts settled.*)
+          match last_proof_statement with
+          | Some _ ->
+              Ok ()
+          | None ->
+              clarify_error
+                (Fee_excess.is_zero source.fee_excess)
+                "nonzero fee excess"
         in
         ()
 
@@ -1105,20 +1113,35 @@ let apply_ordered_txns_stepwise ?(stop_at_last_coinbase = false) ordered_txns
           ~k:(fun () -> Ok (`Complete first_pass_ledger_hash))
           previous_incomplete
     | txns_per_block :: ordered_txns' ->
+        let previous_not_empty =
+          match previous_incomplete with
+          | Unapplied txns ->
+              not (List.is_empty txns)
+          | Partially_applied txns ->
+              not (List.is_empty txns)
+        in
+        (*An unapplied previous-incomplete set is the earlier part of a block
+          that the previous proof's range cut in half, and the ledger this
+          replay starts from predates all of it. So it is the leading part of
+          this block's first pass rather than something to apply afterwards:
+          the rest of the block, in this tree, has to be applied on top of it.
+
+          A partially applied set was produced by this replay, and its second
+          pass still follows the first pass of the rest of its block.*)
+        let leading, previous_incomplete =
+          match previous_incomplete with
+          | Unapplied txns ->
+              (txns, Previous_incomplete_txns.Unapplied [])
+          | Partially_applied _ as partially_applied ->
+              ([], partially_applied)
+        in
         (*Apply first pass of a blocks transactions either new or continued from previous tree*)
-        apply_txns_first_pass txns_per_block.first_pass
+        apply_txns_first_pass (leading @ txns_per_block.first_pass)
           ~k:(fun first_pass_ledger_hash partially_applied_txns ->
             (*Apply second pass of previous tree's transactions, if any*)
             apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
                 let continue_previous_tree's_txns =
                   (* If this is a continuation from previous tree for the same block (incomplete txns in both sets) then do second pass now*)
-                  let previous_not_empty =
-                    match previous_incomplete with
-                    | Unapplied txns ->
-                        not (List.is_empty txns)
-                    | Partially_applied txns ->
-                        not (List.is_empty txns)
-                  in
                   previous_not_empty
                   && not (List.is_empty txns_per_block.current_incomplete)
                 in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -999,8 +999,7 @@ let staged_transactions t =
 
 (* written in continuation passing style so that implementation can be used both sync and async *)
 let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
-    ~ledger ~get_protocol_state ~apply_first_pass ~apply_second_pass
-    ~apply_first_pass_sparse_ledger =
+    ~ledger ~get_protocol_state ~apply_first_pass ~apply_second_pass =
   let open Or_error.Let_syntax in
   let module Previous_incomplete_txns = struct
     type t =
@@ -1061,130 +1060,29 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
             expected_status status
             (Ledger.Transaction_partially_applied.command partially_applied_txn)
   in
-  let apply_previous_incomplete_txns ~signature_kind ~k
-      (txns : Previous_incomplete_txns.t) =
-    (*Note: Previous incomplete transactions refer to the block's transactions from previous scan state tree that were split between the two trees.
-      The set in the previous tree have gone through the first pass. For the second pass that is to happen after the rest of the set goes through the first pass, we need partially applied state - result of previous tree's transactions' first pass. To generate the partial state, we do a first pass application of previous tree's transaction on a sparse ledger created from witnesses stored in the scan state and then use it to apply to the ledger here*)
-    let inject_ledger_info partially_applied_txn =
-      let open Sparse_ledger.T.Transaction_partially_applied in
-      match partially_applied_txn with
-      | Zkapp_command t ->
-          let%map original_first_pass_account_states =
-            Mina_stdlib.Result.List.map t.original_first_pass_account_states
-              ~f:(fun (id, loc_opt) ->
-                match loc_opt with
-                | None ->
-                    return (id, None)
-                | Some (_sparse_ledger_loc, account) -> (
-                    match Ledger.location_of_account ledger id with
-                    | Some loc ->
-                        return (id, Some (loc, account))
-                    | None ->
-                        Or_error.errorf
-                          "Original accounts states from partially applied \
-                           transactions don't exist in the ledger" ) )
-          in
-          let global_state : Ledger.Global_state.t =
-            { first_pass_ledger = ledger
-            ; second_pass_ledger = ledger
-            ; fee_excess = t.global_state.fee_excess
-            ; supply_increase = t.global_state.supply_increase
-            ; protocol_state = t.global_state.protocol_state
-            ; block_global_slot = t.global_state.block_global_slot
-            }
-          in
-          let local_state =
-            { Mina_transaction_logic.Zkapp_command_logic.Local_state.stack_frame =
-                t.local_state.stack_frame
-            ; call_stack = t.local_state.call_stack
-            ; transaction_commitment = t.local_state.transaction_commitment
-            ; full_transaction_commitment =
-                t.local_state.full_transaction_commitment
-            ; excess = t.local_state.excess
-            ; supply_increase = t.local_state.supply_increase
-            ; ledger
-            ; success = t.local_state.success
-            ; account_update_index = t.local_state.account_update_index
-            ; failure_status_tbl = t.local_state.failure_status_tbl
-            ; will_succeed = t.local_state.will_succeed
-            }
-          in
-          Ledger.Transaction_partially_applied.Zkapp_command
-            { command = t.command
-            ; previous_hash = t.previous_hash
-            ; original_first_pass_account_states
-            ; signature_kind
-            ; constraint_constants = t.constraint_constants
-            ; state_view = t.state_view
-            ; global_state
-            ; local_state
-            }
-      | Signed_command c ->
-          return
-            (Ledger.Transaction_partially_applied.Signed_command
-               { previous_hash = c.previous_hash; applied = c.applied } )
-      | Fee_transfer f ->
-          return
-            (Ledger.Transaction_partially_applied.Fee_transfer
-               { previous_hash = f.previous_hash; applied = f.applied } )
-      | Coinbase c ->
-          return
-            (Ledger.Transaction_partially_applied.Coinbase
-               { previous_hash = c.previous_hash; applied = c.applied } )
-    in
-    let rec apply_txns_to_witnesses_first_pass ?(acc = []) ~k txns =
-      match txns with
-      | [] ->
-          k (List.rev acc)
-      | txn :: txns' ->
-          let transaction, state_hash, block_global_slot =
-            extract_txn_and_global_slot txn
-          in
-          let expected_status = transaction.status in
-          let%bind partially_applied_txn =
-            apply ~apply:apply_first_pass_sparse_ledger
-              ~ledger:txn.first_pass_ledger_witness transaction.data state_hash
-              block_global_slot
-          in
-          let%map partially_applied_txn' =
-            inject_ledger_info partially_applied_txn
-          in
-          `Continue
-            (fun () ->
-              apply_txns_to_witnesses_first_pass
-                ~acc:((expected_status, partially_applied_txn') :: acc)
-                ~k txns' )
-    in
+  let apply_previous_incomplete_txns ~k (txns : Previous_incomplete_txns.t) =
+    (*Previous incomplete transactions are the earlier part of a block that the
+      previous ledger proof's range cut in half. The ledger this replay starts
+      from is the one recorded as of a coinbase, and a coinbase is a block's
+      last transaction, so that ledger is from before the whole of the split
+      block: these transactions are unapplied here, not half-applied, and they
+      go through both passes against the ledger itself.*)
     match txns with
     | Unapplied txns ->
-        apply_txns_to_witnesses_first_pass txns
-          ~k:(fun partially_applied_txns ->
+        apply_txns_first_pass txns
+          ~k:(fun (`First_pass_ledger_hash _) partially_applied_txns ->
             apply_txns_second_pass partially_applied_txns ~k )
     | Partially_applied partially_applied_txns ->
+        (*Reached part way through this replay, where the partially applied
+          state is in hand rather than needing to be rebuilt.*)
         apply_txns_second_pass partially_applied_txns ~k
   in
   let rec apply_txns (previous_incomplete : Previous_incomplete_txns.t)
       (ordered_txns : _ Transactions_ordered.Poly.t list)
       ~first_pass_ledger_hash ~signature_kind =
-    let previous_incomplete =
-      (*filter out any non-zkapp transactions for second pass application*)
-      match previous_incomplete with
-      | Previous_incomplete_txns.Unapplied txns ->
-          Previous_incomplete_txns.Unapplied
-            (List.filter txns ~f:(fun txn ->
-                 match txn.transaction_with_status.data with
-                 | Command (Zkapp_command _) ->
-                     true
-                 | _ ->
-                     false ) )
-      | Partially_applied txns ->
-          Partially_applied
-            (List.filter txns ~f:(fun (_, t) ->
-                 match t with Zkapp_command _ -> true | _ -> false ) )
-    in
     match ordered_txns with
     | [] ->
-        apply_previous_incomplete_txns ~signature_kind
+        apply_previous_incomplete_txns
           ~k:(fun () -> Ok (`Complete first_pass_ledger_hash))
           previous_incomplete
     | [ txns_per_block ] when stop_at_first_pass ->
@@ -1201,8 +1099,7 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
         apply_txns_first_pass txns_per_block.first_pass
           ~k:(fun first_pass_ledger_hash partially_applied_txns ->
             (*Apply second pass of previous tree's transactions, if any*)
-            apply_previous_incomplete_txns previous_incomplete ~signature_kind
-              ~k:(fun () ->
+            apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
                 let continue_previous_tree's_txns =
                   (* If this is a continuation from previous tree for the same block (incomplete txns in both sets) then do second pass now*)
                   let previous_not_empty =
@@ -1243,8 +1140,7 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
   apply_txns previous_incomplete ordered_txns ~first_pass_ledger_hash
 
 let apply_ordered_txns_sync ?stop_at_first_pass ordered_txns ~ledger
-    ~get_protocol_state ~apply_first_pass ~apply_second_pass
-    ~apply_first_pass_sparse_ledger ~signature_kind =
+    ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind =
   let rec run = function
     | Ok (`Continue k) ->
         run (k ())
@@ -1255,12 +1151,11 @@ let apply_ordered_txns_sync ?stop_at_first_pass ordered_txns ~ledger
   in
   run
   @@ apply_ordered_txns_stepwise ?stop_at_first_pass ordered_txns ~ledger
-       ~get_protocol_state ~apply_first_pass ~apply_second_pass
-       ~apply_first_pass_sparse_ledger ~signature_kind
+       ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
 
 let apply_ordered_txns_async ?stop_at_first_pass ordered_txns
     ?(async_batch_size = 10) ~ledger ~get_protocol_state ~apply_first_pass
-    ~apply_second_pass ~apply_first_pass_sparse_ledger ~signature_kind =
+    ~apply_second_pass ~signature_kind =
   let open Deferred.Result.Let_syntax in
   let yield =
     let f = Staged.unstage (Scheduler.yield_every ~n:async_batch_size) in
@@ -1278,39 +1173,35 @@ let apply_ordered_txns_async ?stop_at_first_pass ordered_txns
   in
   run
   @@ apply_ordered_txns_stepwise ?stop_at_first_pass ordered_txns ~ledger
-       ~get_protocol_state ~apply_first_pass ~apply_second_pass
-       ~apply_first_pass_sparse_ledger ~signature_kind
+       ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
 
 let get_snarked_ledger_sync ~ledger ~get_protocol_state ~apply_first_pass
-    ~apply_second_pass ~apply_first_pass_sparse_ledger ~signature_kind t =
+    ~apply_second_pass ~signature_kind t =
   match latest_ledger_proof_and_txs' t with
   | None ->
       Or_error.errorf "No transactions found"
   | Some (_, txns_per_block) ->
       apply_ordered_txns_sync ~stop_at_first_pass:true txns_per_block ~ledger
-        ~get_protocol_state ~apply_first_pass ~apply_second_pass
-        ~apply_first_pass_sparse_ledger ~signature_kind
+        ~get_protocol_state ~apply_first_pass ~apply_second_pass ~signature_kind
       |> Or_error.ignore_m
 
 let get_snarked_ledger_async ?async_batch_size ~ledger ~get_protocol_state
-    ~apply_first_pass ~apply_second_pass ~apply_first_pass_sparse_ledger
-    ~signature_kind t =
+    ~apply_first_pass ~apply_second_pass ~signature_kind t =
   match latest_ledger_proof_and_txs' t with
   | None ->
       Deferred.Or_error.errorf "No transactions found"
   | Some (_, txns_per_block) ->
       apply_ordered_txns_async ~stop_at_first_pass:true txns_per_block
         ?async_batch_size ~ledger ~get_protocol_state ~apply_first_pass
-        ~apply_second_pass ~apply_first_pass_sparse_ledger ~signature_kind
+        ~apply_second_pass ~signature_kind
       |> Deferred.Or_error.ignore_m
 
 let get_staged_ledger_async ?async_batch_size ~ledger ~get_protocol_state
-    ~apply_first_pass ~apply_second_pass ~apply_first_pass_sparse_ledger
-    ~signature_kind t =
+    ~apply_first_pass ~apply_second_pass ~signature_kind t =
   let staged_transactions_with_state_hash = staged_transactions t in
   apply_ordered_txns_async staged_transactions_with_state_hash ?async_batch_size
     ~ledger ~get_protocol_state ~apply_first_pass ~apply_second_pass
-    ~apply_first_pass_sparse_ledger ~signature_kind
+    ~signature_kind
 
 let free_space t = Parallel_scan.free_space t.scan_state
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -1159,22 +1159,19 @@ let apply_ordered_txns_stepwise ?(stop_at_last_coinbase = false) ordered_txns
           ~k:(fun first_pass_ledger_hash partially_applied_txns ->
             (*Apply second pass of previous tree's transactions, if any*)
             apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
-                let continue_previous_tree's_txns =
-                  (* If this is a continuation from previous tree for the same block (incomplete txns in both sets) then do second pass now*)
-                  (*The previous tree left transactions of this block
-                    pending, and this group defers nothing further, so the
-                    block's first pass finishes here and its second pass can
-                    run. A non-empty [current_incomplete] means the block
-                    carries on into the next tree -- with the coinbase last,
-                    that is where its first pass ends -- so the second pass has
-                    to keep waiting.*)
-                  previous_not_empty
-                  && List.is_empty txns_per_block.current_incomplete
+                let block_first_pass_ends_here =
+                  (*A block carried over from the previous tree can have its
+                    second pass once its first pass is complete, which is where
+                    its coinbase is: a coinbase is a block's last transaction.
+                    Inferring this from whether anything was deferred is what
+                    the old condition did, and it does not survive the coinbase
+                    moving to the end of the block.*)
+                  previous_not_empty && block_contains_coinbase txns_per_block
                 in
                 let do_second_pass =
                   (*if transactions completed in the same tree; do second pass now*)
                   (not (List.is_empty txns_per_block.second_pass))
-                  || continue_previous_tree's_txns
+                  || block_first_pass_ends_here
                 in
                 if do_second_pass then
                   apply_txns_second_pass partially_applied_txns ~k:(fun () ->

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -28,7 +28,7 @@ module Transaction_with_witness = struct
       *)
       type t =
         { transaction_with_status :
-            Mina_transaction.Transaction.Stable.V3.t With_status.Stable.V2.t
+            Mina_transaction.Transaction.Stable.V4.t With_status.Stable.V2.t
         ; state_hash : State_hash.Stable.V1.t * State_body_hash.Stable.V1.t
         ; statement : Transaction_snark.Statement.Stable.V3.t
         ; init_stack : Pending_coinbase.Stack_versioned.Stable.V1.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -121,13 +121,6 @@ val get_snarked_ledger_sync :
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
         -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
-  -> apply_first_pass_sparse_ledger:
-       (   global_slot:Mina_numbers.Global_slot_since_genesis.t
-        -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
-        -> Mina_ledger.Sparse_ledger.t
-        -> Mina_transaction.Transaction.t
-        -> Mina_ledger.Sparse_ledger.T.Transaction_partially_applied.t
-           Or_error.t )
   -> signature_kind:Mina_signature_kind.t
   -> t
   -> unit Or_error.t
@@ -147,13 +140,6 @@ val get_snarked_ledger_async :
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
         -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
-  -> apply_first_pass_sparse_ledger:
-       (   global_slot:Mina_numbers.Global_slot_since_genesis.t
-        -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
-        -> Mina_ledger.Sparse_ledger.t
-        -> Mina_transaction.Transaction.t
-        -> Mina_ledger.Sparse_ledger.T.Transaction_partially_applied.t
-           Or_error.t )
   -> signature_kind:Mina_signature_kind.t
   -> t
   -> unit Deferred.Or_error.t
@@ -180,13 +166,6 @@ val get_staged_ledger_async :
        (   Ledger.t
         -> Ledger.Transaction_partially_applied.t
         -> Mina_transaction_logic.Transaction_applied.t Or_error.t )
-  -> apply_first_pass_sparse_ledger:
-       (   global_slot:Mina_numbers.Global_slot_since_genesis.t
-        -> txn_state_view:Mina_base.Zkapp_precondition.Protocol_state.View.t
-        -> Mina_ledger.Sparse_ledger.t
-        -> Mina_transaction.Transaction.t
-        -> Mina_ledger.Sparse_ledger.T.Transaction_partially_applied.t
-           Or_error.t )
   -> signature_kind:Mina_signature_kind.t
   -> t
   -> [ `First_pass_ledger_hash of Ledger_hash.t ] Deferred.Or_error.t

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -147,7 +147,7 @@ module Stable = struct
 
   module V4 = struct
     type t =
-      { transaction : Mina_transaction.Transaction.Stable.V3.t
+      { transaction : Mina_transaction.Transaction.Stable.V4.t
       ; first_pass_ledger : Mina_ledger.Sparse_ledger.Stable.V3.t
       ; second_pass_ledger : Mina_ledger.Sparse_ledger.Stable.V3.t
       ; protocol_state_body : Mina_state.Protocol_state.Body.Value.Stable.V4.t

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -90,7 +90,7 @@ module Stable : sig
 
   module V4 : sig
     type t =
-      { transaction : Mina_transaction.Transaction.Stable.V3.t
+      { transaction : Mina_transaction.Transaction.Stable.V4.t
       ; first_pass_ledger : Mina_ledger.Sparse_ledger.Stable.V3.t
       ; second_pass_ledger : Mina_ledger.Sparse_ledger.Stable.V3.t
       ; protocol_state_body : Mina_state.Protocol_state.Body.Value.Stable.V4.t

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -743,7 +743,7 @@ module Metrics = struct
     match (d1.coinbase, d2) with
     | Zero, None | Zero, Some { coinbase = Zero; _ } ->
         false
-    | Zero, Some { coinbase = One _; _ } | One _, _ | Two _, _ ->
+    | Zero, Some { coinbase = One _; _ } | One _, _ ->
         true
 
   let intprop f b = Unsigned.UInt32.to_int (f (Breadcrumb.consensus_state b))

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -510,16 +510,6 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
           ~constraint_constants:Context.constraint_constants
       in
       let apply_second_pass = Ledger.apply_transaction_second_pass in
-      let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
-          sparse_ledger txn =
-        let open Or_error.Let_syntax in
-        let%map _ledger, partial_txn =
-          Mina_ledger.Sparse_ledger.apply_transaction_first_pass
-            ~constraint_constants:Context.constraint_constants ~txn_state_view
-            ~global_slot sparse_ledger txn
-        in
-        partial_txn
-      in
       let get_protocol_state state_hash =
         match find_protocol_state t state_hash with
         | Some s ->
@@ -531,7 +521,7 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
       Or_error.ok_exn
         (Staged_ledger.Scan_state.get_snarked_ledger_sync ~ledger:mt
            ~get_protocol_state ~apply_first_pass ~apply_second_pass
-           ~apply_first_pass_sparse_ledger ~signature_kind
+           ~signature_kind
            (Staged_ledger.scan_state
               (Breadcrumb.staged_ledger new_root_node.breadcrumb) ) ) ;
       (*Check that the new snarked ledger is as expected*)

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -405,12 +405,14 @@ let%test_module "malformed gossiped block is handled gracefully" =
               ; commands = []
               ; coinbase = Staged_ledger_diff.At_most_two.One None
               ; internal_command_statuses = []
+              ; padding = None
               }
             , Some
                 { completed_works = []
                 ; commands = []
                 ; coinbase = Staged_ledger_diff.At_most_one.One None
                 ; internal_command_statuses = []
+                ; padding = None
                 } )
         }
       in

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -403,7 +403,7 @@ let%test_module "malformed gossiped block is handled gracefully" =
         { diff =
             ( { completed_works = []
               ; commands = []
-              ; coinbase = Staged_ledger_diff.At_most_two.One None
+              ; coinbase = Staged_ledger_diff.At_most_one.One None
               ; internal_command_statuses = []
               ; padding = None
               }

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -405,14 +405,12 @@ let%test_module "malformed gossiped block is handled gracefully" =
               ; commands = []
               ; coinbase = Staged_ledger_diff.At_most_one.One None
               ; internal_command_statuses = []
-              ; padding = None
               }
             , Some
                 { completed_works = []
                 ; commands = []
                 ; coinbase = Staged_ledger_diff.At_most_one.One None
                 ; internal_command_statuses = []
-                ; padding = None
                 } )
         }
       in


### PR DESCRIPTION
**This is a hard-fork change.** It alters the transaction snark circuit, the
pending coinbase circuit, the versioned wire types and the meaning of the
snarked ledger hash the protocol surfaces. It is the last PR of the series that
began with #19302.

## What changes

The snarked ledger hash the protocol carries stops being
`target.first_pass_ledger` — the ledger at whichever transaction the scan
state's chunk boundary happened to fall on — and becomes
`target.ledger_after_coinbase`, the ledger as of the latest coinbase.

To make that meaningful, a block's coinbase becomes its last transaction, and
the coinbase pays out whatever the block's transaction fees did not spend on
provers. The fee excess is then settled at the coinbase rather than at the
proof boundary, which is what frees a block's transactions to span a scan state
tree boundary without having to balance at the edge.

## Why this is worth doing

**It can be explained in one sentence.** The snarked ledger hash is the ledger
hash of the most recent completely-snarked block. The previous definition — the
first pass ledger at an arbitrary point inside a block, determined by scan state
geometry rather than by anything a reader of the protocol cares about — could
not be stated that briefly, and the difference matters every time someone has to
reason about what the hash commits to.

**Bridging gets much simpler.** A bridge can now show that a recent block has
enough confirmations building on it, and separately that that block's
transactions have been confirmed to produce its claimed `staged_ledger_hash`.
Both halves are statements about a block. Previously the snarked ledger
corresponded to no block at all, so a bridge had to reason about scan state
internals to connect the two.

**It simplifies the transaction snark work splitting protocol.** Work no longer
has to be arranged so that fees balance at chunk boundaries, which is
groundwork for splitting zkApps across multiple scan state tree leaves.

**It moves the transaction snark closer to being independently verifiable.**
Less of the statement's meaning depends on consensus constructing the same
thing in parallel from the blockchain protocol, and more of it is carried by
the transaction snark itself.

## How the series builds to this

Each earlier PR is small enough to review on its own terms, and each one
removes an obstacle that this change would otherwise have had to carry:

- **#19302** collapsed `Fee_excess.t` to a single signed fee by removing fee
  tokens. Everything downstream reasons about one number instead of a pair with
  rebalancing rules.
- **#19303** moved the fee excess and the supply into the statement's registers,
  as before/after values rather than an accumulated total, and dropped the
  consensus-side accumulator. That is what makes "the excess at this point in
  the block" expressible at all.
- **#19304** added `ledger_after_coinbase` and `total_supply_after_coinbase`,
  recorded by the transaction snark but not yet surfaced anywhere. Inert on its
  own, and deliberately so: it establishes the values without changing what the
  protocol means by them.
- **this PR** puts the coinbase last, has it settle the excess, and switches the
  protocol to surface the post-coinbase ledger.

## Why not split it further

The pieces here are mutually load-bearing in a way the earlier ones were not.
Moving the coinbase to the end of the block without also having it absorb the
fee remainder introduces a failure: the remainder was previously paid by a fee
transfer to the coinbase receiver, and with the coinbase last that transfer
would have to create the receiver's account out of an amount too small to cover
the account creation fee — which aborts the whole block rather than failing one
transaction. Conversely, asserting a zero excess at the coinbase is only
satisfiable once every fee payment precedes it.

Surfacing `ledger_after_coinbase` has the same character: it is only correct
once the replay stops at the last coinbase, and the replay can only stop there
once the coinbase reliably ends a block. Splitting these apart would produce
commits that are individually broken and only jointly correct, which is worse
for a reviewer than one commit series that is coherent throughout. The 17
commits are each self-contained and each compile.

## A note on the replay

Three places in the scan state replay encoded "a block ends where its first pass
ends within this tree". A coinbase being a block's last transaction moves that
boundary, and each had to follow: what counts as outstanding relative to the
snarked ledger, the order in which a split block's halves are applied, and when
a carried-over block's second pass may run. The last of these is now stated
directly — the first pass ends in the group holding the coinbase — rather than
inferred from whether anything happened to be deferred, which is what the
previous condition did and what did not survive the coinbase moving.

## Testing

`dune runtest src/lib/staged_ledger` — 31/31 pass. Transition frontier suite
passes.

Beyond that, a local network was run for several hours at `--proof-level full`,
which is the configuration that actually exercises the transaction snark (at
check level the snark worker short-circuits and the base and merge circuits are
never run):

- two block producers, four snark workers, 30s slots, `k=10`, scan state depth
  4, real Pickles proofs throughout
- a sustained mixture of payments and zkApp commands, with zkApps landing in
  most blocks, so that second passes span scan state tree boundaries
- snark work deliberately running behind demand, so that blocks land part way
  through scan state chunks rather than on tree boundaries — the misalignment
  this change has to survive
- the scan state driven to saturation, cycling trees continuously, with the
  snarked ledger advancing block to block

Against that, both restart paths were exercised on a node and verified:

1. **Restart with persisted state** — reads the scan state from disk and
   re-materialises the root snarked ledger. Resynced cleanly and reproduced the
   producer's `snarkedLedgerHash` and `stagedLedgerHash` exactly at three
   consecutive heights.
2. **Restart with state wiped** — full bootstrap from a peer, confirmed to be a
   real scan state transfer (`get_staged_ledger_aux_and_pending_coinbases_at_hash`)
   rather than block-by-block catchup. Also reproduced the producer's hashes
   exactly.

The `stagedLedgerHash` agreement is the meaningful result: that hash commits to
the scan state via `aux_hash`, so equality shows the scan state was rebuilt
identically rather than merely plausibly.

## Still to do before merge

- Regenerate the dev verification keys and constraint counts; nine commits here
  touch the circuit.
- `mina internal dump-type-shapes` against `upstream/develop` to confirm the
  version cascade separated cleanly.
- Enforce "a block with any transaction has a coinbase" in `check_coinbase`, so
  it binds on the apply path rather than only in `create_coinbase`.
- `replayer.ml` reconstructs coinbases with a zero fee remainder, which will
  rebuild the wrong transaction once producers emit non-zero ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
