### PR TITLE
Uptime Service: stamp sok digest on zkapp segment proofs

### DIFF
--- a/changes/19313.md
+++ b/changes/19313.md
@@ -1,0 +1,9 @@
+## Uptime service: fix SNARK work rejected by the Delegation Program
+
+Uptime submissions carrying SNARK work for a block whose last transaction is a zkApp
+command were rejected by `delegation_verify` with `proof's sok message digest does not
+match the sok message`, so those submissions did not count toward Delegation Program
+scoring. Blocks ending in a payment, fee transfer or coinbase were unaffected, as were
+submissions carrying no SNARK work.
+
+Node operators need take no action beyond upgrading the daemon.

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -146,7 +146,8 @@ module Impl = struct
         match w.transaction with
         | Command (Zkapp_command zkapp_command) -> (
             let%bind witnesses_specs_stmts =
-              extract_zkapp_segment_works ~m ~input ~witness:w
+              extract_zkapp_segment_works ~signature_kind
+                ~constraint_constants:M.constraint_constants ~input ~witness:w
                 ~zkapp_command:
                   (Zkapp_command.write_all_proofs_to_disk ~signature_kind
                      ~proof_cache_db zkapp_command )

--- a/src/lib/uptime_service/test/dune
+++ b/src/lib/uptime_service/test/dune
@@ -1,0 +1,27 @@
+(test
+ (name test_uptime_service)
+ (package uptime_service)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version))
+ (libraries
+  ;; opam libraries
+  alcotest
+  alcotest-async
+  async
+  core
+  core_kernel
+  ;; local libraries
+  currency
+  genesis_constants
+  mina_base
+  mina_generators
+  mina_ledger
+  mina_state
+  mina_transaction
+  precomputed_values
+  signature_lib
+  transaction_snark
+  transaction_witness
+  uptime_service))

--- a/src/lib/uptime_service/test/test_uptime_service.ml
+++ b/src/lib/uptime_service/test/test_uptime_service.ml
@@ -1,0 +1,163 @@
+(** End-to-end test for the SNARK work the uptime service attaches to a
+    submission when the block's terminal transaction is a zkApp command.
+
+    This drives the real production function,
+    [Uptime_service.Uptime_snark_worker.extract_terminal_zk_segment], over a
+    real generated ledger and zkApp command: the transaction is applied, real
+    segment witnesses are produced by
+    [Transaction_snark.zkapp_command_witnesses_exn], the terminal segment is
+    located by its target staged ledger hash, and the statement that would be
+    handed to the prover is inspected.
+
+    It stops short of producing a proof — that needs a proving circuit and
+    minutes of runtime — so what it pins down is that the statement reaching the
+    prover carries the submitter's sok digest rather than the placeholder. That
+    is the defect reported as mina#19299: the placeholder survived, and every
+    resulting proof attested to the empty sok message and was rejected by
+    [delegation_verify]. *)
+
+open Core_kernel
+open Async
+open Mina_base
+
+let constraint_constants =
+  Genesis_constants.For_unit_tests.Constraint_constants.t
+
+let genesis_constants = Genesis_constants.For_unit_tests.t
+
+let signature_kind = Mina_signature_kind.Testnet
+
+let protocol_state_body =
+  lazy
+    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
+        .data |> Mina_state.Protocol_state.body )
+
+(** A ledger plus a zkApp command that applies cleanly against it. The generator
+    defaults its verification key to [Pickles.Side_loaded.Verification_key.dummy],
+    so no proving circuit is compiled here. *)
+let generate_zkapp_command_and_ledger () =
+  let user_command, _fee_payer_keypair, _keymap, ledger =
+    Quickcheck.random_value
+      ~seed:(`Deterministic "uptime-service-zkapp-terminal-segment")
+      (Mina_generators.User_command_generators.zkapp_command_with_ledger
+         ~genesis_constants ~constraint_constants () )
+  in
+  match user_command with
+  | User_command.Zkapp_command zkapp_command ->
+      (Zkapp_command.Valid.forget zkapp_command, ledger)
+  | User_command.Signed_command _ ->
+      failwith "generator produced a signed command, expected a zkApp command"
+
+(** Mirrors what the daemon hands the uptime snark worker: the transaction is
+    applied first-pass against a mask, and the resulting ledgers become the
+    witness's sparse ledgers. *)
+let build_witness ~ledger ~zkapp_command ~global_slot =
+  let state_body = Lazy.force protocol_state_body in
+  let second_pass_ledger =
+    let mask =
+      Mina_ledger.Ledger.Mask.create ~depth:(Mina_ledger.Ledger.depth ledger) ()
+    in
+    let registered = Mina_ledger.Ledger.register_mask ledger mask in
+    let _partial =
+      Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+        ~constraint_constants ~global_slot
+        ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
+        registered
+        (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
+      |> Or_error.ok_exn
+    in
+    registered
+  in
+  let accounts_referenced = Zkapp_command.accounts_referenced zkapp_command in
+  let sparse_of l =
+    Mina_ledger.Sparse_ledger.of_ledger_subset_exn l accounts_referenced
+  in
+  ( Transaction_witness.read_all_proofs_from_disk
+      { Transaction_witness.transaction =
+          Mina_transaction.Transaction.Command (Zkapp_command zkapp_command)
+      ; first_pass_ledger = sparse_of ledger
+      ; second_pass_ledger = sparse_of second_pass_ledger
+      ; protocol_state_body = state_body
+      ; init_stack = Pending_coinbase.Stack.empty
+      ; status = Mina_base.Transaction_status.Applied
+      ; block_global_slot = global_slot
+      }
+  , second_pass_ledger )
+
+(** Only [source.pending_coinbase_stack], [target.pending_coinbase_stack] and
+    [connecting_ledger_left] are read out of this by the extraction path, so the
+    remaining fields are left at their genesis values. *)
+let build_input ~ledger ~global_slot =
+  let state_body = Lazy.force protocol_state_body in
+  let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
+  let genesis_ledger_hash =
+    Mina_ledger.Ledger.merkle_root ledger |> Frozen_ledger_hash.of_ledger_hash
+  in
+  let base = Mina_state.Snarked_ledger_state.genesis ~genesis_ledger_hash in
+  let source_stack = Pending_coinbase.Stack.empty in
+  let target_stack =
+    Pending_coinbase.Stack.push_state state_body_hash global_slot source_stack
+  in
+  { base with
+    source = { base.source with pending_coinbase_stack = source_stack }
+  ; target = { base.target with pending_coinbase_stack = target_stack }
+  ; connecting_ledger_left = genesis_ledger_hash
+  }
+
+let staged_ledger_hash_of ledger_hash =
+  Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
+    (Staged_ledger_hash.Aux_hash.of_bytes (String.make 32 '\000'))
+    ledger_hash
+    ( Pending_coinbase.create ~depth:constraint_constants.pending_coinbase_depth
+        ()
+    |> Or_error.ok_exn )
+
+let sok_message =
+  Sok_message.create
+    ~fee:(Currency.Fee.of_nanomina_int_exn 1_000_000)
+    ~prover:
+      (Quickcheck.random_value ~seed:(`Deterministic "uptime-service-submitter")
+         Signature_lib.Public_key.Compressed.gen )
+
+let test_terminal_segment_is_stamped () =
+  let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2 in
+  let zkapp_command, ledger = generate_zkapp_command_and_ledger () in
+  let witness, second_pass_ledger =
+    build_witness ~ledger ~zkapp_command ~global_slot
+  in
+  let input = build_input ~ledger ~global_slot in
+  (* The block's staged ledger hash is the ledger the block ends on, which is
+     what makes the last segment of the last transaction the terminal one. *)
+  let staged_ledger_hash =
+    Mina_ledger.Ledger.merkle_root second_pass_ledger
+    |> Frozen_ledger_hash.of_ledger_hash |> staged_ledger_hash_of
+  in
+  let sok_digest = Sok_message.digest sok_message in
+  match
+    Uptime_service.Uptime_snark_worker.extract_terminal_zk_segment
+      ~signature_kind ~constraint_constants ~sok_digest ~witness ~input
+      ~zkapp_command ~staged_ledger_hash
+  with
+  | Error e ->
+      failwithf "could not extract the terminal zkApp segment: %s"
+        (Error.to_string_hum e) ()
+  | Ok (_witness, _spec, (statement : Transaction_snark.Statement.With_sok.t))
+    ->
+      if Sok_message.Digest.equal statement.sok_digest sok_digest then ()
+      else if
+        Sok_message.Digest.equal statement.sok_digest Sok_message.Digest.default
+      then
+        failwith
+          "terminal segment statement still carries \
+           Sok_message.Digest.default; a proof over it would attest to the \
+           empty sok message and be rejected by delegation_verify"
+      else failwith "terminal segment statement carries an unexpected digest"
+
+let () =
+  Alcotest.run "uptime_service"
+    [ ( "zkapp terminal segment"
+      , [ Alcotest.test_case
+            "terminal segment statement carries the submitter's sok digest"
+            `Quick test_terminal_segment_is_stamped
+        ] )
+    ]

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -351,7 +351,11 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
                       in
                       make_interruptible
                       @@ Uptime_snark_worker.perform_partitioned snark_worker
-                           (witness, input, zkapp_command, staged_ledger_hash)
+                           ( message
+                           , witness
+                           , input
+                           , zkapp_command
+                           , staged_ledger_hash )
                   | Ok (`Transaction single_spec) ->
                       make_interruptible
                       @@ Uptime_snark_worker.perform_single snark_worker

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -19,10 +19,13 @@ end
     is a valid proof of the *empty* sok message, which [delegation_verify]
     rejects with "proof's sok message digest does not match the sok message". *)
 let select_terminal_segment ~sok_digest ~staged_ledger_hash segments =
-  ignore (sok_digest : Sok_message.Digest.t) ;
   Mina_stdlib.Nonempty_list.find segments
     ~f:(fun (_, _, (s : Transaction_snark.Statement.With_sok.t)) ->
       Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) )
+  |> Option.map ~f:(fun (witness, spec, statement) ->
+         ( witness
+         , spec
+         , Mina_state.Snarked_ledger_state.Poly.{ statement with sok_digest } ) )
 
 let%test_module "terminal zkapp segment selection" =
   ( module struct

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -8,12 +8,108 @@ open struct
   module Impl = Snark_worker.Impl
 end
 
-let extract_terminal_zk_segment ~(m : (module Transaction_snark.S)) ~witness
-    ~input ~zkapp_command ~staged_ledger_hash =
+(** Pick the segment whose target second-pass ledger is the block's staged
+    ledger hash -- the last segment of the block's last transaction -- and stamp
+    [sok_digest] into its statement.
+
+    The stamping is not optional. Statements produced by
+    [Transaction_snark.zkapp_command_witnesses_exn] carry
+    [Sok_message.Digest.default] as a placeholder, because the witness generator
+    cannot know the fee or the prover. A proof built over an unstamped statement
+    is a valid proof of the *empty* sok message, which [delegation_verify]
+    rejects with "proof's sok message digest does not match the sok message". *)
+let select_terminal_segment ~sok_digest ~staged_ledger_hash segments =
+  ignore (sok_digest : Sok_message.Digest.t) ;
+  Mina_stdlib.Nonempty_list.find segments
+    ~f:(fun (_, _, (s : Transaction_snark.Statement.With_sok.t)) ->
+      Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) )
+
+let%test_module "terminal zkapp segment selection" =
+  ( module struct
+    let hashes =
+      Quickcheck.random_value
+        ~seed:(`Deterministic "uptime-sok-digest-target-hashes")
+        (Quickcheck.Generator.list_with_length 3 Frozen_ledger_hash.gen)
+
+    let statement_with_target target : Transaction_snark.Statement.With_sok.t =
+      let s =
+        Quickcheck.random_value
+          ~seed:(`Deterministic "uptime-sok-digest-statement")
+          Mina_state.Snarked_ledger_state.gen
+      in
+      (* [Sok_message.Digest.default] is exactly what the witness generator
+         emits, so this mirrors the real input to [select_terminal_segment]. *)
+      { s with
+        sok_digest = Sok_message.Digest.default
+      ; target = { s.target with second_pass_ledger = target }
+      }
+
+    let segments =
+      match List.map hashes ~f:(fun h -> ((), (), statement_with_target h)) with
+      | first :: rest ->
+          Mina_stdlib.Nonempty_list.init first rest
+      | [] ->
+          failwith "unreachable: three hashes were generated"
+
+    let message =
+      Sok_message.create
+        ~fee:(Currency.Fee.of_nanomina_int_exn 1_000_000)
+        ~prover:
+          (Quickcheck.random_value
+             ~seed:(`Deterministic "uptime-sok-digest-prover")
+             Signature_lib.Public_key.Compressed.gen )
+
+    (* The terminal segment is the middle one here, so a test that accidentally
+       picked the first or last element would still have to stamp correctly. *)
+    let staged_ledger_hash = List.nth_exn hashes 1
+
+    let%test_unit "selects the segment whose target is the staged ledger hash" =
+      match
+        select_terminal_segment
+          ~sok_digest:(Sok_message.digest message)
+          ~staged_ledger_hash segments
+      with
+      | None ->
+          failwith "no segment matched the staged ledger hash"
+      | Some (_, _, (statement : Transaction_snark.Statement.With_sok.t)) ->
+          if
+            not
+              Ledger_hash.(
+                statement.target.second_pass_ledger = staged_ledger_hash)
+          then failwith "selected a segment with the wrong target hash"
+
+    (* Regression test for the defect reported as mina#19299: the selected
+       segment was returned carrying the placeholder digest, so the resulting
+       proof attested to the empty sok message and every uptime submission for a
+       zkApp-terminal block was rejected by the delegation program. *)
+    let%test_unit "stamps the submitter's sok digest into the terminal segment"
+        =
+      let sok_digest = Sok_message.digest message in
+      match
+        select_terminal_segment ~sok_digest ~staged_ledger_hash segments
+      with
+      | None ->
+          failwith "no segment matched the staged ledger hash"
+      | Some (_, _, (statement : Transaction_snark.Statement.With_sok.t)) ->
+          if Sok_message.Digest.equal statement.sok_digest sok_digest then ()
+          else if
+            Sok_message.Digest.equal statement.sok_digest
+              Sok_message.Digest.default
+          then
+            failwith
+              "terminal segment statement still carries \
+               Sok_message.Digest.default; a proof over it would attest to the \
+               empty sok message and be rejected by delegation_verify"
+          else
+            failwith "terminal segment statement carries an unexpected digest"
+  end )
+
+let extract_terminal_zk_segment ~signature_kind ~constraint_constants
+    ~sok_digest ~witness ~input ~zkapp_command ~staged_ledger_hash =
   let staged_ledger_hash = Staged_ledger_hash.ledger_hash staged_ledger_hash in
   let%bind.Result final_segment =
-    Work_partitioner.Snark_worker_shared.extract_zkapp_segment_works ~m ~input
-      ~witness ~zkapp_command
+    Work_partitioner.Snark_worker_shared.extract_zkapp_segment_works
+      ~signature_kind ~constraint_constants ~input ~witness ~zkapp_command
     |> Result.map_error
          ~f:
            Work_partitioner.Snark_worker_shared.Failed_to_generate_inputs
@@ -21,8 +117,7 @@ let extract_terminal_zk_segment ~(m : (module Transaction_snark.S)) ~witness
     |> Result.map ~f:(function x ->
            Work_partitioner.Snark_worker_shared.Zkapp_command_inputs
            .read_all_proofs_from_disk x
-           |> Mina_stdlib.Nonempty_list.find ~f:(function _, _, s ->
-                  Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) ) )
+           |> select_terminal_segment ~sok_digest ~staged_ledger_hash )
   in
   match final_segment with
   | Some res ->
@@ -45,7 +140,8 @@ module Worker = struct
           F.t
       ; perform_partitioned :
           ( 'w
-          , Transaction_witness.Stable.Latest.t
+          , Sok_message.t
+            * Transaction_witness.Stable.Latest.t
             * Mina_state.Snarked_ledger_state.Stable.Latest.t
             * Zkapp_command.Stable.Latest.t
             * Staged_ledger_hash.t
@@ -77,7 +173,8 @@ module Worker = struct
         Impl.perform_single ~message state single_spec
 
       let perform_partitioned (state : Worker_state.t)
-          (witness, statement, zkapp_command, staged_ledger_hash) =
+          (message, witness, statement, zkapp_command, staged_ledger_hash) =
+        let sok_digest = Sok_message.digest message in
         let zkapp_command =
           Zkapp_command.write_all_proofs_to_disk
             ~signature_kind:state.signature_kind
@@ -86,8 +183,8 @@ module Worker = struct
         match state.proof_level_snark with
         | Full (module S) ->
             let%bind.Deferred.Or_error witness, spec, statement =
-              extract_terminal_zk_segment
-                ~m:(module S)
+              extract_terminal_zk_segment ~signature_kind:state.signature_kind
+                ~constraint_constants:S.constraint_constants ~sok_digest
                 ~witness ~input:statement ~zkapp_command ~staged_ledger_hash
               |> Deferred.return
             in
@@ -128,7 +225,8 @@ module Worker = struct
         ; perform_partitioned =
             f
               ( [%bin_type_class:
-                  Transaction_witness.Stable.Latest.t
+                  Sok_message.Stable.Latest.t
+                  * Transaction_witness.Stable.Latest.t
                   * Mina_state.Snarked_ledger_state.Stable.Latest.t
                   * Zkapp_command.Stable.Latest.t
                   * Staged_ledger_hash.Stable.Latest.t]

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -46,17 +46,18 @@ module Failed_to_generate_inputs = struct
     |> Error.tag ~tag:"failed to generate inputs for zkapp command"
 end
 
-let extract_zkapp_segment_works ~m:(module M : S)
+(* Only [signature_kind] and [constraint_constants] are needed here, so they
+   are taken directly rather than via a [Transaction_snark.S] module. That keeps
+   this callable without compiling a proving circuit, which matters for tests. *)
+let extract_zkapp_segment_works ~signature_kind ~constraint_constants
     ~(input : Mina_state.Snarked_ledger_state.t)
     ~(witness : Transaction_witness.Stable.Latest.t)
     ~(zkapp_command : Zkapp_command.t) :
     (Zkapp_command_inputs.t, Failed_to_generate_inputs.t) Result.t =
   let inputs =
     Or_error.try_with (fun () ->
-        Transaction_snark.zkapp_command_witnesses_exn
-          ~signature_kind:M.signature_kind
-          ~constraint_constants:M.constraint_constants
-          ~global_slot:witness.block_global_slot
+        Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
+          ~constraint_constants ~global_slot:witness.block_global_slot
           ~state_body:witness.protocol_state_body
           ~fee_excess:Currency.Amount.Signed.zero
           [ ( `Pending_coinbase_init_stack witness.init_stack

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -158,8 +158,11 @@ let convert_single_work_from_selector ~(partitioner : t)
       match witness.transaction with
       | Command (Zkapp_command zkapp_command) ->
           let witness = Transaction_witness.read_all_proofs_from_disk witness in
+          let (module M) = partitioner.transaction_snark in
           Snark_worker_shared.extract_zkapp_segment_works
-            ~m:partitioner.transaction_snark ~input ~witness ~zkapp_command
+            ~signature_kind:M.signature_kind
+            ~constraint_constants:M.constraint_constants ~input ~witness
+            ~zkapp_command
           |> Result.map
                ~f:
                  (convert_zkapp_command_from_selector ~partitioner ~job ~pairing)


### PR DESCRIPTION
Fixes #19299.

## Problem

On post-Mesa devnet, every uptime submission carrying SNARK work for a block whose **terminal transaction is a zkApp command** is rejected by `delegation_verify` with:

```
proof's sok message digest does not match the sok message
```

Reproduced against `4.0.0-devnet-mesa` with the reporter's submission; analysis in [#19299 (comment)](https://github.com/MinaProtocol/mina/issues/19299#issuecomment-5473713239).

## Cause

The uptime service has two paths for producing the attached SNARK work (`uptime_service.ml:330-361`):

- terminal tx is a signed command / fee transfer / coinbase → `perform_single (message, spec)`, which stamps the digest. Correct.
- terminal tx is a **zkApp command** → `perform_partitioned (witness, input, zkapp_command, staged_ledger_hash)`. The `message` built at `uptime_service.ml:219-221` was not passed.

That path proved the statement returned by `Transaction_snark.zkapp_command_witnesses_exn`, whose `sok_digest` is `Sok_message.Digest.default` (`transaction_snark.ml:4041`) — the generator cannot know the fee or prover, so it emits a placeholder and relies on the caller to overwrite it. `Snark_worker.Prod` does so on every branch (`prod.ml:59-61`, `:222`, `:361`); the uptime copy did not.

Decoding the failing submission's blob confirms it: at offset 790 there is a bin_prot string of 32 zero bytes in the statement's trailing `sok_digest` field.

The proof itself is valid — `sok_digest` is a public input, not a signature — which is why `delegation_verify` reports `verified: true` beside the error (#19291, fixed by #19296). But it attests to the empty sok message, so the digest check fails.

## Which paths are affected

Only the zkApp-terminal path. Every other way of producing this SNARK work already stamps the digest, which is what makes the omission a local defect rather than a systemic one.

`Snark_worker.Impl.perform_single` derives the digest up front (`prod.ml:234-238`):

```ocaml
let perform_single (...) ~message single_spec =
  let sok_digest = Mina_base.Sok_message.digest message in
```

and every branch below consumes it:

| terminal transaction / spec | stamping site | correct before this PR? |
|---|---|---|
| signed command, fee transfer, coinbase | `prod.ml:222` — `~statement:{ input with sok_digest }` | yes |
| `Merge` | `prod.ml:232` — `M.merge ~sok_digest` | yes |
| `Check` / `No_check` (dummy proof) | `prod.ml:258` — `~statement:{ stmt with sok_digest }` | yes |
| zkApp segment, via `Snark_worker.Prod` | `prod.ml:327` — `~sok_digest`, added by #17578 | yes |
| **zkApp segment, via the uptime worker** | **none — `message` was never passed in** | **no** |

So a submission for a block ending in a payment, fee transfer or coinbase verifies today and is untouched by this change. Only a block whose *last* transaction is a zkApp command reaches the broken path.

## Fix

Thread the `Sok_message.t` through the `perform_partitioned` RPC and stamp the statement before proving, mirroring `Snark_worker.Prod`.

The RPC is served by an `rpc_parallel` subprocess spawned from the same binary, so widening its argument tuple has no cross-version wire implications.

## Scope note

This is the minimal repair. The same defect was found and fixed once before in `Snark_worker.Prod` — #17578, commit `fcd38c5e` — by moving the stamp *into* `log_subzkapp_base_snark` so no caller can omit it. This path bypasses that guard by calling `of_zkapp_command_segment_exn` directly, so the guard did not apply.

The full set of direct callers of that primitive is `prod.ml` (three sites, all guarded), `transaction_snark/test/util.ml`, `zkapp_test_transaction/lib/commands.ml:70`, and this one. The `zkapp_test_transaction` site has the same unstamped shape but wraps the call in `Deferred.ignore_m` — it proves the segment only to check it does not raise and discards the result — so nothing is submitted and the digest there is immaterial. The uptime worker is the only caller that proves work which is then sent somewhere that checks the digest.

A structural follow-up that pushes the obligation into the types, so the omission becomes a compile error, is worth doing separately. It is out of scope here given the mainnet fork timeline.

## Backport

The defective code is contained in tag `3.4.0` onward, not only Mesa — the trigger is zkApp traffic share, not the fork, so it is live but dormant on mainnet today. Worth considering for the Berkeley line as well.

## Testing

Four commits: two failing tests, the fix that turns them green, and the changelog.

| commit | `dune runtest src/lib/uptime_service` |
|---|---|
| `e487e97` unit test | `FAILED 1 / 2 tests` |
| `7d26c43` e2e test | `1 error! in 0.000s. 1 test run.` |
| `c5f247f` fix | `2 tests ran` + `Test Successful`, exit 0 |

Both failures report the cause rather than a bare assertion:

```
terminal segment statement still carries Sok_message.Digest.default; a proof over it
would attest to the empty sok message and be rejected by delegation_verify
```

**Unit test** (`e487e97`) covers `select_terminal_segment`, extracted from
`extract_terminal_zk_segment` — it is where the missing stamping belongs, and being
parametric in the witness and spec components it runs on real statements with dummy
witnesses. A companion case asserts the segment *selection* still works, so the guard is
not vacuous.

**End-to-end test** (`7d26c43`) drives the real `extract_terminal_zk_segment`: it
generates a ledger and a zkApp command that applies against it, applies the transaction
first-pass to get the block's second-pass ledger, builds the `Transaction_witness.t` the
daemon would hand the worker, and asks for the terminal segment by the block's staged
ledger hash — then inspects the statement that would reach the prover.

The fixture is cheap because `Zkapp_command_generators` defaults its verification key to
`Pickles.Side_loaded.Verification_key.dummy` and `zkapp_command_witnesses_exn` only runs
transaction logic, so no circuit is compiled. That is what taking `~signature_kind` and
`~constraint_constants` instead of a whole `Transaction_snark.S` bought; callers in
`prod.ml` and `work_partitioner.ml` are updated accordingly.

`dune build src/lib/snark_worker src/lib/work_partitioner src/lib/uptime_service src/app/cli --profile=devnet` is clean.

**Not covered:** both tests exercise `select_terminal_segment` / `extract_terminal_zk_segment`, which are only reachable when the terminal transaction is a zkApp command — neither would notice a regression on the signed-command path, which is stamped elsewhere (see *Which paths are affected*). And neither test produces a proof — that needs a proving circuit and minutes
of runtime. They pin down that the statement reaching the prover carries the submitter's
digest, which is the defect, but they do not prove a real submission survives
`delegation_verify` end to end. That needs a daemon built from this branch producing a
fresh submission on the rehearsal stack, which I have not run. @SanabriaRusso offered to
run experiments there and it would be the decisive confirmation.

## Open question from the issue

The report observes 546/546 snark-work-bearing submissions failing, with an exact correlation to the presence of snark work.

Per the table above, that correlation is not fully explained by this defect. A signed-command-terminal block should already have verified before this PR. For the observed rate to follow from this bug alone, *every* snark-work-bearing block on that rehearsal stack must have ended in a zkApp command — plausible for a zkApp-heavy load generator, but not established.

@SanabriaRusso — could you check whether any snark-work-bearing submission from a block with a **non-zkApp terminal transaction** also failed? If any did, there is a second cause stacked on top of this one and this PR is only a partial fix.
