### PR TITLE
test(archive): check the pinned candidate block exists before selecting

### DIFF
--- a/src/test/archive/patch_archive_test/patch_archive_test.ml
+++ b/src/test/archive/patch_archive_test/patch_archive_test.ml
@@ -109,6 +109,18 @@ let main ~db_uri ~network_data_folder () =
         else None )
     |> Array.of_list
   in
+
+  let%bind () =
+    if Array.is_empty candidate_blocks then (
+      printf
+        "No extracted block matches state hash %s. The sample database and the \
+         pinned candidate block have drifted apart; pick a new orphan-branch \
+         block to withhold.\n"
+        missing_block_state_hash ;
+      exit 1 )
+    else Deferred.unit
+  in
+
   let missing_blocks =
     Array.slice (knuth_shuffle candidate_blocks) 0 missing_blocks_count
   in


### PR DESCRIPTION
`patch_archive_test` withholds one block from the import and expects
`mina-missing-blocks-guardian` to patch it back. Since #18884 the withheld block
is chosen by matching a hardcoded state hash against the extracted filenames:

```ocaml
let missing_block_state_hash =
  "3NKSqLA8BWMgHHkX4TqkVQjTmHLkXBumBb2aSBS3myzHQGopXC9x"
in
let candidate_blocks =
  List.filter_mapi extensional_files ~f:(fun i file ->
      if String.is_substring file ~substring:missing_block_state_hash then Some i
      else None )
  |> Array.of_list
in
```

That pins the test to the contents of `src/test/archive/sample_db/archive_db.sql`
without checking the coupling. If the fixture is ever regenerated without that
block, `candidate_blocks` is empty and the next line raises a bare
`Invalid_argument` out of `Array.slice`, naming neither the state hash nor the
fixture — leaving whoever hits it to work backwards from an index error.

This adds the missing check, so the failure names its own cause. No behaviour
change while the fixture and the pinned hash agree, which is the case today.

### Testing

`dune build src/test/archive/patch_archive_test/patch_archive_test.exe` is
clean and `ocamlformat --check` passes on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFJphUjAqSwjwRQhNnGEgc