### PR TITLE
Build and cache a portable bundle on the noble apps job

### DIFF
--- a/buildkite/scripts/apps/restore_portable.sh
+++ b/buildkite/scripts/apps/restore_portable.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Restores the portable bundle published by apps/write_portable_to_cache.sh into
+# the current workspace, for a docker or debian job running on a different agent
+# than the build.
+#
+# Usage: restore_portable.sh <codename> [<variant>]
+#   codename : the Debian codename the bundle was built on
+#   variant  : the apps-cache variant, empty for a standard amd64 build
+#
+# Unpacks to $MINA_PORTABLE_ROOT (default _build_portable) in the current
+# directory, replacing anything already there.
+#
+# A missing cache entry is a HARD failure. This is a consumer of the app build:
+# if the bundle is absent, either the build job did not run for this variant or
+# it did not have MINA_BUILD_PORTABLE set, and continuing would produce an
+# artifact silently missing the very thing it is supposed to ship.
+
+set -eo pipefail
+
+CODENAME=$1
+VARIANT=$2
+
+if [[ -z "$CODENAME" ]]; then
+  echo "Usage: $0 <codename> [<variant>]" >&2
+  exit 1
+fi
+
+SRC_DIR="portable/${CODENAME}${VARIANT:+/${VARIANT}}"
+TARBALL="mina-portable.tar.gz"
+PORTABLE_ROOT="${MINA_PORTABLE_ROOT:-_build_portable}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "--- Restoring portable bundle from ${SRC_DIR}"
+if ! ./buildkite/scripts/cache/manager.sh read "${SRC_DIR}/${TARBALL}" "$TMP_DIR"; then
+  echo "restore_portable: ${SRC_DIR}/${TARBALL} not found in cache" >&2
+  echo "restore_portable: the app-build job for ${CODENAME} must run with" >&2
+  echo "  MINA_BUILD_PORTABLE=1 and publish the bundle BEFORE this job." >&2
+  echo "  See buildkite/scripts/apps/write_portable_to_cache.sh." >&2
+  exit 1
+fi
+
+rm -rf "$PORTABLE_ROOT"
+# The tarball carries its own top-level directory name, which is not necessarily
+# the name we want here, so unpack to a staging dir and move the single entry.
+STAGE="${TMP_DIR}/stage"
+mkdir -p "$STAGE"
+tar -xzf "${TMP_DIR}/${TARBALL}" -C "$STAGE"
+
+unpacked="$(find "$STAGE" -mindepth 1 -maxdepth 1 -type d | head -1)"
+if [[ -z "$unpacked" ]]; then
+  echo "restore_portable: tarball contained no directory" >&2
+  exit 1
+fi
+mv "$unpacked" "$PORTABLE_ROOT"
+
+loader_count=$(find "${PORTABLE_ROOT}/lib" -maxdepth 1 -name 'ld-linux*.so*' 2>/dev/null | wc -l)
+if [[ "$loader_count" -eq 0 ]]; then
+  echo "restore_portable: the bundle has no dynamic loader in lib/" >&2
+  echo "  Its wrappers cannot run without one; refusing a broken bundle." >&2
+  exit 1
+fi
+
+echo "restore_portable: restored $(find "${PORTABLE_ROOT}/bin" -type f 2>/dev/null | wc -l) wrappers, \
+$(find "${PORTABLE_ROOT}/lib" -type f 2>/dev/null | wc -l) libraries into ${PORTABLE_ROOT}"

--- a/buildkite/scripts/apps/write_portable_to_cache.sh
+++ b/buildkite/scripts/apps/write_portable_to_cache.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Publishes the portable bundle produced by build-artifact.sh to the CI cache,
+# so a docker or debian job on a DIFFERENT agent can consume it:
+#
+#   portable/<codename>[/<variant>]/mina-portable.tar.gz
+#   portable/<codename>[/<variant>]/closure-report.txt
+#
+# Usage: write_portable_to_cache.sh <codename> [<variant>]
+#
+# The variant follows the apps cache exactly (apps/write_to_cache.sh): empty for
+# a standard amd64 build, otherwise "instrumented", "arm64" or
+# "instrumented-arm64". Same reasoning -- an instrumented build emits binaries
+# with the same names, and sharing a directory would leave whichever job
+# finished last.
+#
+# Unlike the apps cache this stores ONE tarball for the whole tree rather than
+# one per binary. The bundle is a single deduplicated bin/libexec/lib tree whose
+# libraries are shared between binaries; there is no way to hand a consumer one
+# binary out of it without the shared lib directory, so splitting it would only
+# duplicate.
+#
+# Exits 0 doing nothing when there is no bundle. Whether a build produces one is
+# decided by MINA_BUILD_PORTABLE in build-artifact.sh, and this step is present
+# on every apps job, so "no bundle" is the ordinary case for a job that did not
+# opt in -- not an error.
+
+set -eo pipefail
+
+CODENAME=$1
+VARIANT=$2
+
+if [[ -z "$CODENAME" ]]; then
+  echo "Usage: $0 <codename> [<variant>]" >&2
+  exit 1
+fi
+
+PORTABLE_ROOT="${MINA_PORTABLE_ROOT:-_build_portable}"
+
+if [[ ! -d "$PORTABLE_ROOT" ]]; then
+  echo "write_portable_to_cache: no ${PORTABLE_ROOT}, nothing to publish" >&2
+  exit 0
+fi
+
+DEST="portable/${CODENAME}${VARIANT:+/${VARIANT}}"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# -C the parent and name the directory, so the tarball unpacks to a directory
+# rather than spraying bin/ libexec/ lib/ into the consumer's cwd.
+TARBALL="${TMP_DIR}/mina-portable.tar.gz"
+tar -czf "$TARBALL" \
+    -C "$(dirname "$PORTABLE_ROOT")" "$(basename "$PORTABLE_ROOT")"
+
+echo "--- Publishing portable bundle to ${DEST}"
+echo "write_portable_to_cache: $(du -h "$TARBALL" | cut -f1) tarball"
+./buildkite/scripts/cache/manager.sh write-to-dir "$TARBALL" "$DEST"
+
+# The closure report goes up uncompressed as well as inside the tarball, so it
+# can be read straight out of the cache without fetching the whole bundle.
+if [[ -f "${PORTABLE_ROOT}/closure-report.txt" ]]; then
+  ./buildkite/scripts/cache/manager.sh write-to-dir \
+    "${PORTABLE_ROOT}/closure-report.txt" "$DEST"
+fi

--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -122,6 +122,22 @@ if [[ "${MINA_BUILD_PORTABLE:-0}" == "1" ]]; then
       "$portable_bin/$exe_name" "lib" "libexec/$exe_name" "$loader"
   done
 
+  # The closure, written into the bundle so it travels with it. This is the
+  # audit surface: which SONAMEs the artifact set actually needs, answerable
+  # only from a real build.
+  report="$portable_root/closure-report.txt"
+  {
+    echo "# portable bundle closure"
+    echo "# codename=${MINA_DEB_CODENAME:-unknown} arch=$(uname -m) loader=${loader}"
+    echo "# binary<TAB>library"
+    for source_exe in "${source_exes[@]}"; do
+      bundle_report "$source_exe"
+    done | sort -u
+  } > "$report"
+
   echo "Portable bundle: ${#source_exes[@]} binaries, \
 $(find "$portable_lib" -type f | wc -l) libraries, loader $loader"
+  echo "Distinct libraries in the closure: \
+$(grep -vc '^#' "$report" || true) binary/library pairs, \
+$(grep -v '^#' "$report" | cut -f2 | sort -u | wc -l) distinct"
 fi

--- a/buildkite/scripts/bundle-libs.sh
+++ b/buildkite/scripts/bundle-libs.sh
@@ -124,3 +124,21 @@ bundle_missing() {
 
   ldd "$exe" 2>/dev/null | sed -nE 's|^[[:space:]]*([^[:space:]]+) => not found$|\1|p'
 }
+
+# Echo one "<binary><TAB><library>" line per library $exe resolves, for the
+# closure audit. Sorted and deduplicated across the whole bundle this answers
+# "what does the artifact set actually depend on", which is otherwise only
+# knowable by building mina and running ldd by hand.
+#
+# It reports basenames, not paths: the paths are build-image specific and the
+# question is which SONAMEs travel with us.
+bundle_report() {
+  local exe="$1" lib
+  command -v ldd >/dev/null 2>&1 || return 0
+
+  ldd "$exe" 2>/dev/null \
+    | sed -nE 's|.*=> (/[^ ]+) \(0x[0-9a-f]+\)$|\1|p' \
+    | while read -r lib; do
+        printf '%s\t%s\n' "$(basename "$exe")" "$(basename "$lib")"
+      done
+}

--- a/buildkite/scripts/tests/test_portable_cache.sh
+++ b/buildkite/scripts/tests/test_portable_cache.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+set -uo pipefail
+
+# Tests for apps/write_portable_to_cache.sh and apps/restore_portable.sh
+#
+# Usage: bash buildkite/scripts/tests/test_portable_cache.sh
+#
+# Drives the REAL cache manager against a throwaway CACHE_BASE_URL, the same way
+# cache/tests/cache-parity-test.sh does, so this exercises the actual cache
+# layout rather than a stub that could agree with a wrong assumption.
+#
+# The bundle here is synthetic -- a fake loader that echoes its arguments --
+# because what these two scripts are responsible for is the round trip: that a
+# tree written on one agent comes back intact and runnable on another. Whether
+# the bundle's CONTENTS are correct is bundle-libs.sh's job and is covered by
+# test_bundle_libs.sh.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+RUN=0; PASSED=0; FAILED=0; FAILURES=()
+
+check() {
+    local label="$1" expected="$2" actual="$3"
+    RUN=$((RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        PASSED=$((PASSED + 1))
+    else
+        FAILED=$((FAILED + 1))
+        FAILURES+=("${label}: expected '${expected}', got '${actual}'")
+        echo "  FAIL ${label}: expected '${expected}', got '${actual}'" >&2
+    fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# A throwaway cache. Both scripts require Buildkite context, so supply it.
+export CACHE_BASE_URL="${WORK}/cache"
+export BUILDKITE_BUILD_ID="test-build-id"
+mkdir -p "$CACHE_BASE_URL"
+
+# Build a synthetic bundle at $1 with the layout build-artifact.sh produces.
+make_bundle() {
+    local root="$1" with_loader="${2:-yes}"
+    mkdir -p "${root}/bin" "${root}/libexec" "${root}/lib"
+    echo "not a real elf" > "${root}/libexec/mina.exe"
+    echo "libc" > "${root}/lib/libc.so.6"
+    if [[ "$with_loader" == "yes" ]]; then
+        cat > "${root}/lib/ld-linux-x86-64.so.2" <<'LOADER'
+#!/bin/sh
+echo "ran exe=$3 args=$4"
+LOADER
+        chmod 0755 "${root}/lib/ld-linux-x86-64.so.2"
+        # shellcheck source=buildkite/scripts/bundle-libs.sh
+        source ./buildkite/scripts/bundle-libs.sh
+        bundle_write_wrapper "${root}/bin/mina" lib "libexec/mina.exe" \
+            "ld-linux-x86-64.so.2"
+    fi
+    printf '# portable bundle closure\nmina.exe\tlibc.so.6\n' \
+        > "${root}/closure-report.txt"
+}
+
+echo "TEST: a build with no bundle publishes nothing and does not fail"
+export MINA_PORTABLE_ROOT="${WORK}/absent"
+status=0
+./buildkite/scripts/apps/write_portable_to_cache.sh noble >/dev/null 2>&1 || status=$?
+check "exit status" "0" "$status"
+check "nothing written to the cache" "0" \
+    "$(find "$CACHE_BASE_URL" -name 'mina-portable.tar.gz' 2>/dev/null | wc -l)"
+
+echo "TEST: a bundle round-trips through the cache and still runs"
+export MINA_PORTABLE_ROOT="${WORK}/src/_build_portable"
+make_bundle "$MINA_PORTABLE_ROOT"
+status=0
+./buildkite/scripts/apps/write_portable_to_cache.sh noble >/dev/null 2>&1 || status=$?
+check "write exit status" "0" "$status"
+check "tarball is in the cache" "1" \
+    "$(find "$CACHE_BASE_URL" -name 'mina-portable.tar.gz' | wc -l)"
+check "the closure report is beside it, unpacked" "1" \
+    "$(find "$CACHE_BASE_URL" -name 'closure-report.txt' | wc -l)"
+
+# Restore on a "different agent": a fresh directory with no bundle in it.
+dest="${WORK}/consumer"
+mkdir -p "$dest"
+export MINA_PORTABLE_ROOT="${dest}/_build_portable"
+status=0
+./buildkite/scripts/apps/restore_portable.sh noble >/dev/null 2>&1 || status=$?
+check "restore exit status" "0" "$status"
+check "the wrapper came back" "1" \
+    "$([[ -x "${dest}/_build_portable/bin/mina" ]] && echo 1 || echo 0)"
+check "the loader came back" "1" \
+    "$([[ -f "${dest}/_build_portable/lib/ld-linux-x86-64.so.2" ]] && echo 1 || echo 0)"
+check "the real binary came back" "1" \
+    "$([[ -f "${dest}/_build_portable/libexec/mina.exe" ]] && echo 1 || echo 0)"
+
+out="$(cd / && "${dest}/_build_portable/bin/mina" --version 2>&1)"
+check "the restored wrapper runs the restored binary" "1" \
+    "$(echo "$out" | grep -c "exe=${dest}/_build_portable/libexec/mina.exe")"
+check "and forwards arguments" "1" "$(echo "$out" | grep -c 'args=--version')"
+
+echo "TEST: variants do not collide"
+export MINA_PORTABLE_ROOT="${WORK}/src/_build_portable"
+./buildkite/scripts/apps/write_portable_to_cache.sh noble arm64 >/dev/null 2>&1
+check "the variant has its own directory" "1" \
+    "$(find "$CACHE_BASE_URL" -path '*noble/arm64/mina-portable.tar.gz' | wc -l)"
+check "the default is still its own" "1" \
+    "$(find "$CACHE_BASE_URL" -path '*noble/mina-portable.tar.gz' | wc -l)"
+
+echo "TEST: a consumer fails hard when the bundle is absent"
+export MINA_PORTABLE_ROOT="${WORK}/consumer2/_build_portable"
+mkdir -p "${WORK}/consumer2"
+status=0
+msg="$(./buildkite/scripts/apps/restore_portable.sh bookworm 2>&1)" || status=$?
+check "exit status is non-zero" "1" "$([[ "$status" -ne 0 ]] && echo 1 || echo 0)"
+check "it says what must run first" "1" \
+    "$(echo "$msg" | grep -c 'MINA_BUILD_PORTABLE=1')"
+check "it did not leave a partial tree" "0" \
+    "$([[ -d "$MINA_PORTABLE_ROOT" ]] && echo 1 || echo 0)"
+
+echo "TEST: a bundle with no loader is rejected rather than restored"
+export MINA_PORTABLE_ROOT="${WORK}/broken/_build_portable"
+make_bundle "$MINA_PORTABLE_ROOT" no
+./buildkite/scripts/apps/write_portable_to_cache.sh focal >/dev/null 2>&1
+export MINA_PORTABLE_ROOT="${WORK}/consumer3/_build_portable"
+mkdir -p "${WORK}/consumer3"
+status=0
+msg="$(./buildkite/scripts/apps/restore_portable.sh focal 2>&1)" || status=$?
+check "exit status is non-zero" "1" "$([[ "$status" -ne 0 ]] && echo 1 || echo 0)"
+check "it names the missing loader" "1" "$(echo "$msg" | grep -c 'no dynamic loader')"
+
+echo
+echo "Ran ${RUN}, passed ${PASSED}, failed ${FAILED}"
+if [[ "$FAILED" -gt 0 ]]; then
+    printf '%s\n' "${FAILURES[@]}" >&2
+    exit 1
+fi

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -437,6 +437,18 @@ let build_apps
                                                                   spec.debVersion} ${appsSpecVariant
                                                                                        spec}"
 
+          let portableCacheWrite =
+              -- Publishes _build_portable when the build produced one. The
+              -- step is unconditional and the script exits 0 when there is no
+              -- bundle, because whether a build is portable is decided by
+              -- MINA_BUILD_PORTABLE in the job's environment -- there is no
+              -- portable-ness in the types to branch on here, deliberately.
+                    \(spec : AppsSpec.Type)
+                ->  Cmd.run
+                      "./buildkite/scripts/apps/write_portable_to_cache.sh ${DebianVersions.lowerName
+                                                                               spec.debVersion} ${appsSpecVariant
+                                                                                                    spec}"
+
           in  Command.build
                 Command.Config::{
                 , commands =
@@ -454,6 +466,7 @@ let build_apps
                           "./buildkite/scripts/apps/write_build_manifest_to_cache.sh ${DebianVersions.lowerName
                                                                                          spec.debVersion} ${appsSpecTreeVariant
                                                                                                               spec}"
+                      , portableCacheWrite spec
                       ]
                 , label = "Build apps: ${appsLabelSuffix spec}"
                 , key = "build-apps"

--- a/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifactNobleApps.dhall
@@ -12,6 +12,7 @@ in  Pipeline.build
       ( ArtifactPipelines.appsPipeline
           ArtifactPipelines.AppsSpec::{
           , debVersion = DebianVersions.DebVersion.Noble
+          , extraBuildEnvs = [ "MINA_BUILD_PORTABLE=1" ]
           , tags =
             [ PipelineTag.Type.Long
             , PipelineTag.Type.Release

--- a/buildkite/src/Jobs/Test/BundleLibsTest.dhall
+++ b/buildkite/src/Jobs/Test/BundleLibsTest.dhall
@@ -21,6 +21,7 @@ in  Pipeline.build
           [ S.exactly "buildkite/scripts/bundle-libs" "sh"
           , S.strictlyStart (S.contains "buildkite/scripts/tests")
           , S.exactly "buildkite/scripts/build-artifact" "sh"
+          , S.strictlyStart (S.contains "buildkite/scripts/cache")
           , S.strictlyStart (S.contains "buildkite/scripts/apps")
           , S.exactly "buildkite/src/Jobs/Test/BundleLibsTest" "dhall"
           ]
@@ -39,6 +40,15 @@ in  Pipeline.build
               [ Cmd.run "./buildkite/scripts/tests/test_bundle_libs.sh" ]
             , label = "Shared-library bundling tests"
             , key = "bundle-libs-tests"
+            , target = Size.Small
+            , docker = None Docker.Type
+            }
+        , Command.build
+            Command.Config::{
+            , commands =
+              [ Cmd.run "./buildkite/scripts/tests/test_portable_cache.sh" ]
+            , label = "Portable bundle cache round-trip tests"
+            , key = "portable-cache-tests"
             , target = Size.Small
             , docker = None Docker.Type
             }


### PR DESCRIPTION
**Stacked on #19311** — review that first; this PR's diff is only the three
commits on top.

#19311 added a bundler that nothing runs. This turns it on for one build and
carries the result across agents, so the packaging work has something real to
consume.

## Why this is the next step

The two questions blocking everything downstream — what the artifact set's
shared-library closure actually is, and whether a bundled-glibc daemon really
runs — can only be answered from real mina binaries. Both were stuck behind
"build mina by hand and look". This makes CI answer them instead, on the
toolchain the project intends to keep.

## What it does

**Records the closure.** Each bundle now carries a `closure-report.txt`: every
binary/library pair, sorted and deduplicated, with the codename, architecture
and loader it was built with. SONAMEs rather than paths, because the paths are
build-image specific and the question is which libraries travel with us. This
is the audit surface for what a slim base image must provide and what still
needs runtime wiring.

**Publishes the bundle to the CI cache**, so a docker or debian job on another
agent can consume it. One tarball for the whole tree, not one per binary as the
apps cache does: the bundle is a single deduplicated `bin`/`libexec`/`lib` tree
whose libraries are shared between its binaries, so there is no way to hand a
consumer one binary without the shared lib directory — splitting it would only
duplicate. The closure report is stored uncompressed beside it, readable
without fetching the bundle.

The write step is unconditional on every apps job and exits 0 when there is no
bundle, because whether a build is portable is decided by `MINA_BUILD_PORTABLE`
in the job's environment — there is deliberately no portable-ness in the Dhall
types to branch on. Restoring is the opposite: a missing bundle is a hard
failure, never a fallback, because a consumer continuing without it would
produce an artifact silently missing the thing it exists to ship. A bundle
whose `lib/` has no loader is rejected for the same reason — its wrappers
cannot run without one.

**Enables it on the noble apps build.** One line. Every other apps job is
unchanged apart from the publish step that finds no bundle and exits.

## Tests

`test_portable_cache.sh`, added to the existing `BundleLibsTest` job — 18
assertions driving the **real** cache manager against a throwaway
`CACHE_BASE_URL`, the same approach `cache/tests/cache-parity-test.sh` uses, so
it exercises the actual cache layout rather than a stub that could agree with a
wrong assumption. It covers the round trip (a tree written on one agent comes
back runnable on another), that variants do not collide, that a cache miss
fails hard and says what must run first, and that a loaderless bundle is
rejected.

Mutation-checked: removing the loader rejection, treating a cache miss as
success, ignoring the variant, or failing instead of no-opping when there is no
bundle each fails the suite.

The bundle these tests use is synthetic — a fake loader that echoes its
arguments — because the round trip is what these two scripts are responsible
for. Whether the bundle's *contents* are right is `bundle-libs.sh`'s job and is
covered by `test_bundle_libs.sh` in #19311.

## What to look at in the build

This PR's real output is the noble apps job: whether the bundler survives a
full mina build, and what its closure report says. If the build image is
missing runtime packages the bundler cannot work around, this is where it
surfaces — the portable path fails on an unresolvable library rather than
shipping without it.

Still nothing consumes the bundle: no `.deb`, no image, no per-codename job or
toolchain removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYa2oHPyzjvXZU5u3YFwoE
