### PR TITLE
Remove the placeholder sok digest from the zkApp segment wire spec

### DIFF
--- a/changes/19325.md
+++ b/changes/19325.md
@@ -1,0 +1,18 @@
+## Uptime service: fix SNARK work rejected by the Delegation Program
+
+Uptime submissions carrying SNARK work for a block whose last transaction is a zkApp
+command were rejected by `delegation_verify` with `proof's sok message digest does not
+match the sok message`, so those submissions did not count toward Delegation Program
+scoring. Blocks ending in a payment, fee transfer or coinbase were unaffected, as were
+submissions carrying no SNARK work.
+
+## Snark workers: upgrade daemons before workers
+
+The RPC a snark worker uses to fetch work has a new version. A snark worker requests
+exactly the version it was built with and does not negotiate, so **upgrade coordinators
+and daemons before upgrading snark workers**. A daemon on this release still serves
+workers from earlier releases, but a worker from this release cannot get work from an
+earlier daemon and will sit idle until the daemon is upgraded.
+
+Operators running the daemon and its snark workers as one unit, or upgrading everything
+together, need take no action.

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -504,49 +504,61 @@ let setup_local_server ?(client_trustlist = []) ~rest_server_port
           return @@ Itn_logger.log ~process ~timestamp ~message ~metadata () )
     ]
   in
+  (* The snark-worker RPCs are versioned, so they are implemented for every
+     registered version rather than only the newest. A worker dispatches the
+     version it was compiled against and never negotiates down, so a daemon that
+     serves [Stable.Latest] alone leaves pre-upgrade workers stuck in
+     [Snark_worker.Entry]'s retry backoff, getting Unimplemented_rpc forever. *)
+  let implement_versioned name f () ~version:_ query =
+    O1trace.thread ("serve_" ^ name) (fun () -> f query)
+  in
   let snark_worker_impls =
-    [ implement Snark_worker.Rpcs.Get_work.Stable.Latest.rpc (fun () () ->
-          match Mina_lib.request_work mina with
-          | None ->
-              Deferred.return None
-          | Some (Ok spec) ->
-              [%log debug] "responding to a Get_work request with some new work"
-                ~metadata:
-                  [ ( "work_id"
-                    , Snark_work_lib.(
-                        Spec.Partitioned.Poly.get_id spec |> Id.Any.to_yojson )
-                    )
-                  ] ;
+    Snark_worker.Rpcs.Get_work.implement_multi
+      (implement_versioned Snark_worker.Rpcs.Get_work.name (fun () ->
+           match Mina_lib.request_work mina with
+           | None ->
+               Deferred.return None
+           | Some (Ok spec) ->
+               [%log debug]
+                 "responding to a Get_work request with some new work"
+                 ~metadata:
+                   [ ( "work_id"
+                     , Snark_work_lib.(
+                         Spec.Partitioned.Poly.get_id spec |> Id.Any.to_yojson )
+                     )
+                   ] ;
 
-              Mina_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
-              Deferred.return (Some spec)
-          | Some (Error (`Failed_to_generate_inputs (zkapp_cmd, e))) ->
-              let open Mina_base.Zkapp_command in
-              [%log error]
-                "Mina_lib.request_work failed to generate inputs for a zkapp \
-                 command"
-                ~metadata:
-                  [ ("error", `String (Error.to_string_hum e))
-                  ; ( "zkapp_cmd"
-                    , Stable.Latest.to_yojson
-                      @@ read_all_proofs_from_disk zkapp_cmd )
-                  ] ;
-              Deferred.return None )
-    ; implement Snark_worker.Rpcs.Submit_work.Stable.Latest.rpc
-        (fun () (result : Snark_work_lib.Result.Partitioned.Stable.Latest.t) ->
-          [%log debug] "received completed work from a snark worker"
-            ~metadata:[ ("work_id", Snark_work_lib.Id.Any.to_yojson result.id) ] ;
-          Mina_metrics.(
-            Counter.inc_one Snark_work.completed_snark_work_received_rpc ) ;
-          Deferred.return @@ Mina_lib.add_work mina result )
-    ; implement Snark_worker.Rpcs.Failed_to_generate_snark.Stable.Latest.rpc
-        (fun () (error, _) ->
-          [%str_log error]
-            (Snark_worker.Events.Generating_snark_work_failed
-               { error = Error_json.error_to_yojson error } ) ;
-          Mina_metrics.(Counter.inc_one Snark_work.snark_work_failed_rpc) ;
-          Deferred.unit )
-    ]
+               Mina_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
+               Deferred.return (Some spec)
+           | Some (Error (`Failed_to_generate_inputs (zkapp_cmd, e))) ->
+               let open Mina_base.Zkapp_command in
+               [%log error]
+                 "Mina_lib.request_work failed to generate inputs for a zkapp \
+                  command"
+                 ~metadata:
+                   [ ("error", `String (Error.to_string_hum e))
+                   ; ( "zkapp_cmd"
+                     , Stable.Latest.to_yojson
+                       @@ read_all_proofs_from_disk zkapp_cmd )
+                   ] ;
+               Deferred.return None ) )
+    @ Snark_worker.Rpcs.Submit_work.implement_multi
+        (implement_versioned Snark_worker.Rpcs.Submit_work.name
+           (fun (result : Snark_work_lib.Result.Partitioned.Stable.Latest.t) ->
+             [%log debug] "received completed work from a snark worker"
+               ~metadata:
+                 [ ("work_id", Snark_work_lib.Id.Any.to_yojson result.id) ] ;
+             Mina_metrics.(
+               Counter.inc_one Snark_work.completed_snark_work_received_rpc ) ;
+             Deferred.return @@ Mina_lib.add_work mina result ) )
+    @ Snark_worker.Rpcs.Failed_to_generate_snark.implement_multi
+        (implement_versioned Snark_worker.Rpcs.Failed_to_generate_snark.name
+           (fun (error, _) ->
+             [%str_log error]
+               (Snark_worker.Events.Generating_snark_work_failed
+                  { error = Error_json.error_to_yojson error } ) ;
+             Mina_metrics.(Counter.inc_one Snark_work.snark_work_failed_rpc) ;
+             Deferred.unit ) )
   in
   let create_graphql_server_with_auth ~mk_context ?auth_keys ~bind_to_address
       ~schema ~server_description ~require_auth port =

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -56,6 +56,12 @@ let print_witnesses ~constraint_constants ~proof_level witnesses =
   end) in
   Async.Deferred.List.iter ~how:`Sequential (List.rev witnesses)
     ~f:(fun (witness, spec, statement) ->
+      (* A debug dump with no submitter: [zkapp_command_witnesses_exn] returns a
+         sok-less statement, and there is no fee or prover here to stamp with. *)
+      let statement =
+        Mina_state.Snarked_ledger_state.Poly.
+          { statement with sok_digest = Mina_base.Sok_message.Digest.default }
+      in
       printf "%s"
         (sprintf
            !"current witness \

--- a/src/lib/snark_work_lib/partitioned_spec.ml
+++ b/src/lib/snark_work_lib/partitioned_spec.ml
@@ -38,9 +38,9 @@ end
 module Stable = struct
   [@@@no_toplevel_latest_type]
 
-  module V2 = struct
+  module V3 = struct
     type t =
-      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V2.t) Poly.Stable.V1.t
+      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V3.t) Poly.Stable.V1.t
     [@@deriving sexp, yojson]
 
     let to_latest = Fn.id
@@ -49,11 +49,41 @@ module Stable = struct
       | Single { spec; _ } ->
           Single_spec.Poly.statement spec
       | Sub_zkapp_command { spec; _ } ->
-          Sub_zkapp_spec.Stable.Latest.statement spec
+          Sub_zkapp_spec.Stable.V3.statement spec
 
     let sok_message : t -> Mina_base.Sok_message.t = function
       | Single { sok_message; _ } | Sub_zkapp_command { sok_message; _ } ->
           sok_message
+  end
+
+  module V2 = struct
+    type t =
+      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V2.t) Poly.Stable.V1.t
+    [@@deriving sexp, yojson]
+
+    let statement : t -> Transaction_snark.Statement.t = function
+      | Single { spec; _ } ->
+          Single_spec.Poly.statement spec
+      | Sub_zkapp_command { spec; _ } ->
+          Sub_zkapp_spec.Stable.V2.statement spec
+
+    let sok_message : t -> Mina_base.Sok_message.t = function
+      | Single { sok_message; _ } | Sub_zkapp_command { sok_message; _ } ->
+          sok_message
+
+    let to_latest : t -> V3.t =
+      Poly.map ~f_single_spec:Fn.id
+        ~f_subzkapp_spec:Sub_zkapp_spec.Stable.V2.to_latest
+
+    (** Downgrade, for serving a worker that predates V3. The digest an old
+        worker receives is derived from this job's own sok message -- the value
+        it re-derives from on arrival anyway -- rather than the zeros the
+        placeholder used to carry. *)
+    let of_v3 (spec : V3.t) : t =
+      let sok_digest = Poly.sok_message spec |> Mina_base.Sok_message.digest in
+      Poly.map ~f_single_spec:Fn.id
+        ~f_subzkapp_spec:(Sub_zkapp_spec.Stable.V2.of_v3 ~sok_digest)
+        spec
   end
 end]
 

--- a/src/lib/snark_work_lib/partitioned_spec.mli
+++ b/src/lib/snark_work_lib/partitioned_spec.mli
@@ -30,9 +30,9 @@ end
 module Stable : sig
   [@@@no_toplevel_latest_type]
 
-  module V2 : sig
+  module V3 : sig
     type t =
-      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V2.t) Poly.Stable.V1.t
+      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V3.t) Poly.Stable.V1.t
     [@@deriving sexp, yojson]
 
     val to_latest : t -> t
@@ -40,6 +40,22 @@ module Stable : sig
     val statement : t -> Transaction_snark.Statement.t
 
     val sok_message : t -> Mina_base.Sok_message.t
+  end
+
+  module V2 : sig
+    type t =
+      (Single_spec.Stable.V3.t, Sub_zkapp_spec.Stable.V2.t) Poly.Stable.V1.t
+    [@@deriving sexp, yojson]
+
+    val statement : t -> Transaction_snark.Statement.t
+
+    val sok_message : t -> Mina_base.Sok_message.t
+
+    (** Upgrade, for reading a query from a pre-V3 worker. *)
+    val to_latest : t -> V3.t
+
+    (** Downgrade, for serving a pre-V3 worker. *)
+    val of_v3 : V3.t -> t
   end
 end]
 

--- a/src/lib/snark_work_lib/sub_zkapp_spec.ml
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.ml
@@ -1,8 +1,43 @@
 open Core
 
+(* Merging two ledger proofs' statements. Shared by every version, since the
+   [Merge] arm has never differed between them. *)
+let merge_statement_exn proof1 proof2 =
+  let stmt1 = Ledger_proof.statement proof1 in
+  let stmt2 = Ledger_proof.statement proof2 in
+  match Mina_state.Snarked_ledger_state.merge stmt1 stmt2 with
+  | Ok stmt ->
+      stmt
+  | Error e ->
+      failwithf "Failed to construct a statement from zkapp merge command %s"
+        (Error.to_string_hum e) ()
+
 [%%versioned
 module Stable = struct
   [@@@no_toplevel_latest_type]
+
+  module V3 = struct
+    type t =
+      | Segment of
+          { statement : Transaction_snark.Statement.Stable.V2.t
+          ; witness :
+              Transaction_snark.Zkapp_command_segment.Witness.Stable.V2.t
+          ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          }
+      | Merge of
+          { proof1 : Ledger_proof.Stable.V3.t
+          ; proof2 : Ledger_proof.Stable.V3.t
+          }
+    [@@deriving sexp, yojson]
+
+    let statement : t -> Transaction_snark.Statement.t = function
+      | Segment { statement; _ } ->
+          statement
+      | Merge { proof1; proof2; _ } ->
+          merge_statement_exn proof1 proof2
+
+    let to_latest = Fn.id
+  end
 
   module V2 = struct
     type t =
@@ -21,25 +56,45 @@ module Stable = struct
     let statement : t -> Transaction_snark.Statement.t = function
       | Segment { statement; _ } ->
           Mina_state.Snarked_ledger_state.Poly.drop_sok statement
-      | Merge { proof1; proof2; _ } -> (
-          let stmt1 = Ledger_proof.statement proof1 in
-          let stmt2 = Ledger_proof.statement proof2 in
-          let stmt = Mina_state.Snarked_ledger_state.merge stmt1 stmt2 in
-          match stmt with
-          | Ok stmt ->
-              stmt
-          | Error e ->
-              failwithf
-                "Failed to construct a statement from zkapp merge command %s"
-                (Error.to_string_hum e) () )
+      | Merge { proof1; proof2; _ } ->
+          merge_statement_exn proof1 proof2
 
-    let to_latest = Fn.id
+    (** Upgrade. The embedded digest is discarded, not read: it is known to be a
+        placeholder, and the authoritative sok message rides on
+        [With_job_meta.sok_message] alongside. *)
+    let to_latest : t -> V3.t = function
+      | Segment { statement; witness; spec } ->
+          V3.Segment
+            { statement =
+                Mina_state.Snarked_ledger_state.Poly.drop_sok statement
+            ; witness
+            ; spec
+            }
+      | Merge { proof1; proof2 } ->
+          V3.Merge { proof1; proof2 }
+
+    (** Downgrade, for serving a worker that predates V3. [sok_digest] comes
+        from the enclosing job's sok message, so the field an old worker
+        receives is the real digest rather than the zeros it used to get. It
+        re-derives from [sok_message] on arrival regardless, so it never reads
+        this value. *)
+    let of_v3 ~sok_digest : V3.t -> t = function
+      | V3.Segment { statement; witness; spec } ->
+          Segment
+            { statement =
+                Mina_state.Snarked_ledger_state.Poly.
+                  { statement with sok_digest }
+            ; witness
+            ; spec
+            }
+      | V3.Merge { proof1; proof2 } ->
+          Merge { proof1; proof2 }
   end
 end]
 
 type t =
   | Segment of
-      { statement : Transaction_snark.Statement.With_sok.t
+      { statement : Transaction_snark.Statement.t
       ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
       }

--- a/src/lib/snark_work_lib/sub_zkapp_spec.mli
+++ b/src/lib/snark_work_lib/sub_zkapp_spec.mli
@@ -4,6 +4,25 @@ open Core
 module Stable : sig
   [@@@no_toplevel_latest_type]
 
+  module V3 : sig
+    type t =
+      | Segment of
+          { statement : Transaction_snark.Statement.Stable.V2.t
+          ; witness :
+              Transaction_snark.Zkapp_command_segment.Witness.Stable.V2.t
+          ; spec : Transaction_snark.Zkapp_command_segment.Basic.Stable.V1.t
+          }
+      | Merge of
+          { proof1 : Ledger_proof.Stable.V3.t
+          ; proof2 : Ledger_proof.Stable.V3.t
+          }
+    [@@deriving sexp, yojson]
+
+    val statement : t -> Transaction_snark.Statement.t
+
+    val to_latest : t -> t
+  end
+
   module V2 : sig
     type t =
       | Segment of
@@ -20,13 +39,18 @@ module Stable : sig
 
     val statement : t -> Transaction_snark.Statement.t
 
-    val to_latest : t -> t
+    (** Upgrade. Discards the embedded digest, which is a placeholder. *)
+    val to_latest : t -> V3.t
+
+    (** Downgrade, for serving a pre-V3 worker. [sok_digest] should come from
+        the enclosing job's sok message. *)
+    val of_v3 : sok_digest:Mina_base.Sok_message.Digest.t -> V3.t -> t
   end
 end]
 
 type t =
   | Segment of
-      { statement : Transaction_snark.Statement.With_sok.t
+      { statement : Transaction_snark.Statement.t
       ; witness : Transaction_snark.Zkapp_command_segment.Witness.t
       ; spec : Transaction_snark.Zkapp_command_segment.Basic.t
       }

--- a/src/lib/snark_work_lib/test/dune
+++ b/src/lib/snark_work_lib/test/dune
@@ -12,15 +12,11 @@
   sexplib0
   ;; local libraries
   currency
-  genesis_constants
   mina_base
-  mina_generators
   mina_ledger
-  mina_numbers
   mina_state
-  mina_transaction
-  precomputed_values
   signature_lib
   snark_work_lib
   transaction_snark
+  transaction_snark_test_helpers
   transaction_witness))

--- a/src/lib/snark_work_lib/test/dune
+++ b/src/lib/snark_work_lib/test/dune
@@ -1,0 +1,26 @@
+(test
+ (name test_snark_work_lib)
+ (package snark_work_lib)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version))
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  sexplib0
+  ;; local libraries
+  currency
+  genesis_constants
+  mina_base
+  mina_generators
+  mina_ledger
+  mina_numbers
+  mina_state
+  mina_transaction
+  precomputed_values
+  signature_lib
+  snark_work_lib
+  transaction_snark
+  transaction_witness))

--- a/src/lib/snark_work_lib/test/test_snark_work_lib.ml
+++ b/src/lib/snark_work_lib/test/test_snark_work_lib.ml
@@ -14,20 +14,7 @@
 
 open Core
 open Mina_base
-
-let constraint_constants =
-  Genesis_constants.For_unit_tests.Constraint_constants.t
-
-let genesis_constants = Genesis_constants.For_unit_tests.t
-
-let signature_kind = Mina_signature_kind.Testnet
-
-let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2
-
-let protocol_state_body =
-  lazy
-    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
-        .data |> Mina_state.Protocol_state.body )
+module Fixture = Transaction_snark_test_helpers.Zkapp_segment_fixture
 
 let sok_message =
   Sok_message.create
@@ -37,61 +24,33 @@ let sok_message =
          ~seed:(`Deterministic "snark-work-lib-segment-prover")
          Signature_lib.Public_key.Compressed.gen )
 
-(** One real segment. The generator defaults its verification key to
-    [Pickles.Side_loaded.Verification_key.dummy] and
-    [zkapp_command_witnesses_exn] only applies transaction logic, so no proving
-    circuit is compiled here. *)
+(** One real segment. Nothing here proves anything, so no proving circuit is
+    compiled. *)
 let segment =
   lazy
-    (let user_command, _fee_payer_keypair, _keymap, ledger =
-       Quickcheck.random_value
-         ~seed:(`Deterministic "snark-work-lib-zkapp-segment")
-         (Mina_generators.User_command_generators.zkapp_command_with_ledger
-            ~genesis_constants ~constraint_constants () )
-     in
-     let zkapp_command =
-       match user_command with
-       | User_command.Zkapp_command zkapp_command ->
-           Zkapp_command.Valid.forget zkapp_command
-       | User_command.Signed_command _ ->
-           failwith "generator produced a signed command, expected a zkApp one"
-     in
-     let state_body = Lazy.force protocol_state_body in
-     let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
-     let second_pass_ledger =
-       let mask =
-         Mina_ledger.Ledger.Mask.create
-           ~depth:(Mina_ledger.Ledger.depth ledger)
-           ()
-       in
-       let registered = Mina_ledger.Ledger.register_mask ledger mask in
-       let _partial =
-         Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
-           ~constraint_constants ~global_slot
-           ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
-           registered
-           (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
-         |> Or_error.ok_exn
-       in
-       registered
+    (let fixture = Fixture.create ~seed:"snark-work-lib-zkapp-segment" in
+     let state_body_hash =
+       Mina_state.Protocol_state.Body.hash fixture.state_body
      in
      let witness, spec, statement =
-       Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
-         ~constraint_constants ~global_slot ~state_body
+       Transaction_snark.zkapp_command_witnesses_exn
+         ~signature_kind:Fixture.signature_kind
+         ~constraint_constants:Fixture.constraint_constants
+         ~global_slot:fixture.global_slot ~state_body:fixture.state_body
          ~fee_excess:Currency.Amount.Signed.zero
          [ ( `Pending_coinbase_init_stack Pending_coinbase.Stack.empty
            , `Pending_coinbase_of_statement
                { Transaction_snark.Pending_coinbase_stack_state.source =
                    Pending_coinbase.Stack.empty
                ; target =
-                   Pending_coinbase.Stack.push_state state_body_hash global_slot
-                     Pending_coinbase.Stack.empty
+                   Pending_coinbase.Stack.push_state state_body_hash
+                     fixture.global_slot Pending_coinbase.Stack.empty
                }
-           , `Ledger ledger
-           , `Ledger second_pass_ledger
+           , `Ledger fixture.first_pass_ledger
+           , `Ledger fixture.second_pass_ledger
            , `Connecting_ledger_hash
-               (Mina_ledger.Ledger.merkle_root second_pass_ledger)
-           , zkapp_command )
+               (Mina_ledger.Ledger.merkle_root fixture.second_pass_ledger)
+           , fixture.zkapp_command )
          ]
        |> List.hd_exn
      in

--- a/src/lib/snark_work_lib/test/test_snark_work_lib.ml
+++ b/src/lib/snark_work_lib/test/test_snark_work_lib.ml
@@ -1,0 +1,187 @@
+(** Wire round-trip for the zkApp segment spec across the V2/V3 boundary.
+
+    [Sub_zkapp_spec.V3] carries a sok-less [Statement.t], matching what
+    [Single_spec] has always done; V2 carried a [Statement.With_sok.t] whose
+    digest was a placeholder sitting next to the authoritative one in
+    [With_job_meta.sok_message]. A daemon serving a worker built before V3 has
+    to convert, so both directions must be total and lossless in the sense that
+    matters:
+
+    - downgrade fills the segment's sok field from the job's own sok message, so
+      an old worker sees the real digest rather than 32 zero bytes;
+    - upgrade drops that field, which is exactly what the old
+      [Sub_zkapp_spec.statement] did before returning. *)
+
+open Core
+open Mina_base
+
+let constraint_constants =
+  Genesis_constants.For_unit_tests.Constraint_constants.t
+
+let genesis_constants = Genesis_constants.For_unit_tests.t
+
+let signature_kind = Mina_signature_kind.Testnet
+
+let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2
+
+let protocol_state_body =
+  lazy
+    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
+        .data |> Mina_state.Protocol_state.body )
+
+let sok_message =
+  Sok_message.create
+    ~fee:(Currency.Fee.of_nanomina_int_exn 1_000_000)
+    ~prover:
+      (Quickcheck.random_value
+         ~seed:(`Deterministic "snark-work-lib-segment-prover")
+         Signature_lib.Public_key.Compressed.gen )
+
+(** One real segment. The generator defaults its verification key to
+    [Pickles.Side_loaded.Verification_key.dummy] and
+    [zkapp_command_witnesses_exn] only applies transaction logic, so no proving
+    circuit is compiled here. *)
+let segment =
+  lazy
+    (let user_command, _fee_payer_keypair, _keymap, ledger =
+       Quickcheck.random_value
+         ~seed:(`Deterministic "snark-work-lib-zkapp-segment")
+         (Mina_generators.User_command_generators.zkapp_command_with_ledger
+            ~genesis_constants ~constraint_constants () )
+     in
+     let zkapp_command =
+       match user_command with
+       | User_command.Zkapp_command zkapp_command ->
+           Zkapp_command.Valid.forget zkapp_command
+       | User_command.Signed_command _ ->
+           failwith "generator produced a signed command, expected a zkApp one"
+     in
+     let state_body = Lazy.force protocol_state_body in
+     let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
+     let second_pass_ledger =
+       let mask =
+         Mina_ledger.Ledger.Mask.create
+           ~depth:(Mina_ledger.Ledger.depth ledger)
+           ()
+       in
+       let registered = Mina_ledger.Ledger.register_mask ledger mask in
+       let _partial =
+         Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+           ~constraint_constants ~global_slot
+           ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
+           registered
+           (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
+         |> Or_error.ok_exn
+       in
+       registered
+     in
+     let witness, spec, statement =
+       Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
+         ~constraint_constants ~global_slot ~state_body
+         ~fee_excess:Currency.Amount.Signed.zero
+         [ ( `Pending_coinbase_init_stack Pending_coinbase.Stack.empty
+           , `Pending_coinbase_of_statement
+               { Transaction_snark.Pending_coinbase_stack_state.source =
+                   Pending_coinbase.Stack.empty
+               ; target =
+                   Pending_coinbase.Stack.push_state state_body_hash global_slot
+                     Pending_coinbase.Stack.empty
+               }
+           , `Ledger ledger
+           , `Ledger second_pass_ledger
+           , `Connecting_ledger_hash
+               (Mina_ledger.Ledger.merkle_root second_pass_ledger)
+           , zkapp_command )
+         ]
+       |> List.hd_exn
+     in
+     ( Transaction_witness.Zkapp_command_segment_witness
+       .read_all_proofs_from_disk witness
+     , spec
+     , statement ) )
+
+let job_id : Snark_work_lib.Id.Sub_zkapp.Stable.V1.t =
+  { which_one = `One; pairing_id = 1L; range = { first = 0; last = 0 } }
+
+let v3_spec () : Snark_work_lib.Spec.Partitioned.Stable.V3.t =
+  let witness, spec, statement = Lazy.force segment in
+  Sub_zkapp_command
+    { spec =
+        Snark_work_lib.Spec.Sub_zkapp.Stable.V3.Segment
+          { statement; witness; spec }
+    ; job_id
+    ; sok_message
+    }
+
+let segment_statement_v2 (spec : Snark_work_lib.Spec.Partitioned.Stable.V2.t) =
+  match spec with
+  | Sub_zkapp_command
+      { spec = Snark_work_lib.Spec.Sub_zkapp.Stable.V2.Segment { statement; _ }
+      ; _
+      } ->
+      statement
+  | _ ->
+      failwith "expected a zkApp segment spec"
+
+let segment_statement_v3 (spec : Snark_work_lib.Spec.Partitioned.Stable.V3.t) =
+  match spec with
+  | Sub_zkapp_command
+      { spec = Snark_work_lib.Spec.Sub_zkapp.Stable.V3.Segment { statement; _ }
+      ; _
+      } ->
+      statement
+  | _ ->
+      failwith "expected a zkApp segment spec"
+
+(* The value the placeholder used to carry, and the value an old worker must no
+   longer receive. *)
+let test_downgrade_stamps_the_jobs_digest () =
+  let statement =
+    v3_spec () |> Snark_work_lib.Spec.Partitioned.Stable.V2.of_v3
+    |> segment_statement_v2
+  in
+  let expected = Sok_message.digest sok_message in
+  if Sok_message.Digest.equal statement.sok_digest Sok_message.Digest.default
+  then
+    Alcotest.fail
+      "downgraded segment carries Sok_message.Digest.default; a pre-V3 worker \
+       would be served the placeholder this change exists to remove"
+  else if not (Sok_message.Digest.equal statement.sok_digest expected) then
+    Alcotest.fail
+      "downgraded segment carries a digest other than the job's sok message"
+
+let test_downgrade_preserves_the_statement () =
+  let v3 = v3_spec () in
+  let downgraded =
+    Snark_work_lib.Spec.Partitioned.Stable.V2.of_v3 v3 |> segment_statement_v2
+  in
+  Alcotest.(check bool)
+    "statement is unchanged modulo the sok field" true
+    (Transaction_snark.Statement.equal
+       (Mina_state.Snarked_ledger_state.Poly.drop_sok downgraded)
+       (segment_statement_v3 v3) )
+
+let test_round_trip_is_the_identity () =
+  let v3 = v3_spec () in
+  let round_tripped =
+    Snark_work_lib.Spec.Partitioned.Stable.V2.of_v3 v3
+    |> Snark_work_lib.Spec.Partitioned.Stable.V2.to_latest
+  in
+  let sexp_of = Snark_work_lib.Spec.Partitioned.Stable.V3.sexp_of_t in
+  Alcotest.(check bool)
+    "V3 -> V2 -> V3 returns the spec unchanged, witness and segment spec \
+     included"
+    true
+    (Sexp.equal (sexp_of v3) (sexp_of round_tripped))
+
+let () =
+  Alcotest.run "snark_work_lib"
+    [ ( "zkapp segment spec wire round trip"
+      , [ Alcotest.test_case "downgrade stamps the job's sok digest" `Quick
+            test_downgrade_stamps_the_jobs_digest
+        ; Alcotest.test_case "downgrade preserves the statement" `Quick
+            test_downgrade_preserves_the_statement
+        ; Alcotest.test_case "V3 -> V2 -> V3 is the identity" `Quick
+            test_round_trip_is_the_identity
+        ] )
+    ]

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -146,7 +146,8 @@ module Impl = struct
         match w.transaction with
         | Command (Zkapp_command zkapp_command) -> (
             let%bind witnesses_specs_stmts =
-              extract_zkapp_segment_works ~m ~input ~witness:w
+              extract_zkapp_segment_works ~signature_kind
+                ~constraint_constants:M.constraint_constants ~input ~witness:w
                 ~zkapp_command:
                   (Zkapp_command.write_all_proofs_to_disk ~signature_kind
                      ~proof_cache_db zkapp_command )

--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -48,6 +48,10 @@ module Stable = struct
      from the job's own sok message, and the upgrade drops a field that is known
      to be a placeholder.
 
+     Retaining a version only helps if the daemon actually serves it: the RPC
+     server must implement this with [implement_multi], not [Rpc.Rpc.implement]
+     on a pinned [Stable.Latest.rpc]. See [Mina_run.setup_local_server].
+
      Note that a worker does not negotiate: [entry.ml] dispatches a pinned
      [Stable.Latest.rpc]. So this buys daemon-newer-than-worker only. A V5
      worker against a V4-only daemon still fails to get work, and daemons must

--- a/src/lib/snark_worker/rpc_get_work.ml
+++ b/src/lib/snark_worker/rpc_get_work.ml
@@ -24,11 +24,11 @@ include Versioned_rpc.Both_convert.Plain.Make (Master)
 
 [%%versioned_rpc
 module Stable = struct
-  module V4 = struct
+  module V5 = struct
     module T = struct
       type query = unit
 
-      type response = Spec.Partitioned.Stable.V2.t option
+      type response = Spec.Partitioned.Stable.V3.t option
 
       let query_of_caller_model = Fn.id
 
@@ -43,5 +43,35 @@ module Stable = struct
     include Register (T)
   end
 
-  module Latest = V4
+  (* Retained so a daemon can serve snark workers built before V3 of the spec.
+     Both conversions are total: the downgrade fills the segment's sok field
+     from the job's own sok message, and the upgrade drops a field that is known
+     to be a placeholder.
+
+     Note that a worker does not negotiate: [entry.ml] dispatches a pinned
+     [Stable.Latest.rpc]. So this buys daemon-newer-than-worker only. A V5
+     worker against a V4-only daemon still fails to get work, and daemons must
+     be upgraded before workers. *)
+  module V4 = struct
+    module T = struct
+      type query = unit
+
+      type response = Spec.Partitioned.Stable.V2.t option
+
+      let query_of_caller_model = Fn.id
+
+      let callee_model_of_query = Fn.id
+
+      let response_of_callee_model =
+        Option.map ~f:Spec.Partitioned.Stable.V2.of_v3
+
+      let caller_model_of_response =
+        Option.map ~f:Spec.Partitioned.Stable.V2.to_latest
+    end
+
+    include T
+    include Register (T)
+  end
+
+  module Latest = V5
 end]

--- a/src/lib/transaction_snark/test/helpers/dune
+++ b/src/lib/transaction_snark/test/helpers/dune
@@ -1,0 +1,20 @@
+(library
+ (name transaction_snark_test_helpers)
+ (libraries
+  ;; opam libraries
+  core
+  core_kernel
+  ;; local libraries
+  genesis_constants
+  mina_base
+  mina_generators
+  mina_ledger
+  mina_numbers
+  mina_state
+  mina_transaction_logic
+  mina_transaction
+  precomputed_values)
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/lib/transaction_snark/test/helpers/zkapp_segment_fixture.ml
+++ b/src/lib/transaction_snark/test/helpers/zkapp_segment_fixture.ml
@@ -1,0 +1,92 @@
+(** A real ledger and a zkApp command that applies cleanly against it, with the
+    transaction passes applied the way a block producer applies them.
+
+    Shared by the tests in [snark_work_lib] and [uptime_service]: both need
+    genuine zkApp segment witnesses, and both need the ledgers those witnesses
+    are taken from. The generator defaults its verification key to
+    [Pickles.Side_loaded.Verification_key.dummy] and nothing here proves
+    anything, so no proving circuit is compiled. *)
+
+open Core
+open Mina_base
+
+let constraint_constants =
+  Genesis_constants.For_unit_tests.Constraint_constants.t
+
+let genesis_constants = Genesis_constants.For_unit_tests.t
+
+let signature_kind = Mina_signature_kind.Testnet
+
+let protocol_state_body =
+  lazy
+    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
+        .data |> Mina_state.Protocol_state.body )
+
+type t =
+  { zkapp_command : Zkapp_command.t
+  ; global_slot : Mina_numbers.Global_slot_since_genesis.t
+  ; state_body : Mina_state.Protocol_state.Body.Value.t
+  ; first_pass_ledger : Mina_ledger.Ledger.t
+        (** The generated ledger, untouched: the ledger the first pass starts
+            from. *)
+  ; second_pass_ledger : Mina_ledger.Ledger.t
+        (** A mask over [first_pass_ledger] carrying the first pass only, so
+            the ledger the second pass starts from until
+            [finish_second_pass] is called. *)
+  ; partially_applied : Mina_ledger.Ledger.Transaction_partially_applied.t
+  }
+
+let transaction (t : t) : Mina_transaction.Transaction.t =
+  Command (Zkapp_command t.zkapp_command)
+
+let create ~seed =
+  let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2 in
+  let user_command, _fee_payer_keypair, _keymap, first_pass_ledger =
+    Quickcheck.random_value ~seed:(`Deterministic seed)
+      (Mina_generators.User_command_generators.zkapp_command_with_ledger
+         ~genesis_constants ~constraint_constants () )
+  in
+  let zkapp_command =
+    match user_command with
+    | User_command.Zkapp_command zkapp_command ->
+        Zkapp_command.Valid.forget zkapp_command
+    | User_command.Signed_command _ ->
+        failwith "generator produced a signed command, expected a zkApp command"
+  in
+  let state_body = Lazy.force protocol_state_body in
+  let second_pass_ledger =
+    Mina_ledger.Ledger.register_mask first_pass_ledger
+      (Mina_ledger.Ledger.Mask.create
+         ~depth:(Mina_ledger.Ledger.depth first_pass_ledger)
+         () )
+  in
+  let partially_applied =
+    Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+      ~constraint_constants ~global_slot
+      ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
+      second_pass_ledger
+      (Mina_transaction.Transaction.Command
+         (User_command.Zkapp_command zkapp_command) )
+    |> Or_error.ok_exn
+  in
+  { zkapp_command
+  ; global_slot
+  ; state_body
+  ; first_pass_ledger
+  ; second_pass_ledger
+  ; partially_applied
+  }
+
+(** Apply the second pass to [second_pass_ledger], leaving it on the ledger the
+    block ends on, and return that ledger's root.
+
+    Any sparse-ledger witness of the second pass has to be taken *before*
+    calling this, since the witness records the ledger that pass starts from.
+    [Staged_ledger] snapshots it in the same order. *)
+let finish_second_pass (t : t) =
+  let (_ : Mina_transaction_logic.Transaction_applied.t) =
+    Mina_ledger.Ledger.apply_transaction_second_pass t.second_pass_ledger
+      t.partially_applied
+    |> Or_error.ok_exn
+  in
+  Mina_ledger.Ledger.merkle_root t.second_pass_ledger

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -245,11 +245,21 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                       | (witness, spec, stmt) :: rest ->
                           let open Async.Deferred.Or_error.Let_syntax in
                           let start = Time_float.now () in
+                          (* [zkapp_command_witnesses_exn] returns sok-less
+                             statements; these tests assert on the transition,
+                             not on any submitter, so stamp the empty digest
+                             explicitly. *)
+                          let with_sok stmt =
+                            Mina_state.Snarked_ledger_state.Poly.
+                              { stmt with
+                                sok_digest = Sok_message.Digest.default
+                              }
+                          in
                           let%bind p1 =
                             Async.Deferred.Or_error.try_with ~here:[%here]
                               (fun () ->
-                                T.of_zkapp_command_segment_exn ~statement:stmt
-                                  ~witness ~spec )
+                                T.of_zkapp_command_segment_exn
+                                  ~statement:(with_sok stmt) ~witness ~spec )
                           in
                           let%map result =
                             Async.Deferred.List.fold ~init:(Ok p1) rest
@@ -259,7 +269,8 @@ let check_zkapp_command_with_merges_exn ?(logger = logger_null)
                                   Async.Deferred.Or_error.try_with ~here:[%here]
                                     (fun () ->
                                       T.of_zkapp_command_segment_exn
-                                        ~statement:stmt ~witness ~spec )
+                                        ~statement:(with_sok stmt) ~witness
+                                        ~spec )
                                 in
                                 let sok_digest =
                                   Sok_message.create ~fee:Fee.zero

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3999,7 +3999,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           |> Option.value_map ~default:Call_stack_digest.empty
                ~f:With_stack_hash.stack_hash
         in
-        let statement : Statement.With_sok.t =
+        let statement : Statement.t =
           let target_first_pass_ledger_root =
             Sparse_ledger.merkle_root target_global.first_pass_ledger
           in
@@ -4038,7 +4038,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ; connecting_ledger_right = connecting_ledger
           ; supply_increase
           ; fee_excess
-          ; sok_digest = Sok_message.Digest.default
+          ; sok_digest = ()
           }
         in
         (w, spec, statement) :: witnesses )

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -259,7 +259,9 @@ module type Full = sig
       * the witness information for the segment, to be passed to the prover
       * the segment kind, identifying the type of proof that will be generated
       * the proof statement, describing the transition between the states before
-      and after the segment
+      and after the segment. It carries no sok digest: this function knows
+      neither the fee nor the prover, so the caller must stamp one from its own
+      [Sok_message.t] before handing the statement to a prover.
       * the list of calculated 'snapp statements', corresponding to the expected
       public input of any snapp zkapp_command in the current segment.
 
@@ -285,7 +287,7 @@ module type Full = sig
        list
     -> ( Zkapp_command_segment.Witness.t
        * Zkapp_command_segment.Basic.t
-       * Statement.With_sok.t )
+       * Statement.t )
        list
 
   module Make (Inputs : sig

--- a/src/lib/uptime_service/test/dune
+++ b/src/lib/uptime_service/test/dune
@@ -1,0 +1,27 @@
+(test
+ (name test_uptime_service)
+ (package uptime_service)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version))
+ (libraries
+  ;; opam libraries
+  alcotest
+  alcotest-async
+  async
+  core
+  core_kernel
+  ;; local libraries
+  currency
+  genesis_constants
+  mina_base
+  mina_generators
+  mina_ledger
+  mina_state
+  mina_transaction
+  precomputed_values
+  signature_lib
+  transaction_snark
+  transaction_witness
+  uptime_service))

--- a/src/lib/uptime_service/test/dune
+++ b/src/lib/uptime_service/test/dune
@@ -8,20 +8,14 @@
  (libraries
   ;; opam libraries
   alcotest
-  alcotest-async
-  async
   core
-  core_kernel
   ;; local libraries
   currency
-  genesis_constants
   mina_base
-  mina_generators
   mina_ledger
   mina_state
-  mina_transaction
-  precomputed_values
   signature_lib
   transaction_snark
+  transaction_snark_test_helpers
   transaction_witness
   uptime_service))

--- a/src/lib/uptime_service/test/test_uptime_service.ml
+++ b/src/lib/uptime_service/test/test_uptime_service.ml
@@ -17,86 +17,45 @@
     [delegation_verify]. *)
 
 open Core
-open Async
 open Mina_base
+module Fixture = Transaction_snark_test_helpers.Zkapp_segment_fixture
 
-let constraint_constants =
-  Genesis_constants.For_unit_tests.Constraint_constants.t
-
-let genesis_constants = Genesis_constants.For_unit_tests.t
-
-let signature_kind = Mina_signature_kind.Testnet
-
-let protocol_state_body =
-  lazy
-    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
-        .data |> Mina_state.Protocol_state.body )
-
-(** A ledger plus a zkApp command that applies cleanly against it. The generator
-    defaults its verification key to [Pickles.Side_loaded.Verification_key.dummy],
-    so no proving circuit is compiled here. *)
-let generate_zkapp_command_and_ledger () =
-  let user_command, _fee_payer_keypair, _keymap, ledger =
-    Quickcheck.random_value
-      ~seed:(`Deterministic "uptime-service-zkapp-terminal-segment")
-      (Mina_generators.User_command_generators.zkapp_command_with_ledger
-         ~genesis_constants ~constraint_constants () )
+(** Mirrors what the daemon hands the uptime snark worker: both sparse ledgers
+    are snapshotted before the second pass runs, since the witness records the
+    ledgers each pass starts from. *)
+let build_witness (fixture : Fixture.t) =
+  let accounts_referenced =
+    Zkapp_command.accounts_referenced fixture.zkapp_command
   in
-  match user_command with
-  | User_command.Zkapp_command zkapp_command ->
-      (Zkapp_command.Valid.forget zkapp_command, ledger)
-  | User_command.Signed_command _ ->
-      failwith "generator produced a signed command, expected a zkApp command"
-
-(** Mirrors what the daemon hands the uptime snark worker: the transaction is
-    applied first-pass against a mask, and the resulting ledgers become the
-    witness's sparse ledgers. *)
-let build_witness ~ledger ~zkapp_command ~global_slot =
-  let state_body = Lazy.force protocol_state_body in
-  let second_pass_ledger =
-    let mask =
-      Mina_ledger.Ledger.Mask.create ~depth:(Mina_ledger.Ledger.depth ledger) ()
-    in
-    let registered = Mina_ledger.Ledger.register_mask ledger mask in
-    let _partial =
-      Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
-        ~constraint_constants ~global_slot
-        ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
-        registered
-        (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
-      |> Or_error.ok_exn
-    in
-    registered
-  in
-  let accounts_referenced = Zkapp_command.accounts_referenced zkapp_command in
   let sparse_of l =
     Mina_ledger.Sparse_ledger.of_ledger_subset_exn l accounts_referenced
   in
-  ( Transaction_witness.read_all_proofs_from_disk
-      { Transaction_witness.transaction =
-          Mina_transaction.Transaction.Command (Zkapp_command zkapp_command)
-      ; first_pass_ledger = sparse_of ledger
-      ; second_pass_ledger = sparse_of second_pass_ledger
-      ; protocol_state_body = state_body
-      ; init_stack = Pending_coinbase.Stack.empty
-      ; status = Mina_base.Transaction_status.Applied
-      ; block_global_slot = global_slot
-      }
-  , second_pass_ledger )
+  Transaction_witness.read_all_proofs_from_disk
+    { Transaction_witness.transaction = Fixture.transaction fixture
+    ; first_pass_ledger = sparse_of fixture.first_pass_ledger
+    ; second_pass_ledger = sparse_of fixture.second_pass_ledger
+    ; protocol_state_body = fixture.state_body
+    ; init_stack = Pending_coinbase.Stack.empty
+    ; status = Mina_base.Transaction_status.Applied
+    ; block_global_slot = fixture.global_slot
+    }
 
 (** Only [source.pending_coinbase_stack], [target.pending_coinbase_stack] and
     [connecting_ledger_left] are read out of this by the extraction path, so the
     remaining fields are left at their genesis values. *)
-let build_input ~ledger ~global_slot =
-  let state_body = Lazy.force protocol_state_body in
-  let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
+let build_input (fixture : Fixture.t) =
+  let state_body_hash =
+    Mina_state.Protocol_state.Body.hash fixture.state_body
+  in
   let genesis_ledger_hash =
-    Mina_ledger.Ledger.merkle_root ledger |> Frozen_ledger_hash.of_ledger_hash
+    Mina_ledger.Ledger.merkle_root fixture.first_pass_ledger
+    |> Frozen_ledger_hash.of_ledger_hash
   in
   let base = Mina_state.Snarked_ledger_state.genesis ~genesis_ledger_hash in
   let source_stack = Pending_coinbase.Stack.empty in
   let target_stack =
-    Pending_coinbase.Stack.push_state state_body_hash global_slot source_stack
+    Pending_coinbase.Stack.push_state state_body_hash fixture.global_slot
+      source_stack
   in
   { base with
     source = { base.source with pending_coinbase_stack = source_stack }
@@ -108,8 +67,8 @@ let staged_ledger_hash_of ledger_hash =
   Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
     (Staged_ledger_hash.Aux_hash.of_bytes (String.make 32 '\000'))
     ledger_hash
-    ( Pending_coinbase.create ~depth:constraint_constants.pending_coinbase_depth
-        ()
+    ( Pending_coinbase.create
+        ~depth:Fixture.constraint_constants.pending_coinbase_depth ()
     |> Or_error.ok_exn )
 
 let sok_message =
@@ -120,23 +79,40 @@ let sok_message =
          Signature_lib.Public_key.Compressed.gen )
 
 let test_terminal_segment_is_stamped () =
-  let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2 in
-  let zkapp_command, ledger = generate_zkapp_command_and_ledger () in
-  let witness, second_pass_ledger =
-    build_witness ~ledger ~zkapp_command ~global_slot
-  in
-  let input = build_input ~ledger ~global_slot in
+  let fixture = Fixture.create ~seed:"uptime-service-zkapp-terminal-segment" in
+  let witness = build_witness fixture in
+  let input = build_input fixture in
   (* The block's staged ledger hash is the ledger the block ends on, which is
-     what makes the last segment of the last transaction the terminal one. *)
+     what makes the last segment of the last transaction the terminal one. That
+     is the root *after* the second pass, not the first-pass root: every
+     first-pass segment statement carries the untouched second-pass ledger as
+     its target, so selecting on the first-pass root would match the fee-payer
+     segment and never exercise terminal selection at all. *)
+  let first_pass_root =
+    Mina_ledger.Ledger.merkle_root fixture.second_pass_ledger
+  in
   let staged_ledger_hash =
-    Mina_ledger.Ledger.merkle_root second_pass_ledger
+    Fixture.finish_second_pass fixture
     |> Frozen_ledger_hash.of_ledger_hash |> staged_ledger_hash_of
   in
+  (* Guards the point above: if this command's second pass happened to leave the
+     root alone, the hash below would not distinguish the terminal segment from
+     the fee-payer one and the assertion would prove nothing. *)
+  if
+    Ledger_hash.equal first_pass_root
+      (Staged_ledger_hash.ledger_hash staged_ledger_hash)
+  then
+    failwith
+      "the generated zkApp command's second pass left the ledger root \
+       unchanged, so the terminal segment is not distinguishable by target \
+       hash; pick a different generator seed"
+  else () ;
   let sok_digest = Sok_message.digest sok_message in
   match
     Uptime_service.Uptime_snark_worker.extract_terminal_zk_segment
-      ~signature_kind ~constraint_constants ~sok_digest ~witness ~input
-      ~zkapp_command ~staged_ledger_hash
+      ~signature_kind:Fixture.signature_kind
+      ~constraint_constants:Fixture.constraint_constants ~sok_digest ~witness
+      ~input ~zkapp_command:fixture.zkapp_command ~staged_ledger_hash
   with
   | Error e ->
       failwithf "could not extract the terminal zkApp segment: %s"

--- a/src/lib/uptime_service/test/test_uptime_service.ml
+++ b/src/lib/uptime_service/test/test_uptime_service.ml
@@ -1,0 +1,163 @@
+(** End-to-end test for the SNARK work the uptime service attaches to a
+    submission when the block's terminal transaction is a zkApp command.
+
+    This drives the real production function,
+    [Uptime_service.Uptime_snark_worker.extract_terminal_zk_segment], over a
+    real generated ledger and zkApp command: the transaction is applied, real
+    segment witnesses are produced by
+    [Transaction_snark.zkapp_command_witnesses_exn], the terminal segment is
+    located by its target staged ledger hash, and the statement that would be
+    handed to the prover is inspected.
+
+    It stops short of producing a proof — that needs a proving circuit and
+    minutes of runtime — so what it pins down is that the statement reaching the
+    prover carries the submitter's sok digest rather than the placeholder. That
+    is the defect reported as mina#19299: the placeholder survived, and every
+    resulting proof attested to the empty sok message and was rejected by
+    [delegation_verify]. *)
+
+open Core
+open Async
+open Mina_base
+
+let constraint_constants =
+  Genesis_constants.For_unit_tests.Constraint_constants.t
+
+let genesis_constants = Genesis_constants.For_unit_tests.t
+
+let signature_kind = Mina_signature_kind.Testnet
+
+let protocol_state_body =
+  lazy
+    ( (Lazy.force Precomputed_values.for_unit_tests).protocol_state_with_hashes
+        .data |> Mina_state.Protocol_state.body )
+
+(** A ledger plus a zkApp command that applies cleanly against it. The generator
+    defaults its verification key to [Pickles.Side_loaded.Verification_key.dummy],
+    so no proving circuit is compiled here. *)
+let generate_zkapp_command_and_ledger () =
+  let user_command, _fee_payer_keypair, _keymap, ledger =
+    Quickcheck.random_value
+      ~seed:(`Deterministic "uptime-service-zkapp-terminal-segment")
+      (Mina_generators.User_command_generators.zkapp_command_with_ledger
+         ~genesis_constants ~constraint_constants () )
+  in
+  match user_command with
+  | User_command.Zkapp_command zkapp_command ->
+      (Zkapp_command.Valid.forget zkapp_command, ledger)
+  | User_command.Signed_command _ ->
+      failwith "generator produced a signed command, expected a zkApp command"
+
+(** Mirrors what the daemon hands the uptime snark worker: the transaction is
+    applied first-pass against a mask, and the resulting ledgers become the
+    witness's sparse ledgers. *)
+let build_witness ~ledger ~zkapp_command ~global_slot =
+  let state_body = Lazy.force protocol_state_body in
+  let second_pass_ledger =
+    let mask =
+      Mina_ledger.Ledger.Mask.create ~depth:(Mina_ledger.Ledger.depth ledger) ()
+    in
+    let registered = Mina_ledger.Ledger.register_mask ledger mask in
+    let _partial =
+      Mina_ledger.Ledger.apply_transaction_first_pass ~signature_kind
+        ~constraint_constants ~global_slot
+        ~txn_state_view:(Mina_state.Protocol_state.Body.view state_body)
+        registered
+        (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
+      |> Or_error.ok_exn
+    in
+    registered
+  in
+  let accounts_referenced = Zkapp_command.accounts_referenced zkapp_command in
+  let sparse_of l =
+    Mina_ledger.Sparse_ledger.of_ledger_subset_exn l accounts_referenced
+  in
+  ( Transaction_witness.read_all_proofs_from_disk
+      { Transaction_witness.transaction =
+          Mina_transaction.Transaction.Command (Zkapp_command zkapp_command)
+      ; first_pass_ledger = sparse_of ledger
+      ; second_pass_ledger = sparse_of second_pass_ledger
+      ; protocol_state_body = state_body
+      ; init_stack = Pending_coinbase.Stack.empty
+      ; status = Mina_base.Transaction_status.Applied
+      ; block_global_slot = global_slot
+      }
+  , second_pass_ledger )
+
+(** Only [source.pending_coinbase_stack], [target.pending_coinbase_stack] and
+    [connecting_ledger_left] are read out of this by the extraction path, so the
+    remaining fields are left at their genesis values. *)
+let build_input ~ledger ~global_slot =
+  let state_body = Lazy.force protocol_state_body in
+  let state_body_hash = Mina_state.Protocol_state.Body.hash state_body in
+  let genesis_ledger_hash =
+    Mina_ledger.Ledger.merkle_root ledger |> Frozen_ledger_hash.of_ledger_hash
+  in
+  let base = Mina_state.Snarked_ledger_state.genesis ~genesis_ledger_hash in
+  let source_stack = Pending_coinbase.Stack.empty in
+  let target_stack =
+    Pending_coinbase.Stack.push_state state_body_hash global_slot source_stack
+  in
+  { base with
+    source = { base.source with pending_coinbase_stack = source_stack }
+  ; target = { base.target with pending_coinbase_stack = target_stack }
+  ; connecting_ledger_left = genesis_ledger_hash
+  }
+
+let staged_ledger_hash_of ledger_hash =
+  Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
+    (Staged_ledger_hash.Aux_hash.of_bytes (String.make 32 '\000'))
+    ledger_hash
+    ( Pending_coinbase.create ~depth:constraint_constants.pending_coinbase_depth
+        ()
+    |> Or_error.ok_exn )
+
+let sok_message =
+  Sok_message.create
+    ~fee:(Currency.Fee.of_nanomina_int_exn 1_000_000)
+    ~prover:
+      (Quickcheck.random_value ~seed:(`Deterministic "uptime-service-submitter")
+         Signature_lib.Public_key.Compressed.gen )
+
+let test_terminal_segment_is_stamped () =
+  let global_slot = Mina_numbers.Global_slot_since_genesis.of_int 2 in
+  let zkapp_command, ledger = generate_zkapp_command_and_ledger () in
+  let witness, second_pass_ledger =
+    build_witness ~ledger ~zkapp_command ~global_slot
+  in
+  let input = build_input ~ledger ~global_slot in
+  (* The block's staged ledger hash is the ledger the block ends on, which is
+     what makes the last segment of the last transaction the terminal one. *)
+  let staged_ledger_hash =
+    Mina_ledger.Ledger.merkle_root second_pass_ledger
+    |> Frozen_ledger_hash.of_ledger_hash |> staged_ledger_hash_of
+  in
+  let sok_digest = Sok_message.digest sok_message in
+  match
+    Uptime_service.Uptime_snark_worker.extract_terminal_zk_segment
+      ~signature_kind ~constraint_constants ~sok_digest ~witness ~input
+      ~zkapp_command ~staged_ledger_hash
+  with
+  | Error e ->
+      failwithf "could not extract the terminal zkApp segment: %s"
+        (Error.to_string_hum e) ()
+  | Ok (_witness, _spec, (statement : Transaction_snark.Statement.With_sok.t))
+    ->
+      if Sok_message.Digest.equal statement.sok_digest sok_digest then ()
+      else if
+        Sok_message.Digest.equal statement.sok_digest Sok_message.Digest.default
+      then
+        failwith
+          "terminal segment statement still carries \
+           Sok_message.Digest.default; a proof over it would attest to the \
+           empty sok message and be rejected by delegation_verify"
+      else failwith "terminal segment statement carries an unexpected digest"
+
+let () =
+  Alcotest.run "uptime_service"
+    [ ( "zkapp terminal segment"
+      , [ Alcotest.test_case
+            "terminal segment statement carries the submitter's sok digest"
+            `Quick test_terminal_segment_is_stamped
+        ] )
+    ]

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -316,7 +316,11 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
                       in
                       make_interruptible
                       @@ Uptime_snark_worker.perform_partitioned snark_worker
-                           (witness, input, zkapp_command, staged_ledger_hash)
+                           ( message
+                           , witness
+                           , input
+                           , zkapp_command
+                           , staged_ledger_hash )
                   | Ok (`Transaction single_spec) ->
                       make_interruptible
                       @@ Uptime_snark_worker.perform_single snark_worker

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -8,12 +8,108 @@ open struct
   module Impl = Snark_worker.Impl
 end
 
-let extract_terminal_zk_segment ~(m : (module Transaction_snark.S)) ~witness
-    ~input ~zkapp_command ~staged_ledger_hash =
+(** Pick the segment whose target second-pass ledger is the block's staged
+    ledger hash -- the last segment of the block's last transaction -- and stamp
+    [sok_digest] into its statement.
+
+    The stamping is not optional. Statements produced by
+    [Transaction_snark.zkapp_command_witnesses_exn] carry
+    [Sok_message.Digest.default] as a placeholder, because the witness generator
+    cannot know the fee or the prover. A proof built over an unstamped statement
+    is a valid proof of the *empty* sok message, which [delegation_verify]
+    rejects with "proof's sok message digest does not match the sok message". *)
+let select_terminal_segment ~sok_digest ~staged_ledger_hash segments =
+  ignore (sok_digest : Sok_message.Digest.t) ;
+  Mina_stdlib.Nonempty_list.find segments
+    ~f:(fun (_, _, (s : Transaction_snark.Statement.With_sok.t)) ->
+      Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) )
+
+let%test_module "terminal zkapp segment selection" =
+  ( module struct
+    let hashes =
+      Quickcheck.random_value
+        ~seed:(`Deterministic "uptime-sok-digest-target-hashes")
+        (Quickcheck.Generator.list_with_length 3 Frozen_ledger_hash.gen)
+
+    let statement_with_target target : Transaction_snark.Statement.With_sok.t =
+      let s =
+        Quickcheck.random_value
+          ~seed:(`Deterministic "uptime-sok-digest-statement")
+          Mina_state.Snarked_ledger_state.gen
+      in
+      (* [Sok_message.Digest.default] is exactly what the witness generator
+         emits, so this mirrors the real input to [select_terminal_segment]. *)
+      { s with
+        sok_digest = Sok_message.Digest.default
+      ; target = { s.target with second_pass_ledger = target }
+      }
+
+    let segments =
+      match List.map hashes ~f:(fun h -> ((), (), statement_with_target h)) with
+      | first :: rest ->
+          Mina_stdlib.Nonempty_list.init first rest
+      | [] ->
+          failwith "unreachable: three hashes were generated"
+
+    let message =
+      Sok_message.create
+        ~fee:(Currency.Fee.of_nanomina_int_exn 1_000_000)
+        ~prover:
+          (Quickcheck.random_value
+             ~seed:(`Deterministic "uptime-sok-digest-prover")
+             Signature_lib.Public_key.Compressed.gen )
+
+    (* The terminal segment is the middle one here, so a test that accidentally
+       picked the first or last element would still have to stamp correctly. *)
+    let staged_ledger_hash = List.nth_exn hashes 1
+
+    let%test_unit "selects the segment whose target is the staged ledger hash" =
+      match
+        select_terminal_segment
+          ~sok_digest:(Sok_message.digest message)
+          ~staged_ledger_hash segments
+      with
+      | None ->
+          failwith "no segment matched the staged ledger hash"
+      | Some (_, _, (statement : Transaction_snark.Statement.With_sok.t)) ->
+          if
+            not
+              Ledger_hash.(
+                statement.target.second_pass_ledger = staged_ledger_hash)
+          then failwith "selected a segment with the wrong target hash"
+
+    (* Regression test for the defect reported as mina#19299: the selected
+       segment was returned carrying the placeholder digest, so the resulting
+       proof attested to the empty sok message and every uptime submission for a
+       zkApp-terminal block was rejected by the delegation program. *)
+    let%test_unit "stamps the submitter's sok digest into the terminal segment"
+        =
+      let sok_digest = Sok_message.digest message in
+      match
+        select_terminal_segment ~sok_digest ~staged_ledger_hash segments
+      with
+      | None ->
+          failwith "no segment matched the staged ledger hash"
+      | Some (_, _, (statement : Transaction_snark.Statement.With_sok.t)) ->
+          if Sok_message.Digest.equal statement.sok_digest sok_digest then ()
+          else if
+            Sok_message.Digest.equal statement.sok_digest
+              Sok_message.Digest.default
+          then
+            failwith
+              "terminal segment statement still carries \
+               Sok_message.Digest.default; a proof over it would attest to the \
+               empty sok message and be rejected by delegation_verify"
+          else
+            failwith "terminal segment statement carries an unexpected digest"
+  end )
+
+let extract_terminal_zk_segment ~signature_kind ~constraint_constants
+    ~sok_digest ~witness ~input ~zkapp_command ~staged_ledger_hash =
   let staged_ledger_hash = Staged_ledger_hash.ledger_hash staged_ledger_hash in
   let%bind.Result final_segment =
-    Work_partitioner.Snark_worker_shared.extract_zkapp_segment_works ~m ~input
-      ~witness ~zkapp_command
+    Work_partitioner.Snark_worker_shared.extract_zkapp_segment_works
+      ~signature_kind ~constraint_constants ~input ~witness ~zkapp_command
     |> Result.map_error
          ~f:
            Work_partitioner.Snark_worker_shared.Failed_to_generate_inputs
@@ -21,9 +117,7 @@ let extract_terminal_zk_segment ~(m : (module Transaction_snark.S)) ~witness
     |> Result.map ~f:(function x ->
         Work_partitioner.Snark_worker_shared.Zkapp_command_inputs
         .read_all_proofs_from_disk x
-        |> Mina_stdlib.Nonempty_list.find ~f:(function
-            | _, _, (s : Transaction_snark.Statement.With_sok.t) ->
-            Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) ) )
+        |> select_terminal_segment ~sok_digest ~staged_ledger_hash )
   in
   match final_segment with
   | Some res ->
@@ -46,7 +140,8 @@ module Worker = struct
           F.t
       ; perform_partitioned :
           ( 'w
-          , Transaction_witness.Stable.Latest.t
+          , Sok_message.t
+            * Transaction_witness.Stable.Latest.t
             * Mina_state.Snarked_ledger_state.Stable.Latest.t
             * Zkapp_command.Stable.Latest.t
             * Staged_ledger_hash.t
@@ -79,7 +174,8 @@ module Worker = struct
         Impl.perform_single ~message state single_spec
 
       let perform_partitioned (state : Worker_state.t)
-          (witness, statement, zkapp_command, staged_ledger_hash) =
+          (message, witness, statement, zkapp_command, staged_ledger_hash) =
+        let sok_digest = Sok_message.digest message in
         let zkapp_command =
           Zkapp_command.write_all_proofs_to_disk
             ~signature_kind:state.signature_kind
@@ -88,8 +184,8 @@ module Worker = struct
         match state.proof_level_snark with
         | Full (module S) ->
             let%bind.Deferred.Or_error witness, spec, statement =
-              extract_terminal_zk_segment
-                ~m:(module S)
+              extract_terminal_zk_segment ~signature_kind:state.signature_kind
+                ~constraint_constants:S.constraint_constants ~sok_digest
                 ~witness ~input:statement ~zkapp_command ~staged_ledger_hash
               |> Deferred.return
             in
@@ -130,7 +226,8 @@ module Worker = struct
         ; perform_partitioned =
             f
               ( [%bin_type_class:
-                  Transaction_witness.Stable.Latest.t
+                  Sok_message.Stable.Latest.t
+                  * Transaction_witness.Stable.Latest.t
                   * Mina_state.Snarked_ledger_state.Stable.Latest.t
                   * Zkapp_command.Stable.Latest.t
                   * Staged_ledger_hash.Stable.Latest.t]

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -19,6 +19,12 @@ end
     proof built over the wrong digest is a valid proof of the *wrong* sok
     message, which [delegation_verify] rejects with "proof's sok message digest
     does not match the sok message". *)
+
+(* [find] returns the first match, so a zkApp command whose second pass leaves
+   the ledger root unchanged yields the fee-payer segment rather than the last
+   one. That is harmless here: [delegation_verify] uses the work only for the
+   digest comparison and the Pickles check, and everything it emits is derived
+   from the block. *)
 let select_terminal_segment ~sok_digest ~staged_ledger_hash segments =
   Mina_stdlib.Nonempty_list.find segments
     ~f:(fun (_, _, (s : Transaction_snark.Statement.t)) ->

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -12,17 +12,21 @@ end
     ledger hash -- the last segment of the block's last transaction -- and stamp
     [sok_digest] into its statement.
 
-    The stamping is not optional. Statements produced by
-    [Transaction_snark.zkapp_command_witnesses_exn] carry
-    [Sok_message.Digest.default] as a placeholder, because the witness generator
-    cannot know the fee or the prover. A proof built over an unstamped statement
-    is a valid proof of the *empty* sok message, which [delegation_verify]
-    rejects with "proof's sok message digest does not match the sok message". *)
+    The stamping is where the sok digest enters the statement at all.
+    [Transaction_snark.zkapp_command_witnesses_exn] returns a sok-less
+    [Statement.t], because the witness generator knows neither the fee nor the
+    prover, so this is the only place the submitter's digest can be applied. A
+    proof built over the wrong digest is a valid proof of the *wrong* sok
+    message, which [delegation_verify] rejects with "proof's sok message digest
+    does not match the sok message". *)
 let select_terminal_segment ~sok_digest ~staged_ledger_hash segments =
-  ignore (sok_digest : Sok_message.Digest.t) ;
   Mina_stdlib.Nonempty_list.find segments
-    ~f:(fun (_, _, (s : Transaction_snark.Statement.With_sok.t)) ->
+    ~f:(fun (_, _, (s : Transaction_snark.Statement.t)) ->
       Ledger_hash.(s.target.second_pass_ledger = staged_ledger_hash) )
+  |> Option.map ~f:(fun (witness, spec, statement) ->
+      ( witness
+      , spec
+      , Mina_state.Snarked_ledger_state.Poly.{ statement with sok_digest } ) )
 
 let%test_module "terminal zkapp segment selection" =
   ( module struct
@@ -31,18 +35,14 @@ let%test_module "terminal zkapp segment selection" =
         ~seed:(`Deterministic "uptime-sok-digest-target-hashes")
         (Quickcheck.Generator.list_with_length 3 Frozen_ledger_hash.gen)
 
-    let statement_with_target target : Transaction_snark.Statement.With_sok.t =
+    let statement_with_target target : Transaction_snark.Statement.t =
       let s =
         Quickcheck.random_value
           ~seed:(`Deterministic "uptime-sok-digest-statement")
           Mina_state.Snarked_ledger_state.gen
       in
-      (* [Sok_message.Digest.default] is exactly what the witness generator
-         emits, so this mirrors the real input to [select_terminal_segment]. *)
-      { s with
-        sok_digest = Sok_message.Digest.default
-      ; target = { s.target with second_pass_ledger = target }
-      }
+      (* Sok-less, exactly as the witness generator emits it. *)
+      { s with target = { s.target with second_pass_ledger = target } }
 
     let segments =
       match List.map hashes ~f:(fun h -> ((), (), statement_with_target h)) with
@@ -75,13 +75,17 @@ let%test_module "terminal zkapp segment selection" =
           if
             not
               Ledger_hash.(
-                statement.target.second_pass_ledger = staged_ledger_hash)
+                statement.target.second_pass_ledger = staged_ledger_hash )
           then failwith "selected a segment with the wrong target hash"
 
     (* Regression test for the defect reported as mina#19299: the selected
        segment was returned carrying the placeholder digest, so the resulting
        proof attested to the empty sok message and every uptime submission for a
-       zkApp-terminal block was rejected by the delegation program. *)
+       zkApp-terminal block was rejected by the delegation program.
+
+       Since [zkapp_command_witnesses_exn] became sok-less, omitting the stamp
+       here is a type error rather than a silent placeholder, so this now guards
+       against stamping the *wrong* digest rather than none at all. *)
     let%test_unit "stamps the submitter's sok digest into the terminal segment"
         =
       let sok_digest = Sok_message.digest message in

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -8,11 +8,11 @@ module Zkapp_command_inputs = struct
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
-    module V2 = struct
+    module V3 = struct
       type t =
         ( Zkapp_command_segment.Witness.Stable.V2.t
         * Zkapp_command_segment.Basic.Stable.V1.t
-        * Statement.With_sok.Stable.V2.t )
+        * Statement.Stable.V2.t )
         Nonempty_list.Stable.V1.t
       [@@deriving sexp, to_yojson]
 
@@ -23,7 +23,7 @@ module Zkapp_command_inputs = struct
   type t =
     ( Zkapp_command_segment.Witness.t
     * Zkapp_command_segment.Basic.t
-    * Statement.With_sok.t )
+    * Statement.t )
     Nonempty_list.t
 
   let read_all_proofs_from_disk : t -> Stable.Latest.t =

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -46,17 +46,18 @@ module Failed_to_generate_inputs = struct
     |> Error.tag ~tag:"failed to generate inputs for zkapp command"
 end
 
-let extract_zkapp_segment_works ~m:(module M : S)
+(* Only [signature_kind] and [constraint_constants] are needed here, so they
+   are taken directly rather than via a [Transaction_snark.S] module. That keeps
+   this callable without compiling a proving circuit, which matters for tests. *)
+let extract_zkapp_segment_works ~signature_kind ~constraint_constants
     ~(input : Mina_state.Snarked_ledger_state.t)
     ~(witness : Transaction_witness.Stable.Latest.t)
     ~(zkapp_command : Zkapp_command.t) :
     (Zkapp_command_inputs.t, Failed_to_generate_inputs.t) Result.t =
   let inputs =
     Or_error.try_with (fun () ->
-        Transaction_snark.zkapp_command_witnesses_exn
-          ~signature_kind:M.signature_kind
-          ~constraint_constants:M.constraint_constants
-          ~global_slot:witness.block_global_slot
+        Transaction_snark.zkapp_command_witnesses_exn ~signature_kind
+          ~constraint_constants ~global_slot:witness.block_global_slot
           ~state_body:witness.protocol_state_body
           ~fee_excess:Currency.Amount.Signed.zero
           [ ( `Pending_coinbase_init_stack witness.init_stack

--- a/src/lib/work_partitioner/snark_worker_shared.ml
+++ b/src/lib/work_partitioner/snark_worker_shared.ml
@@ -8,7 +8,7 @@ module Zkapp_command_inputs = struct
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
-    module V3 = struct
+    module V2 = struct
       type t =
         ( Zkapp_command_segment.Witness.Stable.V2.t
         * Zkapp_command_segment.Basic.Stable.V1.t

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -132,10 +132,19 @@ let schedule_from_any_pending_zkapp_command ~(partitioner : t) :
 
 let convert_zkapp_command_from_selector ~partitioner ~job ~pairing
     unscheduled_segments =
+  (* [Zkapp_command_inputs] statements are sok-less: the witness generator knows
+     neither the fee nor the prover. The authoritative sok message is the one on
+     the job, which is what the worker re-derives from on arrival. *)
+  let sok_digest =
+    Mina_base.Sok_message.digest job.Work.With_job_meta.sok_message
+  in
   let unscheduled_segments =
     Snark_worker_shared.Zkapp_command_inputs.read_all_proofs_from_disk
       unscheduled_segments
     |> Mina_stdlib.Nonempty_list.map ~f:(fun (witness, spec, statement) ->
+        let statement =
+          Mina_state.Snarked_ledger_state.Poly.{ statement with sok_digest }
+        in
         Work.Spec.Sub_zkapp.Stable.Latest.Segment { statement; witness; spec } )
   in
   let pending_zkapp_command, first_segment, first_range =

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -132,19 +132,12 @@ let schedule_from_any_pending_zkapp_command ~(partitioner : t) :
 
 let convert_zkapp_command_from_selector ~partitioner ~job ~pairing
     unscheduled_segments =
-  (* [Zkapp_command_inputs] statements are sok-less: the witness generator knows
-     neither the fee nor the prover. The authoritative sok message is the one on
-     the job, which is what the worker re-derives from on arrival. *)
-  let sok_digest =
-    Mina_base.Sok_message.digest job.Work.With_job_meta.sok_message
-  in
+  (* Both the segment statements and the wire spec are sok-less; the
+     authoritative sok message rides on the job, in [With_job_meta]. *)
   let unscheduled_segments =
     Snark_worker_shared.Zkapp_command_inputs.read_all_proofs_from_disk
       unscheduled_segments
     |> Mina_stdlib.Nonempty_list.map ~f:(fun (witness, spec, statement) ->
-        let statement =
-          Mina_state.Snarked_ledger_state.Poly.{ statement with sok_digest }
-        in
         Work.Spec.Sub_zkapp.Stable.Latest.Segment { statement; witness; spec } )
   in
   let pending_zkapp_command, first_segment, first_range =

--- a/src/lib/work_partitioner/work_partitioner.ml
+++ b/src/lib/work_partitioner/work_partitioner.ml
@@ -158,8 +158,11 @@ let convert_single_work_from_selector ~(partitioner : t)
       match witness.transaction with
       | Command (Zkapp_command zkapp_command) ->
           let witness = Transaction_witness.read_all_proofs_from_disk witness in
+          let (module M) = partitioner.transaction_snark in
           Snark_worker_shared.extract_zkapp_segment_works
-            ~m:partitioner.transaction_snark ~input ~witness ~zkapp_command
+            ~signature_kind:M.signature_kind
+            ~constraint_constants:M.constraint_constants ~input ~witness
+            ~zkapp_command
           |> Result.map
                ~f:
                  (convert_zkapp_command_from_selector ~partitioner ~job ~pairing)


### PR DESCRIPTION
Closes #19314. Fixes #19299.

`Transaction_snark.zkapp_command_witnesses_exn` cannot know the fee or the prover, so every segment statement it emitted carried `sok_digest = Sok_message.Digest.default` — 32 zero bytes — while its declared return type was `Statement.With_sok.t`. A placeholder statement and a genuinely stamped one were the same type, and overwriting the field before proving was an unwritten caller obligation. Two callers have missed it: #17578, then #19299.

The placeholder also travelled over the network: `Sub_zkapp_spec.Segment` typed its statement as `With_sok`, sitting next to the authoritative value in `With_job_meta.sok_message`. The codebase already treated the embedded field as junk — `Sub_zkapp_spec.statement` called `drop_sok` on it before returning.

### What changed

**Regression tests first** (commits 1–2), both verified failing beforehand: an inline test over `select_terminal_segment`, and an end-to-end test driving `extract_terminal_zk_segment` over a real generated ledger and zkApp command. `src/lib/uptime_service/` had no test target; this adds one.

**The witness generator returns `Statement.t`** (commit 3). A sok digest attests to who is proving and for what fee; this function computes a state transition. The same segment statement can legitimately be proved by different provers at different fees, so binding the two at generation asserted a relationship that does not exist. Callers now stamp where the digest is known — which is what turns the tests green, and is the #19299 fix, arrived at by the type rather than by patch.

**The wire spec drops the field** (commit 4):

```
Sub_zkapp_spec.Stable.V2       → V3
  ↳ Partitioned_spec.Stable.V2 → V3
      ↳ Rpc_get_work.Stable.V4 → V5
```

`Single_spec` has always carried the sok-less `Statement.t` and taken its sok from `With_job_meta`; `Sub_zkapp_spec` was the anomaly. `Poly.Stable.V1` is parametric and does not move. `Result.Partitioned` and `Rpc_submit_work` are untouched — results carry a `Ledger_proof` whose statement holds the real digest, and that is the value `delegation_verify` checks.

V4 is retained **and actually served**: the daemon implements these RPCs with `implement_multi` rather than `Rpc.Rpc.implement` on a pinned `Stable.Latest` (see below), without which the retention would be inert. Both conversions are total: the downgrade fills the segment's sok field from the job's own sok message (so a pre-V3 worker gets the real digest rather than zeros, though it re-derives from `sok_message` on arrival anyway), and the upgrade drops a field known to be a placeholder. The downgrade needs `sok_message` in scope, so it sits at `Partitioned_spec` level.

**The daemon serves every version** (commit 7, added in review — thanks @SanabriaRusso). `mina_run.ml` implemented `get_work` with `Rpc.Rpc.implement` on a pinned `Stable.Latest`, so it registered v5 only. With `~on_unknown_rpc:`Raise` on the implementations list, a v4 worker got `Unimplemented_rpc`, and `entry.ml`'s `retry_forever` turned that into an endless 10s–120s backoff — errors logged, no work assigned, no exit. The retained V4 and its round-trip tests were unreachable, and the compatibility claim below did not hold. All three snark-worker RPCs now use `implement_multi`; only `get_work` has two live versions, but converting `submit_work` and `failed_to_generate_snark` costs nothing and removes the same trap for whoever bumps them next.

The daemon's other RPCs are unaffected: the 31 `Daemon_rpcs` and the archive server's three are unversioned `Rpc.Rpc.create ~version:0`, where `implement_multi` does not apply, and `gossip_net/libp2p.ml` already implements multi with a version menu.

### Rollout — please read before scheduling

`entry.ml` dispatches a pinned `Rpc_get_work.Stable.Latest.rpc`, not `dispatch_multi`, so a worker speaks exactly the version it was built against.

- **Daemons must be upgraded before workers.** A V5 worker against a V4-only daemon fails to get work; the reverse is fine.
- Mixed fleets are supported in the daemon-newer direction, while V4 is retained and served.
- Retiring V4 requires confirming no pre-upgrade workers remain.

Making the reverse direction work needs more than moving `entry.ml` to `dispatch_multi`: that negotiates through a version menu, and this server never calls `Versioned_rpc.Menu.add` — the only menu in the tree belongs to the p2p server. It also buys nothing until daemons carrying the menu are deployed. Separate change; see #19326.

### Verification

- `dune build @check` clean.
- `dune runtest src/lib/snark_work_lib src/lib/work_partitioner src/lib/uptime_service` green.
- New `src/lib/snark_work_lib/test/` (the library had no test target) covers the round trip over a real generated segment: the downgrade carries the job's digest rather than zeros, leaves the statement otherwise untouched, and V3 → V2 → V3 returns the spec unchanged. The digest assertion was mutation-checked — forcing `Digest.default` into the downgrade fails it.
- The end-to-end test derives the block's staged ledger hash from the root **after** the second pass, and asserts up front that the second pass moved the root, so the terminal segment is distinguishable from the fee-payer one by target hash. Mutation-checked: forcing `Digest.default` into the stamp fails it, where an earlier first-pass-only version of the test could not fail at all.
- **Not covered:** a mixed-version fleet smoke test (V4 worker against a V4+V5 daemon). Needs a real deployment; worth doing before rollout — it is what would have caught the `implement_multi` gap.
- `transaction_snark/test/util.ml` and `zkapp_test_transaction` now stamp `Sok_message.Digest.default` explicitly where they previously received it implicitly. Behaviour is unchanged by construction; those suites compile but were not run here, since they compile proving circuits.

Fixes #19326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PkbFKayJw5rYEJqTbyZfM
