### PR TITLE
Wait for the Rosetta port to bind in the integration test

### DIFF
--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -255,7 +255,27 @@ for port in "${ports[@]}"; do
     --graphql-uri http://127.0.0.1:${MINA_GRAPHQL_PORT}/graphql \
     --log-level ${LOG_LEVEL} \
     --port ${port} &
-  sleep 5
+  # Wait for the HTTP listener to bind.  We intentionally do NOT probe a
+  # functional Rosetta endpoint here: at this point the Mina daemon isn't
+  # running yet, and any Rosetta route that calls the daemon (e.g.
+  # /network/list) would fail for the full timeout.  Functional readiness
+  # is exercised later by `rosetta-cli configuration:validate` and the
+  # subsequent sweeps, once the daemon is up.
+  echo "Waiting for Rosetta on port ${port} to bind..."
+  for i in $(seq 1 60); do
+    # ":" opens the connection and closes it; "echo" would also write a
+    # newline, which Rosetta logs as a malformed request line on every
+    # attempt.
+    if (: > "/dev/tcp/127.0.0.1/${port}") 2>/dev/null; then
+      echo "Rosetta on port ${port} is listening"
+      break
+    fi
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Rosetta on port ${port} did not bind within 60s"
+      exit 1
+    fi
+    sleep 1
+  done
 done
 
 # Mina Archive


### PR DESCRIPTION
Split out of #18796, as [requested in review](https://github.com/MinaProtocol/mina/pull/18796#issuecomment-5490628438). This is PR 0 of four; it depends on nothing and touches nothing else.

The Rosetta integration test starts the online and the offline Rosetta
instance, then sleeps 5 seconds for each one. The sleep is both too long
when the process binds immediately and too short when the agent is loaded,
in which case the test fails later, with an error that does not name the
cause.

This replaces the sleep with a poll of the port, once a second, for at
most 60 seconds.

The test deliberately does not probe a functional Rosetta endpoint here.
At this point in the script the Mina daemon is not running, so every
Rosetta route that calls the daemon would fail for the full timeout.
Functional readiness is already checked later, by
`rosetta-cli configuration:validate` and the sweeps that follow it.

`:` is used rather than `echo` to open the connection, because `echo`
writes a newline, which Rosetta records as a malformed request line on
every attempt.

No changelog entry: the change is limited to a CI script.
