### PR TITLE
Add rosetta-healthcheck CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ build-mina: ocaml_checks reformat-diff libp2p_helper build ## Build mina apps
 		src/app/cli/src/mina.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		&& echo "✅ Build complete"
 
@@ -296,6 +297,7 @@ build-rosetta: ocaml_checks ## Build Rosetta API components
 		src/app/archive/archive.exe \
 		src/app/rosetta/rosetta.exe \
 		src/app/rosetta/ocaml-signer/signer.exe \
+		src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
 		src/app/rosetta/client/rosetta_client_cli.exe \
 		--profile=$(DUNE_PROFILE) \
 		&& echo "✅ Build complete"

--- a/buildkite/scripts/tests/rosetta/integration-tests.sh
+++ b/buildkite/scripts/tests/rosetta/integration-tests.sh
@@ -246,6 +246,28 @@ psql -f ./src/test/archive/sample_db/archive_db.sql "${INDEXER_PG_CONN}"
 mina-rosetta-indexer-test --archive_uri "${INDEXER_PG_CONN}"
 sudo -u postgres dropdb "${INDEXER_DBNAME}"
 
+echo "=========================== NEGATIVE TEST: healthcheck against not-yet-running Rosetta ==========================="
+# Sanity check: before Rosetta is up, `rosetta-healthcheck ready` must
+# fail cleanly.  Catches regressions in error formatting and exit codes
+# (e.g. raw OCaml [Unix_error] leaking through to stderr on ECONNREFUSED).
+set +e
+NEGATIVE_OUTPUT=$(rosetta-healthcheck ready \
+  --rosetta-uri "http://127.0.0.1:${MINA_ROSETTA_ONLINE_PORT}" \
+  --json 2>&1)
+NEGATIVE_EXIT=$?
+set -e
+if [ "$NEGATIVE_EXIT" -eq 0 ]; then
+  echo "ERROR: healthcheck reported READY before Rosetta was started" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+if echo "$NEGATIVE_OUTPUT" | grep -q "Unix_error\|Unix\.\|Core\.Unix"; then
+  echo "ERROR: healthcheck leaked raw OCaml exception syntax" >&2
+  echo "Output: $NEGATIVE_OUTPUT" >&2
+  exit 1
+fi
+echo "   ✅  healthcheck correctly reported not-ready with a clean error"
+
 # Mina Rosetta
 echo "=========================== STARTING ROSETTA API ONLINE AND OFFLINE INSTANCES ==========================="
 ports=("$MINA_ROSETTA_ONLINE_PORT" "$MINA_ROSETTA_OFFLINE_PORT")

--- a/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/RosettaIntegrationTests.dhall
@@ -41,6 +41,7 @@ let bareBinaries =
       ++  ",signer.exe:mina-ocaml-signer"
       ++  ",zkapp_test_transaction.exe:mina-zkapp-test-transaction"
       ++  ",indexer_test.exe:mina-rosetta-indexer-test"
+      ++  ",rosetta_healthcheck.exe:rosetta-healthcheck"
       ++  ",libp2p_helper:libp2p_helper"
 
 let envExports =

--- a/changes/19330.md
+++ b/changes/19330.md
@@ -1,0 +1,23 @@
+- New `rosetta-healthcheck` CLI: readiness probes for a running Mina Rosetta
+  server. The subcommands are `connectivity` (does `/network/list` advertise the
+  expected network?), `tip-recency` (is the tip returned by `/network/status`
+  newer than `--max-age`?), `ready` (both of those, and `/network/options`), and
+  `wait` (poll `ready` until it passes or `--deadline` expires). Each prints
+  exactly one result — one JSON object with `--json`, one line without it — so it
+  can be used directly as a Kubernetes exec probe or a Docker `HEALTHCHECK`. See
+  `src/app/rosetta/healthcheck/README.md`.
+
+- In JSON mode a field with no value is left out rather than written as `null`, so
+  a probe that could not reach the server prints
+  `{"healthy": false, "error": "..."}` instead of a record padded with nulls.
+
+- `ready` and `wait` run every check even after an earlier one has failed, and
+  report all the problems they found, rather than stopping at the first.
+
+- The binary reads the same `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
+  `MINA_ROSETTA_NETWORK` as `rosetta-client`, so an operator who works against one
+  server can export them once instead of repeating `--rosetta-uri`, `--blockchain`
+  and `--network` on every call.
+
+- The binary ships in the `mina-rosetta` Debian package as
+  `/usr/local/bin/rosetta-healthcheck`.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -528,6 +528,8 @@ build_rosetta_generic_deb() {
     "${BUILDDIR}/usr/local/bin/mina-rosetta"
   cp "./default/src/app/rosetta/ocaml-signer/signer.exe" \
     "${BUILDDIR}/usr/local/bin/mina-ocaml-signer"
+  cp ./default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe \
+    "${BUILDDIR}/usr/local/bin/rosetta-healthcheck"
   cp ./default/src/app/rosetta/client/rosetta_client_cli.exe \
     "${BUILDDIR}/usr/local/bin/rosetta-client"
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -169,6 +169,7 @@ assert_archive_binaries() {
 assert_rosetta_binaries() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta"
+    assert_file_captured "$captured_files" "usr/local/bin/rosetta-healthcheck"
     assert_file_captured "$captured_files" "usr/local/bin/rosetta-client"
     assert_file_captured "$captured_files" "usr/local/bin/mina-ocaml-signer"
     assert_file_captured "$captured_files" "usr/local/bin/mina-rosetta-indexer-test"
@@ -355,6 +356,7 @@ MOCKEXE
     create_mock_exe "default/src/app/rosetta/rosetta.exe"
     create_mock_exe "default/src/app/rosetta/ocaml-signer/signer.exe"
     create_mock_exe "default/src/app/rosetta/indexer_test/indexer_test.exe"
+    create_mock_exe "default/src/app/rosetta/healthcheck/rosetta_healthcheck.exe"
     create_mock_exe "default/src/app/rosetta/client/rosetta_client_cli.exe"
     create_mock_exe "default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe"
     create_mock_exe "default/src/app/generate_keypair/generate_keypair.exe"

--- a/src/app/rosetta/cli_test_helpers/dune
+++ b/src/app/rosetta/cli_test_helpers/dune
@@ -1,0 +1,18 @@
+;; Helpers shared by the alcotest suites of the two Rosetta CLIs.
+;;
+;; Both suites spawn a binary and assert on what it printed, and the
+;; needle list in [assert_no_ocaml_exn_leak] is the regression guard
+;; both of them exist for.  One copy, so the guard cannot drift.
+
+(library
+ (name rosetta_cli_test_helpers)
+ (libraries
+  ;; opam libraries
+  alcotest
+  async
+  core
+  core_unix.signal_unix)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let)))

--- a/src/app/rosetta/cli_test_helpers/rosetta_cli_test_helpers.ml
+++ b/src/app/rosetta/cli_test_helpers/rosetta_cli_test_helpers.ml
@@ -1,0 +1,42 @@
+(* Helpers shared by the alcotest suites of [rosetta-client] and
+   [rosetta-healthcheck].  See [rosetta_cli_test_helpers.mli]. *)
+
+open Core
+open Async
+
+let exe_beside_test name =
+  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
+  Filename.concat here (Filename.concat ".." name)
+
+let run_cli ~bin ?(env = []) args =
+  Thread_safe.block_on_async_exn (fun () ->
+      let%bind process =
+        Process.create_exn ~prog:bin ~args ~env:(`Extend env) ()
+      in
+      let%map output = Process.collect_output_and_wait process in
+      let code =
+        match output.exit_status with
+        | Ok () ->
+            0
+        | Error (`Exit_non_zero n) ->
+            n
+        | Error (`Signal s) ->
+            128 + Signal_unix.to_system_int s
+      in
+      (code, output.stdout, output.stderr) )
+
+let assert_no_ocaml_exn_leak label s =
+  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
+  List.iter needles ~f:(fun needle ->
+      if String.is_substring s ~substring:needle then
+        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
+          label needle s )
+
+let contains ?(case_insensitive = false) s ~sub =
+  if case_insensitive then
+    String.is_substring (String.lowercase s) ~substring:(String.lowercase sub)
+  else String.is_substring s ~substring:sub
+
+let check_contains ~label s ~sub =
+  if not (contains s ~sub) then
+    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s

--- a/src/app/rosetta/cli_test_helpers/rosetta_cli_test_helpers.mli
+++ b/src/app/rosetta/cli_test_helpers/rosetta_cli_test_helpers.mli
@@ -1,0 +1,41 @@
+(** Helpers shared by the alcotest suites of the two Rosetta CLIs.
+
+    Both suites do the same thing: spawn the binary, capture what it
+    printed, and assert on it.  Sharing the spawning and the assertions
+    keeps the guard in {!assert_no_ocaml_exn_leak} -- the regression both
+    suites exist for -- from drifting between two copies. *)
+
+(** [exe_beside_test name] is the binary [name] sitting next to the
+    directory the test executable was built into.  Resolved relative to
+    [Sys.get_argv ().(0)] so it survives dune's sandboxing, wherever
+    dune chooses to [chdir] to. *)
+val exe_beside_test : string -> string
+
+(** [run_cli ~bin ?env args] runs [bin] and returns
+    [(exit_code, stdout, stderr)].  A signalled child reports
+    [128 + signal], as a shell would.
+
+    Both pipes are drained concurrently and the child's stdin is closed:
+    reading one to EOF and only then the other deadlocks as soon as a
+    child writes more than a pipe buffer to the one not being read,
+    which any test of a subcommand that reports progress on stderr would
+    do. *)
+val run_cli :
+     bin:string
+  -> ?env:(string * string) list
+  -> string list
+  -> int * string * string
+
+(** [assert_no_ocaml_exn_leak label s] fails the test if [s] contains
+    raw OCaml exception syntax.  Both CLIs promise never to print it,
+    and the leak that prompted the promise -- [Unix_error] reaching
+    stderr on ECONNREFUSED -- is what these needles look for. *)
+val assert_no_ocaml_exn_leak : string -> string -> unit
+
+(** [contains s ~sub] is substring containment, optionally ignoring
+    case. *)
+val contains : ?case_insensitive:bool -> string -> sub:string -> bool
+
+(** [check_contains ~label s ~sub] fails the test, quoting [s], when
+    [sub] is absent. *)
+val check_contains : label:string -> string -> sub:string -> unit

--- a/src/app/rosetta/client/README.md
+++ b/src/app/rosetta/client/README.md
@@ -7,6 +7,9 @@ subcommand maps to a single endpoint, auto-injects
 `network_identifier`, and prints the response as JSON (pretty by default,
 `--compact` for one-line output).
 
+For readiness probes, see the sibling
+[`rosetta-healthcheck`](../healthcheck/README.md) binary.
+
 ## Subcommand tree
 
 ```
@@ -50,8 +53,9 @@ Every leaf command accepts:
 | `--compact` | off | | Emit compact JSON instead of indented. |
 
 A flag always wins over its environment variable.  Export the variables
-to talk to the same server repeatedly without repeating the flags.  The
-flags themselves live in `Rosetta_client.Flags` and their fallbacks in
+to talk to the same server repeatedly without repeating the flags; the
+same three variables are read by `rosetta-healthcheck`.  The flags
+themselves live in `Rosetta_client.Flags` and their fallbacks in
 `Rosetta_client.Defaults`, so every binary built on the library offers
 the same flags and falls back to the same place.
 

--- a/src/app/rosetta/client/dune
+++ b/src/app/rosetta/client/dune
@@ -8,7 +8,6 @@
   core_unix.command_unix
   async
   async.async_command
-  uri
   yojson
   ;; local libraries
   interpolator_lib

--- a/src/app/rosetta/client/rosetta_client_cli.ml
+++ b/src/app/rosetta/client/rosetta_client_cli.ml
@@ -13,7 +13,8 @@
    non-zero; the diagnostic never leaks raw OCaml exception syntax.
 
    The connection flags, the environment variables that override their
-   defaults and the values behind those live in [Rosetta_client.Flags]. *)
+   defaults and the values behind those live in [Rosetta_client.Flags],
+   and are shared with [rosetta-healthcheck]. *)
 
 open Core
 open Async
@@ -22,10 +23,10 @@ module MRC = Rosetta_client
 (* Seconds allowed for one request/response exchange with the Rosetta
    server, from sending the request to reading the last byte of the
    response body.  This is deliberately longer than
-   [MRC.Defaults.http_timeout], which is sized for a readiness probe that
-   wants a quick verdict: this CLI is used interactively, for queries such
-   as a /search/transactions sweep that legitimately take much longer than
-   a probe would wait. *)
+   [MRC.Defaults.http_timeout]: a healthcheck probe wants a quick verdict,
+   whereas this CLI is used interactively for queries such as a
+   /search/transactions sweep that legitimately take much longer than a
+   probe would wait. *)
 let default_timeout = 30.0
 
 (* ---------- Global flags shared by every leaf command ---------- *)

--- a/src/app/rosetta/client/tests/dune
+++ b/src/app/rosetta/client/tests/dune
@@ -2,16 +2,17 @@
 ;;
 ;; These exercise only subcommands that don't need a running Rosetta
 ;; server: --help for each subgroup and the clean error paths of the
-;; HTTP code.
+;; HTTP code.  The spawning and the assertions live in
+;; rosetta_cli_test_helpers, shared with the rosetta-healthcheck suite.
 
 (test
  (name test_rosetta_client)
  (libraries
   ;; opam libraries
   alcotest
-  async
   core
-  core_unix.signal_unix)
+  ;; local libraries
+  rosetta_cli_test_helpers)
  (deps ../rosetta_client_cli.exe)
  (instrumentation
   (backend bisect_ppx))

--- a/src/app/rosetta/client/tests/test_rosetta_client.ml
+++ b/src/app/rosetta/client/tests/test_rosetta_client.ml
@@ -9,58 +9,11 @@
    Core.Unix.Unix_error, etc.).  See [assert_no_ocaml_exn_leak]. *)
 
 open Core
-open Async
+open Rosetta_cli_test_helpers
 
-(* Path to the binary under test.  dune places the test executable in
-   the same directory as its deps, so [../rosetta_client_cli.exe] is reachable from
-   wherever dune chooses to [chdir] into.  We resolve it once relative
-   to [Sys.get_argv ().(0)] so the tests survive dune sandboxing. *)
-let bin =
-  let here = Filename.dirname (Array.get (Sys.get_argv ()) 0) in
-  Filename.concat here "../rosetta_client_cli.exe"
+let bin = exe_beside_test "rosetta_client_cli.exe"
 
-(* Spawn the CLI with [args] and an optional env extension, capture
-   stdout and stderr, return [(exit_code, stdout, stderr)].
-
-   [collect_output_and_wait] drains both pipes concurrently and closes
-   the child's stdin.  Reading one to EOF and only then the other would
-   deadlock as soon as a child wrote more than a pipe buffer to the one
-   we are not reading. *)
-let run_cli ?(env = []) args =
-  Thread_safe.block_on_async_exn (fun () ->
-      let%bind process =
-        Process.create_exn ~prog:bin ~args ~env:(`Extend env) ()
-      in
-      let%map output = Process.collect_output_and_wait process in
-      let code =
-        match output.exit_status with
-        | Ok () ->
-            0
-        | Error (`Exit_non_zero n) ->
-            n
-        | Error (`Signal s) ->
-            128 + Signal_unix.to_system_int s
-      in
-      (code, output.stdout, output.stderr) )
-
-(* Regression guard: no user-facing output must contain raw OCaml
-   exception syntax.  The triggering bug for this whole cleanup was
-   connection-refused paths leaking [Unix_error] through to stderr. *)
-let assert_no_ocaml_exn_leak label s =
-  let needles = [ "Unix_error"; "(Unix."; "Core.Unix" ] in
-  List.iter needles ~f:(fun needle ->
-      if String.is_substring s ~substring:needle then
-        Alcotest.failf "%s: output leaked OCaml exception syntax (%s):\n%s"
-          label needle s )
-
-let contains ?(case_insensitive = false) s ~sub =
-  if case_insensitive then
-    String.is_substring (String.lowercase s) ~substring:(String.lowercase sub)
-  else String.is_substring s ~substring:sub
-
-let check_contains ~label s ~sub =
-  if not (contains s ~sub) then
-    Alcotest.failf "%s: expected to contain %S, got:\n%s" label sub s
+let run_cli ?env args = run_cli ~bin ?env args
 
 (* ---------- Tests ---------- *)
 

--- a/src/app/rosetta/healthcheck/README.md
+++ b/src/app/rosetta/healthcheck/README.md
@@ -1,0 +1,179 @@
+# rosetta-healthcheck
+
+Slim CLI focused on answering **"is the Rosetta server healthy right now?"**
+Designed for Kubernetes exec probes, Docker `HEALTHCHECK`, CI gates, and
+CI pre-flight checks.
+
+For arbitrary Rosetta API calls — `/block`, `/account/*`, `/mempool`,
+`/search/*`, `/construction/*` — use the sibling
+[`rosetta-client`](../client/README.md) binary.  Both share the same
+underlying HTTP library (`src/lib/rosetta_client/`).
+
+## Commands
+
+### Probes
+
+| Command | Endpoint(s) | Exit 0 when |
+|---------|-------------|-------------|
+| `ready` | composite | `connectivity` + `tip-recency` + `/network/options` all pass |
+| `wait` | poll `ready` | passes before `--deadline` expires |
+| `tip-recency` | POST `/network/status` | tip returned AND its timestamp is within `--max-age` |
+| `connectivity` | POST `/network/list` | `network_identifier` list advertises the expected network (lists the advertised set on mismatch) |
+
+## Usage
+
+```bash
+# Is the server reachable and advertising our network?
+rosetta-healthcheck connectivity --network testnet
+
+# Is the tip fresh? (default tolerance: 360s)
+rosetta-healthcheck tip-recency --max-age 360
+
+# Composite readiness suitable for k8s readiness probes:
+rosetta-healthcheck ready --max-age 360 --json
+
+# Block until ready (CI / init containers):
+rosetta-healthcheck wait --deadline 600 --interval 10 --json
+```
+
+The rosetta-cli audit configuration (`config.json` and the Construction
+DSL files it names) is not handled by this binary.  It ships in the
+`mina-rosetta` Debian package at
+`/etc/mina/rosetta/rosetta-cli-config/`, and
+`buildkite/scripts/tests/rosetta/integration-tests.sh` copies it to a
+writable directory and fills in its `PLACEHOLDER_*` fields before
+invoking rosetta-cli.
+
+To make a single Rosetta API call for debugging, use
+`rosetta-client network status` / `rosetta-client block get` /
+etc.
+
+## Flags
+
+| Flag | Alias | Default | Environment override | Applies to |
+|------|-------|---------|----------------------|------------|
+| `--rosetta-uri` | | `http://localhost:3087` | `MINA_ROSETTA_URI` | all probes |
+| `--network` | | `testnet` | `MINA_ROSETTA_NETWORK` | all probes |
+| `--blockchain` | | `mina` | `MINA_ROSETTA_BLOCKCHAIN` | all probes |
+| `--json` | `-j` | off | | every subcommand |
+| `--max-age` | | 360 | | `tip-recency`, `ready`, `wait` |
+| `--timeout` | | 5 | | all probes |
+| `--deadline` | `-d` | 600 | | `wait` |
+| `--interval` | `-i` | 10 | | `wait` |
+
+`--interval` and `--deadline` must be at least 1 second, `--max-age` at
+least 0 and `--timeout` positive.  A value below the floor is refused
+before any request goes out: `--interval 0` asks for a poll loop with no
+pause at all, which turns the probe into a load generator pointed at the
+server it is checking.
+
+A flag always wins over its environment variable.  The connection flags
+themselves come from `Rosetta_client.Flags` and their fallbacks from
+`Rosetta_client.Defaults` -- the same place `rosetta-client` gets them
+-- so the two binaries cannot drift apart.
+`--timeout` bounds one request/response exchange -- the same thing it
+means to `rosetta-client` -- and defaults low because a probe wants a
+quick verdict; raise it for a Rosetta that answers `/network/status` out
+of a loaded archive database.  `--deadline` bounds the whole `wait`
+loop, which is a different quantity and so has a different name.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Check passed |
+| 1 | Check failed (one line on stdout, or one JSON record on stdout with `--json`) |
+| 2 | Usage error (a flag value below its floor); the message goes to stderr and no request is sent |
+
+## JSON output contract
+
+When `--json` is set, every probe emits exactly one JSON record on stdout
+and exits. On success:
+
+```json
+{ "healthy": true, ... }
+{ "ready":   true, ... }
+```
+
+On failure the process exits with code 1 and the same record carries the
+reason plus any metrics gathered up to that point: `connectivity` and
+`tip-recency` add `"error"`, while `ready` and `wait` list one line per
+failed check in `"problems"` -- they check three things, so a single
+`error` string would only be those lines joined up.
+
+The records are typed (`health_output.ml`), and a field that has no value
+is left out rather than emitted as `null`.  The probes that produce them
+are in `health_probes.ml` and never print or exit; `rosetta_healthcheck.ml`
+owns the flags, the text/JSON choice and the exit code.  A probe that could not reach
+the server therefore prints:
+
+```json
+{ "healthy": false, "error": "connection refused to http://localhost:3087/network/list" }
+```
+
+All error messages are produced by `Rosetta_client.Errors` and are
+guaranteed to be short, human-readable, and free of raw OCaml exception
+syntax.
+
+Diagnostics -- `wait`'s per-attempt progress -- go to stderr through
+Mina's `Logger`, the way every other Mina binary reports, so a probe
+running in a pod is collected and filtered like the daemon beside it.
+The processor follows `--json`: one JSON record per line when it is set,
+prose when it is not.  Stdout stays the result channel either way.
+
+## Known limitation
+
+A probe that times out closes its connection in every case except one: a
+server that completes the TCP connect and then never sends a response
+line at all. cohttp-async 5.0.0 exposes no handle on that connection, so
+`wait` against such a server holds one socket per attempt until the
+process exits. It is bounded by a single run of a short-lived CLI, and no
+usable `--deadline` / `--interval` pair reaches the default descriptor
+limit. See the comment on `with_request` in
+`src/lib/rosetta_client/http.ml`.
+
+## Kubernetes integration
+
+`timeoutSeconds` is not optional here.  Kubelet defaults an exec probe
+to 1 second and kills the process when it expires, while a probe waits
+up to `--timeout` (5s by default) for a server that accepts the
+connection and then goes quiet.  Left at the default, the examples below
+would report failure on exactly the server they are meant to wait for.
+Keep `timeoutSeconds` above `--timeout`; `ready` runs its three checks
+concurrently, so its ceiling is the same one exchange.
+
+```yaml
+# Liveness: is the Rosetta server answering at all?
+livenessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "connectivity",
+              "--rosetta-uri", "http://localhost:3087",
+              "--network", "testnet"]
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+
+# Readiness: are all discovery endpoints healthy and the tip fresh?
+readinessProbe:
+  exec:
+    command: ["rosetta-healthcheck", "ready",
+              "--rosetta-uri", "http://localhost:3087",
+              "--max-age", "360"]
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 10
+```
+
+## Docker integration
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD ["rosetta-healthcheck", "connectivity", \
+       "--rosetta-uri", "http://localhost:3087"]
+```
+
+## Building
+
+```bash
+dune build src/app/rosetta/healthcheck/rosetta_healthcheck.exe
+```

--- a/src/app/rosetta/healthcheck/dune
+++ b/src/app/rosetta/healthcheck/dune
@@ -1,0 +1,20 @@
+(executable
+ (package rosetta)
+ (name rosetta_healthcheck)
+ (public_name rosetta-healthcheck)
+ (libraries
+  ;; opam libraries
+  core
+  core_unix.command_unix
+  async
+  async.async_command
+  ppx_deriving_yojson.runtime
+  yojson
+  ;; local libraries
+  interpolator_lib
+  logger
+  rosetta_client)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_let ppx_deriving_yojson ppx_mina)))

--- a/src/app/rosetta/healthcheck/health_output.ml
+++ b/src/app/rosetta/healthcheck/health_output.ml
@@ -1,0 +1,74 @@
+(* The JSON records [rosetta-healthcheck ... --json] prints.
+
+   These are the binary's machine-readable contract: an orchestrator
+   reads them to decide whether a Rosetta instance is usable.  Each
+   record therefore has a type here rather than being assembled field by
+   field at the call site, so a probe cannot silently drop a field or
+   rename one.
+
+   Every optional field carries [@default None] (and every list
+   [@default []]), which makes [to_yojson] omit it when it is absent.
+   A probe that could not reach the server therefore emits
+   [{"healthy":false,"error":"..."}] rather than a record padded with
+   nulls. *)
+
+(* One entry of /network/list's advertised set. *)
+type network_id = { blockchain : string; network : string }
+[@@deriving to_yojson]
+
+(* [connectivity]: does /network/list answer, and does it advertise the
+   network we were asked about? *)
+type connectivity =
+  { healthy : bool
+  ; expected_network : string option [@default None]
+  ; advertised : network_id list [@default []]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [tip-recency]: how old is the tip /network/status reports?
+   [max_age] is echoed back only when the tip failed the check, so the
+   reader can see the bound that was applied. *)
+type tip_recency =
+  { healthy : bool
+  ; block_height : int64 option [@default None]
+  ; block_hash : string option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; max_age : int option [@default None]
+  ; error : string option [@default None]
+  }
+[@@deriving to_yojson]
+
+(* [ready] and [wait].  [timed_out] distinguishes "wait gave up" from
+   "ready reported not-ready once"; [problems] lists one line per failed
+   probe.
+
+   There is no [error] field here, unlike the single-probe records: what
+   would go in it is the [problems] list joined up, and a record that
+   states the same failure twice invites a reader to wonder which one is
+   authoritative.  [ready = false] marks the failure, [problems] says
+   what it was. *)
+type readiness =
+  { ready : bool
+  ; timed_out : bool option [@default None]
+  ; block_height : int64 option [@default None]
+  ; age_seconds : int64 option [@default None]
+  ; problems : string list [@default []]
+  }
+[@@deriving to_yojson]
+
+let connectivity_failed error =
+  { healthy = false
+  ; expected_network = None
+  ; advertised = []
+  ; error = Some error
+  }
+
+let tip_recency_failed error =
+  { healthy = false
+  ; block_height = None
+  ; block_hash = None
+  ; age_seconds = None
+  ; max_age = None
+  ; error = Some error
+  }

--- a/src/app/rosetta/healthcheck/health_probes.ml
+++ b/src/app/rosetta/healthcheck/health_probes.ml
@@ -1,0 +1,118 @@
+(* The health probes.  See [health_probes.mli] for the contract, and
+   [rosetta_healthcheck.ml] for the CLI that presents these verdicts. *)
+
+open Core
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+
+type tip = { height : int64; hash : string; age_seconds : int64; fresh : bool }
+
+type readiness = { ready : bool; tip : tip option; problems : string list }
+
+(* Age of a millisecond timestamp, floored at 0: a server whose clock
+   runs ahead of ours reports a fresh tip, not a negative age. *)
+let age_seconds_from_timestamp_ms ts =
+  let now_ms =
+    Time_float.now () |> Time_float.to_span_since_epoch |> Time_float.Span.to_ms
+  in
+  Int64.max 0L (Int64.of_float ((now_ms -. Int64.to_float ts) /. 1000.))
+
+let describe (network_identifier : RM.Network_identifier.t) =
+  sprintf "%s:%s" network_identifier.RM.Network_identifier.blockchain
+    network_identifier.RM.Network_identifier.network
+
+let connectivity client ~expected_blockchain ~expected_network =
+  match%map
+    MRC.Data.network_list client
+    |> MRC.Data.decode RM.Network_list_response.of_yojson
+  with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let advertised = response.RM.Network_list_response.network_identifiers in
+      if List.is_empty advertised then
+        Or_error.error_string "/network/list returned no network_identifiers"
+      else
+        let match_found =
+          List.exists advertised ~f:(fun n ->
+              String.equal n.RM.Network_identifier.blockchain
+                expected_blockchain
+              && String.equal n.RM.Network_identifier.network expected_network )
+        in
+        if match_found then Ok advertised
+        else
+          Or_error.errorf "expected network %s:%s not advertised (got: %s)"
+            expected_blockchain expected_network
+            (String.concat ~sep:", " (List.map advertised ~f:describe))
+
+let tip_recency client ~max_age =
+  match%map
+    MRC.Data.network_status client
+    |> MRC.Data.decode RM.Network_status_response.of_yojson
+  with
+  | Error e ->
+      Error e
+  | Ok response ->
+      let block =
+        response.RM.Network_status_response.current_block_identifier
+      in
+      let age_seconds =
+        age_seconds_from_timestamp_ms
+          response.RM.Network_status_response.current_block_timestamp
+      in
+      Ok
+        { height = block.RM.Block_identifier.index
+        ; hash = block.RM.Block_identifier.hash
+        ; age_seconds
+        ; fresh = Int64.( <= ) age_seconds (Int64.of_int max_age)
+        }
+
+(* [/network/options] is the third readiness signal: a server that
+   answers it with a version and a non-empty operation_types list has
+   finished wiring up its Data API. *)
+let network_options_ok client =
+  match%map
+    MRC.Data.network_options client
+    |> MRC.Data.decode RM.Network_options_response.of_yojson
+  with
+  | Error e ->
+      Error (sprintf "network-options: %s" (Error.to_string_hum e))
+  | Ok response ->
+      let version = response.RM.Network_options_response.version in
+      let allow = response.RM.Network_options_response.allow in
+      if
+        String.is_empty version.RM.Version.rosetta_version
+        || List.is_empty allow.RM.Allow.operation_types
+      then Error "network-options: missing rosetta_version or operation_types"
+      else Ok ()
+
+let readiness client ~expected_blockchain ~expected_network ~max_age =
+  (* Concurrently, not in sequence: the three probes ask three
+     independent questions of the same server over three connections,
+     and running them one after another made a server that black-holes
+     its packets cost three timeouts before any verdict -- long enough
+     for a Kubernetes exec probe to be killed before it answers. *)
+  let%map connectivity_result =
+    connectivity client ~expected_blockchain ~expected_network
+  and tip_result = tip_recency client ~max_age
+  and options_result = network_options_ok client in
+  let problem_of_error label e =
+    sprintf "%s: %s" label (Error.to_string_hum e)
+  in
+  let problems =
+    List.filter_opt
+      [ Result.error connectivity_result
+        |> Option.map ~f:(problem_of_error "connectivity")
+      ; ( match tip_result with
+        | Error e ->
+            Some (problem_of_error "tip-recency" e)
+        | Ok tip when not tip.fresh ->
+            Some
+              (sprintf "tip-recency: tip age %Lds > %ds" tip.age_seconds max_age)
+        | Ok _ ->
+            None )
+      ; Result.error options_result
+      ]
+  in
+  { ready = List.is_empty problems; tip = Result.ok tip_result; problems }

--- a/src/app/rosetta/healthcheck/health_probes.mli
+++ b/src/app/rosetta/healthcheck/health_probes.mli
@@ -1,0 +1,66 @@
+(** The health probes themselves: what [rosetta-healthcheck] asks a
+    Rosetta server, and how it decides whether the answer is healthy.
+
+    Nothing here touches [Command], prints, or exits.  A probe returns a
+    typed verdict and leaves the presentation of it — text or JSON, which
+    exit code — to {!Rosetta_healthcheck}.  That split is what makes the
+    decisions testable without spawning the binary. *)
+
+(** The chain tip as [/network/status] reported it. *)
+type tip =
+  { height : int64
+  ; hash : string
+  ; age_seconds : int64
+        (** Age of [timestamp] at the moment of the probe, never
+            negative: a server whose clock runs ahead of ours reports 0
+            rather than a negative age. *)
+  ; fresh : bool  (** Whether [age_seconds] is within the caller's bound. *)
+  }
+
+(** Verdict of the composite readiness check. *)
+type readiness =
+  { ready : bool  (** True only when [problems] is empty. *)
+  ; tip : tip option
+        (** The tip, when [/network/status] answered — present even when
+            the tip was too old, so a caller can report how far behind
+            the server is. *)
+  ; problems : string list  (** One line per failed check, in probe order. *)
+  }
+
+(** [connectivity client ~expected_blockchain ~expected_network] asks
+    [/network/list] and returns everything the server advertises.
+
+    It is an error when the server answers with an empty list, or when
+    the expected pair is absent — the error message then names the
+    advertised set, because "wrong network" and "server not up" need
+    different fixes. *)
+val connectivity :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> Rosetta_client.Models.Network_identifier.t list Async.Deferred.Or_error.t
+
+(** [tip_recency client ~max_age] asks [/network/status] and reports the
+    tip with its age.  A tip older than [max_age] seconds is returned
+    with [fresh = false] rather than as an error: the caller still wants
+    the height and the age in order to report them. *)
+val tip_recency :
+  Rosetta_client.Http.t -> max_age:int -> tip Async.Deferred.Or_error.t
+
+(** [readiness client ~expected_blockchain ~expected_network ~max_age]
+    runs {!connectivity}, {!tip_recency} and a [/network/options] sanity
+    check.
+
+    The three run concurrently and all of them run, so one invocation
+    reports every problem instead of only the first — an operator
+    debugging a sick server wants the whole picture at once — and a
+    server that answers none of them costs one timeout rather than
+    three.  For that reason this returns a plain [Deferred.t]: a
+    transport failure is an entry in [problems], not an error channel
+    that would short-circuit the remaining checks. *)
+val readiness :
+     Rosetta_client.Http.t
+  -> expected_blockchain:string
+  -> expected_network:string
+  -> max_age:int
+  -> readiness Async.Deferred.t

--- a/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/rosetta_healthcheck.ml
@@ -1,0 +1,373 @@
+(* rosetta_healthcheck.ml — the CLI surface of the Rosetta health probes.
+
+   This file owns everything the operator sees: the flags, the choice
+   between text and JSON, and the exit code.  The probes themselves live
+   in [health_probes.ml] and the JSON records they are rendered into in
+   [health_output.ml]; neither of those prints or exits.
+
+   This binary focuses exclusively on readiness and recency checks.
+   Generic Rosetta API calls live in the sibling [rosetta-client] binary
+   so operators don't have to choose between two overlapping CLIs for
+   debugging.  HTTP calls go through [Rosetta_client] so
+   network_identifier handling, timeout enforcement, and error formatting
+   stay in one place.
+
+   The connection flags, the environment variables that override their
+   defaults and the values behind those live in [Rosetta_client.Flags],
+   and are shared with [rosetta-client], so the two binaries cannot
+   drift apart on what [--rosetta-uri] or [--timeout] means. *)
+
+open Core
+open Async
+module MRC = Rosetta_client
+module RM = MRC.Models
+module Out = Health_output
+module Probes = Health_probes
+
+(* Oldest tip, in seconds, that [tip-recency] and [ready] still call
+   healthy.  360s is two 3-minute slots. *)
+let default_max_age = 360
+
+(* How long [wait] keeps polling before it gives up, in seconds. *)
+let default_deadline = 600
+
+(* Seconds [wait] sleeps between two readiness attempts. *)
+let default_interval = 10
+
+(* ---------- Flags ---------- *)
+
+(* A bound on a numeric flag, checked while the arguments are parsed
+   and before a single request goes out.  Rejecting beats clamping: the
+   values below the floor are not merely unusual but incoherent --
+   [--interval 0] asks for a poll loop with no pause at all, which turns
+   a probe into a load generator against the server it is meant to check
+   and invalidates the descriptor-budget argument in the README -- and
+   an operator who typed one should be told, not quietly given
+   something else.
+
+   The message is printed and the process exits here rather than being
+   raised: [Command] renders an escaping exception as [(Failure "...")],
+   and raw OCaml exception syntax in user-visible output is the one
+   thing this binary promises never to print.  It goes out plainly
+   rather than through [Logger], which is not registered until a
+   subcommand body runs -- the same order [mina_archive_healthcheck]
+   reports its own usage error in.
+
+   Exit 2, not 1: 1 is the probe's answer, and an orchestrator that
+   reads a mistyped flag as "the server is not ready" retries a
+   condition no amount of waiting will fix. *)
+let reject name ~must_be ~got =
+  Stdlib.prerr_endline (sprintf "%s must be %s, got %s" name must_be got) ;
+  Stdlib.exit 2
+
+let seconds_at_least ~name ~minimum param =
+  Command.Param.map param ~f:(fun value ->
+      if value < minimum then
+        reject name
+          ~must_be:
+            (sprintf "at least %d second%s" minimum
+               (if minimum = 1 then "" else "s") )
+          ~got:(Int.to_string value)
+      else value )
+
+let positive_seconds ~name param =
+  Command.Param.map param ~f:(fun value ->
+      if Float.( <= ) value 0.0 then
+        reject name ~must_be:"a positive number of seconds"
+          ~got:(sprintf "%g" value)
+      else value )
+
+let client_flag =
+  MRC.Flags.client
+    ~timeout:
+      (positive_seconds ~name:"--timeout"
+         (MRC.Flags.timeout ~default:MRC.Defaults.http_timeout) )
+
+(* The blockchain/network the client was pointed at, for the probes that
+   check the server advertises them. *)
+let expected client =
+  let id = MRC.Http.network_identifier client in
+  (id.RM.Network_identifier.blockchain, id.RM.Network_identifier.network)
+
+let json_flag =
+  Command.Param.(
+    flag "--json" ~aliases:[ "-j" ] ~doc:" Output as JSON instead of text"
+      no_arg )
+
+let max_age_flag =
+  Command.Param.(
+    flag "--max-age"
+      ~doc:
+        (sprintf "SECONDS Maximum acceptable age of current tip (default: %d)"
+           default_max_age )
+      (optional_with_default default_max_age int) )
+  |> seconds_at_least ~name:"--max-age" ~minimum:0
+
+(* [wait]'s bound on the whole polling loop, as opposed to [--timeout]
+   which bounds one exchange within it. *)
+let deadline_flag =
+  Command.Param.(
+    flag "--deadline" ~aliases:[ "-d" ]
+      ~doc:
+        (sprintf "SECONDS Max seconds to keep polling (default: %d)"
+           default_deadline )
+      (optional_with_default default_deadline int) )
+  |> seconds_at_least ~name:"--deadline" ~minimum:1
+
+let interval_flag =
+  Command.Param.(
+    flag "--interval" ~aliases:[ "-i" ]
+      ~doc:(sprintf "SECONDS Polling interval (default: %d)" default_interval)
+      (optional_with_default default_interval int) )
+  |> seconds_at_least ~name:"--interval" ~minimum:1
+
+(* ---------- Output ---------- *)
+
+(* Stdout is the result channel.  We bypass Async's own [print_*]
+   wrappers (which use non-blocking writers that may not flush before a
+   subsequent [Stdlib.exit]) by going straight to [Stdlib.stdout], and
+   flush explicitly so the result appears even when we exit without
+   going through Async's shutdown path. *)
+let output_line line =
+  Stdlib.print_string line ;
+  Stdlib.print_newline () ;
+  Stdlib.flush Stdlib.stdout
+
+let output json = output_line (Yojson.Safe.pretty_to_string json)
+
+(* Diagnostics go to stderr through [Logger], which is where every other
+   Mina binary sends them, so a rosetta-healthcheck run in a pod is
+   collected and filtered like the daemon beside it.  Stdout stays the
+   result channel: the probe verdict goes out through [output] above and
+   nothing else joins it there.
+
+   The processor follows [--json], as [mina_archive_healthcheck] does:
+   a caller that asked for a machine-readable verdict gets
+   machine-readable diagnostics beside it rather than prose.
+
+   The interpolation cap is high enough to hold what the probes produce
+   -- three problems, each naming a URL -- because a value that exceeds
+   it is dropped from the line and printed under it, which for a
+   progress line is worse than the quotes interpolation adds.  The
+   metadata is rendered compactly for the same reason: [problems] is a
+   list, and pretty-printing it would spread one attempt over five
+   lines. *)
+let logger = Logger.create ~id:"rosetta-healthcheck" ()
+
+let setup_logging ~json =
+  Logger.Consumer_registry.register ~id:"rosetta-healthcheck"
+    ~processor:
+      ( if json then Logger.Processor.raw ~log_level:Logger.Level.Info ()
+        else
+          Logger.Processor.pretty ~log_level:Logger.Level.Info
+            ~config:
+              { Interpolator_lib.Interpolator.mode = Inline
+              ; max_interpolation_length = 4096
+              ; pretty_print = false
+              } )
+    ~transport:(Logger.Transport.raw Stdlib.prerr_endline)
+    ()
+
+(* Exactly one result per invocation, then exit 1.  Mirrors the contract
+   in [mina_archive_healthcheck]: never double-print -- in JSON mode emit
+   one record, in text mode one line, and in neither case also hand the
+   message back to a [Command] wrapper that would print it again.  The
+   two renderings are lazy so only the one that is asked for is built. *)
+let fail ~json ~record ~line =
+  if json then output (Lazy.force record) else output_line (Lazy.force line) ;
+  Stdlib.exit 1
+
+(* A probe that could not reach the server at all.  Both modes say the
+   same thing, so each command states it once. *)
+let fail_unreachable ~json ~record error =
+  let message = Error.to_string_hum error in
+  fail ~json ~record:(lazy (record message)) ~line:(lazy message)
+
+let advertised_network_id (network_identifier : RM.Network_identifier.t) =
+  { Out.blockchain = network_identifier.RM.Network_identifier.blockchain
+  ; network = network_identifier.RM.Network_identifier.network
+  }
+
+let readiness_json ?timed_out (result : Probes.readiness) =
+  Out.readiness_to_yojson
+    { Out.ready = result.Probes.ready
+    ; timed_out
+    ; block_height =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.height)
+    ; age_seconds =
+        Option.map result.Probes.tip ~f:(fun tip -> tip.Probes.age_seconds)
+    ; problems = result.Probes.problems
+    }
+
+(* ---------- connectivity ---------- *)
+
+let connectivity_command =
+  Command.async
+    ~summary:
+      "Verify Rosetta's /network/list advertises the expected network.  Lists \
+       the advertised set when the expected network is absent."
+    (let%map_open.Command client = client_flag and json = json_flag in
+     fun () ->
+       let blockchain, network = expected client in
+       match%map
+         Probes.connectivity client ~expected_blockchain:blockchain
+           ~expected_network:network
+       with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.connectivity_to_yojson (Out.connectivity_failed message) )
+       | Ok advertised ->
+           if json then
+             output
+               (Out.connectivity_to_yojson
+                  { Out.healthy = true
+                  ; expected_network = Some network
+                  ; advertised = List.map advertised ~f:advertised_network_id
+                  ; error = None
+                  } )
+           else
+             output_line
+               (sprintf "advertises %d networks (contains %s)"
+                  (List.length advertised) network ) )
+
+(* ---------- tip-recency ---------- *)
+
+let tip_recency_command =
+  Command.async
+    ~summary:
+      "POST /network/status — exit 0 if tip is returned and its timestamp is \
+       within --max-age"
+    (let%map_open.Command client = client_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       match%map Probes.tip_recency client ~max_age with
+       | Error e ->
+           fail_unreachable ~json e ~record:(fun message ->
+               Out.tip_recency_to_yojson (Out.tip_recency_failed message) )
+       | Ok tip ->
+           let record ~healthy ~max_age_field ~error =
+             Out.tip_recency_to_yojson
+               { Out.healthy
+               ; block_height = Some tip.Probes.height
+               ; block_hash = Some tip.Probes.hash
+               ; age_seconds = Some tip.Probes.age_seconds
+               ; max_age = max_age_field
+               ; error
+               }
+           in
+           if tip.Probes.fresh then
+             if json then
+               output (record ~healthy:true ~max_age_field:None ~error:None)
+             else
+               output_line
+                 (sprintf "tip height=%Ld hash=%s age=%Lds" tip.Probes.height
+                    tip.Probes.hash tip.Probes.age_seconds )
+           else
+             let message =
+               sprintf "tip is %Ld seconds old, exceeds max age %d"
+                 tip.Probes.age_seconds max_age
+             in
+             fail ~json
+               ~record:
+                 ( lazy
+                   (record ~healthy:false ~max_age_field:(Some max_age)
+                      ~error:(Some message) ) )
+               ~line:(lazy message) )
+
+(* ---------- ready and wait ---------- *)
+
+let ready_command =
+  Command.async
+    ~summary:
+      "Composite readiness: connectivity + tip-recency + /network/options"
+    (let%map_open.Command client = client_flag
+     and json = json_flag
+     and max_age = max_age_flag in
+     fun () ->
+       let blockchain, network = expected client in
+       let%map result =
+         Probes.readiness client ~expected_blockchain:blockchain
+           ~expected_network:network ~max_age
+       in
+       if result.Probes.ready then
+         if json then output (readiness_json result) else output_line "READY"
+       else
+         fail ~json
+           ~record:(lazy (readiness_json result))
+           ~line:
+             ( lazy
+               (sprintf "NOT READY: %s"
+                  (String.concat ~sep:", " result.Probes.problems) ) ) )
+
+let wait_command =
+  Command.async
+    ~summary:"Block until Rosetta passes readiness checks or --deadline expires"
+    (let%map_open.Command client = client_flag
+     and json = json_flag
+     and max_age = max_age_flag
+     and deadline_secs = deadline_flag
+     and interval = interval_flag in
+     fun () ->
+       setup_logging ~json ;
+       let blockchain, network = expected client in
+       let start = Time_float.now () in
+       let deadline =
+         Time_float.add start (Time_float.Span.of_int_sec deadline_secs)
+       in
+       let timed_out () = Time_float.( >= ) (Time_float.now ()) deadline in
+       let elapsed () =
+         Float.to_int
+           (Time_float.Span.to_sec (Time_float.diff (Time_float.now ()) start))
+       in
+       let rec loop () =
+         let%bind result =
+           Probes.readiness client ~expected_blockchain:blockchain
+             ~expected_network:network ~max_age
+         in
+         let problems = String.concat ~sep:", " result.Probes.problems in
+         if result.Probes.ready then (
+           if json then output (readiness_json result) else output_line "READY" ;
+           Deferred.unit )
+         else if timed_out () then
+           fail ~json
+             ~record:(lazy (readiness_json ~timed_out:true result))
+             ~line:
+               (lazy (sprintf "timed out waiting for readiness: %s" problems))
+         else (
+           (* The problems go as metadata, not in the message: they
+              carry server text verbatim, and a "$" in a log message is
+              read as an interpolation with nothing behind it, which
+              makes Logger replace the whole line. *)
+           [%log info] "not ready after $elapsed_seconds s: $problems"
+             ~metadata:
+               [ ("elapsed_seconds", `Int (elapsed ()))
+               ; ( "problems"
+                 , `List
+                     (List.map result.Probes.problems ~f:(fun problem ->
+                          `String problem ) ) )
+               ] ;
+           (* Never sleep past the deadline: a plain [--interval] nap
+              would let [--deadline 600 --interval 300] run for 900s
+              before reporting that it had timed out. *)
+           let%bind () =
+             after
+               (Time_float.Span.min
+                  (Time_float.Span.of_int_sec interval)
+                  (Time_float.diff deadline (Time_float.now ())) )
+           in
+           loop () )
+       in
+       loop () )
+
+let () =
+  Command_unix.run
+    (Command.group
+       ~summary:
+         "Mina Rosetta healthcheck CLI — readiness and recency probes. For \
+          generic Rosetta API calls use 'rosetta-client'."
+       [ ("ready", ready_command)
+       ; ("wait", wait_command)
+       ; ("tip-recency", tip_recency_command)
+       ; ("connectivity", connectivity_command)
+       ] )

--- a/src/app/rosetta/healthcheck/tests/dune
+++ b/src/app/rosetta/healthcheck/tests/dune
@@ -1,0 +1,23 @@
+;; Hermetic alcotest smoke tests for rosetta-healthcheck.
+;;
+;; These exercise only the subcommands that don't require a running
+;; Rosetta server: --help at the top level, the flag bounds, and the
+;; single-JSON-record contract for [ready --json] / [tip-recency --json]
+;; / [connectivity --json] against a dead port.  The spawning and the
+;; assertions live in rosetta_cli_test_helpers, shared with the
+;; rosetta-client suite.
+
+(test
+ (name test_rosetta_healthcheck)
+ (libraries
+  ;; opam libraries
+  alcotest
+  core
+  yojson
+  ;; local libraries
+  rosetta_cli_test_helpers)
+ (deps ../rosetta_healthcheck.exe)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version)))

--- a/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
+++ b/src/app/rosetta/healthcheck/tests/test_rosetta_healthcheck.ml
@@ -1,0 +1,169 @@
+(* Hermetic alcotest smoke tests for rosetta-healthcheck.
+
+   These exercise only the subcommands that don't require a running
+   Rosetta server: --help at the top level and the single-JSON-record
+   contract for [ready --json] / [tip-recency --json] /
+   [connectivity --json] against a dead port. *)
+
+open Core
+open Rosetta_cli_test_helpers
+
+let bin = exe_beside_test "rosetta_healthcheck.exe"
+
+let run_cli ?env args = run_cli ~bin ?env args
+
+(* ---------- Tests ---------- *)
+
+let test_help_root () =
+  let code, out, err = run_cli [ "--help" ] in
+  Alcotest.(check int) "--help exit" 0 code ;
+  List.iter [ "ready"; "wait"; "tip-recency"; "connectivity" ] ~f:(fun sub ->
+      check_contains ~label:(sprintf "--help lists %s" sub) out ~sub ) ;
+  assert_no_ocaml_exn_leak "--help stderr" err
+
+let test_ready_dead_port_text () =
+  let code, out, err =
+    run_cli [ "ready"; "--rosetta-uri"; "http://127.0.0.1:1" ]
+  in
+  if code = 0 then Alcotest.failf "ready (dead port): expected non-zero exit" ;
+  let combined = out ^ "\n" ^ err in
+  check_contains ~label:"ready text mentions NOT READY" combined
+    ~sub:"NOT READY" ;
+  assert_no_ocaml_exn_leak "ready stdout" out ;
+  assert_no_ocaml_exn_leak "ready stderr" err
+
+(* "Exactly one JSON object on stdout", the double-print regression the
+   ready/wait/tip-recency/connectivity paths all need to avoid:
+   [Yojson.Safe.from_string] rejects a second object as junk after the
+   end of the value, so parsing is the whole check. *)
+let parse_single_json_record ~label out err =
+  let trimmed = String.strip out in
+  if String.is_empty trimmed then
+    Alcotest.failf "%s: stdout empty, stderr:\n%s" label err ;
+  let json =
+    try Yojson.Safe.from_string trimmed
+    with exn ->
+      Alcotest.failf "%s: stdout did not parse as JSON: %s\nstdout=%s" label
+        (Exn.to_string exn) out
+  in
+  match json with
+  | `Assoc fields ->
+      fields
+  | _ ->
+      Alcotest.failf "%s: stdout was not a JSON object: %s" label out
+
+let check_bool_field ~label fields ~field ~expected =
+  match List.Assoc.find fields ~equal:String.equal field with
+  | Some (`Bool b) when Bool.equal b expected ->
+      ()
+  | Some v ->
+      Alcotest.failf "%s: expected %s:%b, got %s" label field expected
+        (Yojson.Safe.to_string v)
+  | None ->
+      Alcotest.failf "%s: missing %S field" label field
+
+(* Each probe against a dead port: exactly one well-formed record on
+   stdout, its flag false, exit 1, and no OCaml exception leakage. *)
+let test_dead_port_json () =
+  List.iter
+    [ ("ready", "ready")
+    ; ("tip-recency", "healthy")
+    ; ("connectivity", "healthy")
+    ]
+    ~f:(fun (subcommand, field) ->
+      let code, out, err =
+        run_cli [ subcommand; "--rosetta-uri"; "http://127.0.0.1:1"; "--json" ]
+      in
+      let label = sprintf "%s --json (dead port)" subcommand in
+      Alcotest.(check int) (label ^ " exit") 1 code ;
+      assert_no_ocaml_exn_leak (label ^ " stdout") out ;
+      assert_no_ocaml_exn_leak (label ^ " stderr") err ;
+      let fields = parse_single_json_record ~label out err in
+      check_bool_field ~label fields ~field ~expected:false )
+
+(* A flag value below its floor is refused before any request goes out,
+   with a message the operator can act on and no OCaml exception syntax
+   -- [Command] would render an escaping exception as [(Failure "...")].
+   [--interval 0] is the one that matters: it asks for a poll loop with
+   no pause, which hammers the server the probe is checking. *)
+let test_out_of_range_flag_refused () =
+  List.iter
+    [ ([ "wait"; "--interval"; "0" ], "--interval must be at least 1 second")
+    ; ([ "wait"; "--deadline"; "0" ], "--deadline must be at least 1 second")
+    ; ([ "ready"; "--max-age"; "-1" ], "--max-age must be at least 0 seconds")
+    ; ([ "ready"; "--timeout"; "0" ], "--timeout must be a positive number")
+    ]
+    ~f:(fun (args, expected) ->
+      let label = String.concat ~sep:" " args in
+      let code, out, err = run_cli args in
+      (* 2, not 1: a mistyped flag is not the probe reporting that the
+         server is unhealthy. *)
+      Alcotest.(check int) (sprintf "%s: exit" label) 2 code ;
+      check_contains ~label:(sprintf "%s: message" label) err ~sub:expected ;
+      if String.is_substring err ~substring:"(Failure" then
+        Alcotest.failf "%s: message wrapped in OCaml exception syntax:\n%s"
+          label err ;
+      assert_no_ocaml_exn_leak (sprintf "%s stderr" label) err ;
+      if not (String.is_empty (String.strip out)) then
+        Alcotest.failf "%s: expected nothing on stdout, got:\n%s" label out )
+
+(* [wait] is the one subcommand that writes to stderr while it runs --
+   one progress line per attempt -- so it is also the one that could not
+   be tested until the suite drained both pipes concurrently.  Against a
+   dead port it should report every attempt on stderr and still print
+   exactly one record on stdout. *)
+let test_wait_reports_progress_and_one_record () =
+  let code, out, err =
+    run_cli
+      [ "wait"
+      ; "--rosetta-uri"
+      ; "http://127.0.0.1:1"
+      ; "--deadline"
+      ; "3"
+      ; "--interval"
+      ; "1"
+      ; "--json"
+      ]
+  in
+  Alcotest.(check int) "wait (dead port) exit" 1 code ;
+  assert_no_ocaml_exn_leak "wait stdout" out ;
+  assert_no_ocaml_exn_leak "wait stderr" err ;
+  check_contains ~label:"wait reports progress on stderr" err ~sub:"not ready" ;
+  (* With --json the diagnostics are machine-readable too: every stderr
+     line is one Logger record, so a caller collecting the probe's
+     output does not have to parse prose out of the same stream. *)
+  List.iter
+    (List.filter (String.split_lines err) ~f:(fun line ->
+         not (String.is_empty (String.strip line)) ) )
+    ~f:(fun line ->
+      match Yojson.Safe.from_string line with
+      | `Assoc fields ->
+          if not (List.Assoc.mem fields ~equal:String.equal "level") then
+            Alcotest.failf "wait --json: stderr record has no level:\n%s" line
+      | _ | (exception _) ->
+          Alcotest.failf "wait --json: stderr line is not one JSON record:\n%s"
+            line ) ;
+  let fields = parse_single_json_record ~label:"wait (dead port)" out err in
+  check_bool_field ~label:"wait --json" fields ~field:"ready" ~expected:false ;
+  check_bool_field ~label:"wait --json" fields ~field:"timed_out" ~expected:true
+
+(* ---------- Runner ---------- *)
+
+let () =
+  Alcotest.run "rosetta-healthcheck CLI smoke tests"
+    [ ("help", [ ("root", `Quick, test_help_root) ])
+    ; ( "dead port"
+      , [ ("ready text format", `Quick, test_ready_dead_port_text)
+        ; ("json is one record per probe", `Quick, test_dead_port_json)
+        ] )
+    ; ( "wait"
+      , [ ( "reports progress and one record"
+          , `Quick
+          , test_wait_reports_progress_and_one_record )
+        ] )
+    ; ( "flag bounds"
+      , [ ( "out-of-range values are refused"
+          , `Quick
+          , test_out_of_range_flag_refused )
+        ] )
+    ]

--- a/src/lib/rosetta_client/data.ml
+++ b/src/lib/rosetta_client/data.ml
@@ -35,8 +35,18 @@ let decode of_yojson response =
       | Ok response ->
           Async.Deferred.Or_error.return response
       | Error msg ->
+          (* [of_yojson] reports the field it stopped at, which is the
+             useful half of the diagnostic; say what that means around
+             it.  A generated model rejects a response only when a
+             required field is absent or ill-typed -- an unknown extra
+             field decodes fine -- so this is a server that does not
+             speak the schema this build was generated from, not a
+             server that is down.  A caller which treats every error as
+             an outage would otherwise report it as one. *)
           Async.Deferred.Or_error.errorf
-            "response did not match Rosetta schema: %s" msg )
+            "server's response does not match the Rosetta schema this build \
+             expects (at %s)"
+            msg )
 
 let%test_unit "decode parses a matching response and rejects a mismatch" =
   Async.Thread_safe.block_on_async_exn (fun () ->

--- a/src/lib/rosetta_client/data.mli
+++ b/src/lib/rosetta_client/data.mli
@@ -18,7 +18,11 @@
 
 (** [decode of_yojson response] parses [response] through a generated
     Rosetta model's [of_yojson].  A response that does not match the
-    schema becomes an error rather than an exception. *)
+    schema becomes an error rather than an exception, and one that names
+    the offending field and says what a mismatch means: the models
+    ignore unknown fields, so only a missing or ill-typed required field
+    fails, which is a schema-version disagreement rather than a sick
+    server. *)
 val decode :
      (Yojson.Safe.t -> ('a, string) Result.t)
   -> Yojson.Safe.t Async.Deferred.Or_error.t

--- a/src/lib/rosetta_client/rosetta_client.mli
+++ b/src/lib/rosetta_client/rosetta_client.mli
@@ -1,7 +1,8 @@
 (** Mina Rosetta client library.
 
-    Thin HTTP client and typed Rosetta API surface, used by
-    [rosetta-client] (the generic CLI).
+    Thin HTTP client and typed Rosetta API surface, shared by
+    [rosetta-client] (the generic CLI) and [rosetta-healthcheck] (which
+    only exposes readiness probes).
 
     {[
       open Async


### PR DESCRIPTION
Split out of #18796, [as requested in review](https://github.com/MinaProtocol/mina/pull/18796#issuecomment-5490628438). This is PR C of four.

**Stacked on #19328** — review that one first; this PR shows its commits
until it merges.

## `rosetta-healthcheck`

| Command | Exit 0 when |
|---|---|
| `connectivity` | `/network/list` advertises the expected network (it lists the advertised set on a mismatch) |
| `tip-recency` | `/network/status` returns a tip whose timestamp is inside `--max-age` |
| `ready` | both of those, and `/network/options` |
| `wait` | `ready` passes before `--timeout` expires |

Each command prints exactly one result — one JSON object with `--json`,
one line without it — and exits 0 or 1, so it goes straight into a
Kubernetes exec probe, a Docker `HEALTHCHECK`, or a CI gate.

```
$ rosetta-healthcheck ready --json
{ "ready": true, "block_height": 428113, "age_seconds": 84 }

$ rosetta-healthcheck ready --json          # server down
{ "healthy": false, "error": "connection refused to http://localhost:3087/network/list" }
```

A field with no value is left out rather than written as `null`. Every
check runs even after an earlier one has failed, so one invocation reports
every problem instead of only the first.

`health_probes.ml` holds the probes and their verdicts and neither prints
nor exits; the CLI file owns the flags, the text/JSON choice and the exit
codes.

The binary uses `Http.create`, `Defaults` and three of `Data`'s entry
points (`network_list`, `network_status`, `network_options`). It uses no
Construction endpoint, so it does not depend on #19329.

## Environment

It reads the same `MINA_ROSETTA_URI`, `MINA_ROSETTA_BLOCKCHAIN` and
`MINA_ROSETTA_NETWORK` as `rosetta-client`, from
`Rosetta_client.Defaults`, so the two binaries cannot drift apart.

## Tests and CI

- A hermetic alcotest suite.
- The Rosetta integration test gains a negative check: before Rosetta is
  started, `rosetta-healthcheck ready` must fail cleanly and must not leak
  raw OCaml exception syntax.
- `RosettaIntegrationTests.dhall` gains `rosetta-healthcheck` in its
  `bareBinaries`.

## Packaging

The binary ships in `mina-rosetta` as `/usr/local/bin/rosetta-healthcheck`,
built by `make build-mina` and `make build-rosetta`.

## Open question, carried over from the review

Is there a consumer for `rosetta-healthcheck` yet? There is no
`HEALTHCHECK` or exec probe in this repository, and the integration test
uses its own bind loop (#19327) rather than `wait`, because at that point in
the script the daemon is not running and a functional probe cannot pass.
If the consumer lives in the deployment repository, it should be linked
here before this merges.
