### PR TITLE
docs: CI is triggered by a comment, not by a label

### DIFF
--- a/.agents/skills/mina-ci-commands/SKILL.md
+++ b/.agents/skills/mina-ci-commands/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mina-ci-commands
-description: Use when the user asks to trigger Mina CI, Buildkite CI, PR CI, !ci-build-me, !ci-single-me, !ci-docker-me, !ci-nightly-me, or other MinaProtocol/mina GitHub comment CI commands. Use this skill to choose the right magic comment and post it with gh CLI on Mina PRs instead of guessing command syntax.
+description: Use when the user asks to trigger Mina CI, Buildkite CI, PR CI, rerun a failed Mina build, run one Buildkite job, or rebuild the shared base/toolchain docker images — !ci-build-me, !ci-single-me, !ci-docker-me, !ci-docker-base-me, !ci-toolchain-me, !ci-debian-me, !ci-artifacts-me, !ci-nightly-me, !ci-nix-me, !approved-for-mainnet — and when a posted !ci-* comment produced no build, or a build looks failed but its artifact may be fine. Also covers casual phrasings: "kick off CI on that PR", "republish mina-base", "why did nothing start", "add the ci-build-me label". Use this skill to choose the right magic comment and post it with gh CLI on Mina PRs instead of guessing command syntax.
 ---
 
 # Mina CI Commands
@@ -9,14 +9,19 @@ Use this skill when working in or against `MinaProtocol/mina` and the user asks 
 
 The Mina repo uses GitHub PR comments as CI control commands. Prefer `gh` CLI; do not invent syntax. If the target PR or job/filter is ambiguous, ask one focused question before commenting.
 
+## Post a comment — never add a label
+
+Trigger CI by creating an **issue comment**; do not use `gh pr edit --add-label`. Every handler in `frontend/ci-build-me/src/index.js` gates on `issue_comment.created` — there is no label handler. A label named after a command does not exist in the repo, so `gh` creates it, leaving junk on the org's label list and starting no build.
+
 ## Safety checks before posting
 
 1. Identify the PR number or URL.
 2. Confirm the repository is `MinaProtocol/mina` unless the user explicitly gives another repo.
 3. If the requested command is broad or expensive (`!ci-build-me`, `!ci-nightly-me`, broad `!ci-docker-me`), proceed if the user clearly requested it; otherwise ask confirmation.
-4. Prefer exact command-only comments unless extra context is useful. The CI bot mostly keys off the command text.
-5. For PR-build commands (`!ci-build-me`, `!ci-nightly-me`, `!ci-docker-me`), confirm the PR is cleanly mergeable first — the webhook silently skips a non-mergeable PR, including the brief `UNKNOWN` window right after a push. Details and the poll command are in "Troubleshooting: the trigger produced no build".
-6. After posting, return the GitHub comment URL and the exact command body, then attach the triggered build as a follow-up `^ <build-url>` comment (see "Attach the Buildkite build URL as a follow-up comment").
+4. Post the command as the entire comment body. Any explanation belongs in a separate comment — see "Comment must match exactly, or by prefix".
+5. Check the comment shape against "Comment must match exactly, or by prefix" — an exact-match command with any extra prose attached is dropped without a word.
+6. For PR-build commands (`!ci-build-me`, `!ci-nightly-me`, `!ci-docker-me`), check the PR is cleanly mergeable first. Triggers fired in the brief `UNKNOWN` window right after a push have been observed to produce nothing. Poll command in "Troubleshooting: the trigger produced no build".
+7. After posting, return the GitHub comment URL and the exact command body, and stop. Do not poll Buildkite for the build to appear — see "Attach the Buildkite build URL as a follow-up comment" for the one non-blocking query that is worth making.
 
 Useful PR extraction:
 
@@ -38,9 +43,24 @@ gh api repos/MinaProtocol/mina/issues/$pr/comments \
 
 For multiline comments, use `-F body=/path/to/body.txt`.
 
+## Comment must match exactly, or by prefix
+
+Each handler in `frontend/ci-build-me/src/index.js` tests the **whole comment body**. Two shapes exist, and mixing them up is the quietest way to get no build at all:
+
+- **Exact (`==`)** — the comment must be *nothing but* the command: `!ci-build-me`, `!ci-nightly-me`, `!ci-nix-me`, `!ci-debian-me`, `!ci-toolchain-me`, `!ci-docker-base-me`, `!approved-for-mainnet`. A trailing "rebuilding the base images because X" makes the handler skip it silently.
+- **Prefix (`startsWith`)** — arguments allowed: `!ci-single-me`, `!ci-docker-me`, `!ci-artifacts-me`.
+
+Check which shape a command has before adding any prose to the comment:
+
+```bash
+grep -n 'comment.body ==\|comment.body.startsWith' frontend/ci-build-me/src/index.js
+```
+
+`!ci-docker-base-me` is deliberately handled *above* the `!ci-docker-me` prefix branch, since it shares that prefix.
+
 ## Commands handled by `frontend/ci-build-me`
 
-These commands are handled by the Mina `frontend/ci-build-me` webhook on `issue_comment.created` for PRs. The comment author must be a public member of the `MinaProtocol` GitHub org for most commands.
+These commands are handled by the Mina `frontend/ci-build-me` webhook on `issue_comment.created` for PRs. Every one of them requires the comment author be a **public** member of the `MinaProtocol` GitHub org.
 
 | Command | Buildkite pipeline | Use when |
 |---|---|---|
@@ -51,6 +71,8 @@ These commands are handled by the Mina `frontend/ci-build-me` webhook on `issue_
 | `!ci-docker-me` | `mina-build-docker` | Docker image build pipeline; may be filtered. |
 | `!ci-toolchain-me` | `mina-toolchains-build` | Rebuild the opam toolchain images (tag `Toolchain`). Takes hours. Does **not** touch the `mina-base` images. |
 | `!ci-docker-base-me` | `mina-docker-base-build` | Rebuild the shared `mina-base` images (tag `Base`) for all codenames. Use after changing `dockerfiles/stages/1-base-deps`, or to publish/refresh the `minaBase*` pins. |
+| `!ci-single-me <JobName>` | `mina-single-job` | Run one generated job and its dependencies. Passed as `JOB_NAME`. |
+| `!ci-artifacts-me <layer> [k=v]` | `mina-artifacts` | Build a named artifact layer (`docker`/`debian`/`apps`) with no triage. `develop` only — its entrypoint exists on no other branch. |
 | `!approved-for-mainnet` | `mina-pr-gating` | Mainnet approval/gating command; restricted to specific approvers. |
 
 Examples:
@@ -65,18 +87,41 @@ gh api repos/MinaProtocol/mina/issues/$pr/comments -f body='!ci-docker-base-me' 
 
 ## `!ci-docker-base-me`
 
-Takes no arguments. It triggers `mina-docker-base-build` with:
+Rebuilds the shared `mina-base` images — debian-slim plus the common apt deps and the gcloud SDK, the layer the daemon/archive/hardfork images are built `FROM`. Use it after changing `dockerfiles/stages/1-base-deps`, or to publish a fresh set for the `minaBase*` pins.
+
+Takes no arguments, and the comment body must be exactly `!ci-docker-base-me`. It triggers `mina-docker-base-build` with:
 
 ```text
 BUILDKITE_PIPELINE_FILTER=BaseDockersOnly
 BUILDKITE_PIPELINE_JOB_SELECTION=Full
 ```
 
-`BaseDockersOnly` maps to the `Base` tag, which only the `MinaBaseArtifact*` jobs carry, so the opam toolchain images are excluded. `Full` skips dirty-when triage, so the rebuild runs even when the PR touched nothing under `dockerfiles/stages/`.
+`BaseDockersOnly` maps to the `Base` tag (`buildkite/src/Pipeline/TagFilter.dhall`), which only the `MinaBaseArtifact*` jobs carry, so the opam toolchain images are excluded — `!ci-toolchain-me` and this command rebuild disjoint image sets, and bumping one is never a reason to bump the other. `Full` skips dirty-when triage, so the rebuild runs even when the PR touched nothing under `dockerfiles/stages/1-base-deps`, which is the whole point of an on-demand rebuild.
 
 This is the **only** way these jobs run: they carry neither `Fast` nor `Long`, so the standard PR/nightly pipeline stages (`FastOnly`, `LongAndVeryLong`, `TearDownOnly`) filter them out regardless of `dirtyWhen`.
 
-Each selected job pushes to `docker.io/minaprotocol/mina-base:<githash>-<codename>-<network>` and writes `${CACHE_ROOT}/mina-base/<tag>.tar.zst` to the storagebox. After it finishes, bump the `minaBase*` pins in `buildkite/src/Constants/ContainerImages.dhall` to the new githash, otherwise the daemon/archive builds keep falling back to building the base-deps stage inline.
+One run builds every job under `buildkite/src/Jobs/Release/MinaBaseArtifact*.dhall` — currently Bullseye, Bookworm, BookwormArm64, Focal, Jammy, Noble. Confirm the current set rather than trusting this list:
+
+```bash
+ls buildkite/src/Jobs/Release/MinaBaseArtifact*.dhall
+```
+
+Each job pushes `docker.io/minaprotocol/mina-base:<githash>-<codename>-<network>` (the `network` segment is `devnet` for these specs; arm64 adds an `-arm64` suffix) and writes `${CACHE_ROOT}/mina-base/<tag>.tar.zst` under `/var/storagebox/docker-cache`.
+
+### After it finishes: bump the pins
+
+The build is only half the job. Verify the image is actually published, then bump the `minaBase*` entries in `buildkite/src/Constants/ContainerImages.dhall` to the new short githash — all of them land on one hash:
+
+```bash
+tok=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:minaprotocol/mina-base:pull" \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])')
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $tok" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+  "https://registry-1.docker.io/v2/minaprotocol/mina-base/manifests/<7charsha>-bullseye-devnet"   # 200 = published
+```
+
+A stale or unpublished pin is not fatal — `scripts/docker/build.sh` falls back to inlining the base-deps stage when the image is not in the CI cache — so the only cost of forgetting the bump is losing the reuse, which shows up as slower builds rather than a failure. That silence is why the bump is easy to skip; do it in the same PR.
 
 ## `!ci-docker-me` filters
 
@@ -113,17 +158,19 @@ gh api repos/MinaProtocol/mina/issues/$pr/comments \
   --jq '.html_url'
 ```
 
-If any of `arch`, `profile`, or `codename` is missing, the current handler falls back to the broad filter:
+Partial keys are kept, not discarded: `arch=amd64` alone yields the real filter `DockerBuildAmd64`. Only a bare `!ci-docker-me` with none of the three keys falls back to the broad filter:
 
 ```text
 BUILDKITE_PIPELINE_FILTER=DockerBuild
 ```
 
+An *invalid* value is silently dropped from the filter rather than rejected, so `codename=trixie` quietly widens the build instead of failing. Check spellings against the lists above.
+
 Do not use old examples like `network=testnet-generic`; the current handler ignores that key.
 
 ## `!ci-single-me <JobName>`
 
-`!ci-single-me` is not handled by `frontend/ci-build-me`. It is a separate mechanism that runs `buildkite/scripts/run-single-job-with-deps.sh` or equivalent logic.
+Handled by `frontend/ci-build-me` as a **prefix** command: the job name is the last whitespace-separated word of the comment, checked against an allow-list of characters in `src/safe-input.js`, then passed to the `mina-single-job` pipeline as `JOB_NAME`. That pipeline runs `buildkite/scripts/run-single-job-with-deps.sh`.
 
 Use it to trigger one generated Buildkite job and its dependencies:
 
@@ -221,9 +268,9 @@ done
 
 ## Attach the Buildkite build URL as a follow-up comment
 
-The `ci-build-me` webhook eventually posts its own `^ https://buildkite.com/...` reply, but it can lag several minutes. After triggering a `!ci-*` command, locate the build it started and post a follow-up comment pinning the URL into the PR's comment section, mirroring the bot's own `^ <url>` format. This gives reviewers a direct link without waiting on the bot.
+The `ci-build-me` webhook posts its own `^ https://buildkite.com/...` reply, but it can lag several minutes. A `^ <build-url>` follow-up comment pins the link into the PR for reviewers — worth doing, but **not worth stalling the turn for**: do not run a sleep/retry loop waiting for the build to appear. The person who asked for the trigger usually has the Buildkite UI open and sees it first. Post the trigger, report the comment URL, and either ask for the build URL or make **one** non-blocking query.
 
-Each command maps to a pipeline slug (see the tables above), all under the `o-1-labs-2` Buildkite org:
+Pipeline slugs, all under the `o-1-labs-2` Buildkite org:
 
 | Command | Pipeline slug |
 |---|---|
@@ -233,22 +280,21 @@ Each command maps to a pipeline slug (see the tables above), all under the `o-1-
 | `!ci-docker-me` | `mina-build-docker` |
 | `!ci-toolchain-me` | `mina-toolchains-build` |
 | `!ci-nix-me` | `mina-nix-experimental` |
+| `!ci-docker-base-me` | `mina-docker-base-build` |
+| `!ci-single-me` | `mina-single-job` |
+| `!ci-artifacts-me` | `mina-artifacts` |
 
-Match on the **head commit SHA**, not just the branch (`BUILDKITE_API_TOKEN` must be set). A branch filter alone is unreliable: right after a trigger the newest branch build is often a *previous* commit (webhook lag), and on busy pipelines the branch's builds may sit several pages deep. Query by commit and poll until the build for the current head appears:
+Query by **head commit SHA**, not branch: right after a trigger the newest branch build is often a *previous* commit, and on busy pipelines the branch's builds sit pages deep (`BUILDKITE_API_TOKEN` must be set; it is read-only, so it can look but not retry or cancel).
 
 ```bash
 pipeline=mina-o-1-labs   # from the mapping above
 sha=$(gh pr view "$pr" --repo MinaProtocol/mina --json headRefOid --jq .headRefOid)
-for i in $(seq 1 20); do
-  build_url=$(curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
-    "https://api.buildkite.com/v2/organizations/o-1-labs-2/pipelines/$pipeline/builds?commit=$sha&per_page=1" \
-    | python3 -c 'import sys,json; b=json.load(sys.stdin); print(b[0]["web_url"]) if b else print("")')
-  [ -n "$build_url" ] && break
-  sleep 30   # webhook lag; keep polling
-done
+curl -s -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+  "https://api.buildkite.com/v2/organizations/o-1-labs-2/pipelines/$pipeline/builds?commit=$sha&per_page=1" \
+  | python3 -c 'import sys,json; b=json.load(sys.stdin); print(b[0]["web_url"]) if b else print("not yet")'
 ```
 
-If polling never finds a build (empty after several minutes), the trigger was almost certainly skipped — jump to "Troubleshooting: the trigger produced no build" rather than posting a stale/guessed URL. Once found, post it exactly mirroring the bot's format (leading `^ `):
+An empty result means only that the webhook has not landed yet — say so and move on, rather than looping. If it is still empty minutes later when someone checks, the trigger was probably skipped: see "Troubleshooting: the trigger produced no build". Never post a guessed or stale URL. Once you have a real one:
 
 ```bash
 gh api repos/MinaProtocol/mina/issues/$pr/comments \
@@ -267,13 +313,15 @@ gh api repos/MinaProtocol/mina/issues/comments/<id> --jq '{author:.user.login,ty
 
 The real causes, in order of likelihood:
 
-1. **PR not cleanly mergeable.** The `ci-build-me` path skips a PR whose `mergeStateStatus` is `DIRTY`/`CONFLICTING` — or `UNKNOWN`, the transient state GitHub reports for a few seconds after every push while it recomputes. A trigger fired in that window is silently dropped. This is the most common surprise: a trigger sent seconds after a `git push` fails, the identical command a minute later succeeds. Poll until it settles, then re-post:
+1. **The comment body was not an exact match.** For an `==` command, any extra character — a trailing note, a second line, a stray space — means no handler matched and nothing was logged. Re-post the command alone. See "Comment must match exactly, or by prefix".
+2. **Author not a public org member.** Every command requires the comment author be a *public* member of the `MinaProtocol` org — private membership does not count, because the handler reads the sender's public `organizations_url`. Check with `gh api orgs/MinaProtocol/public_members/<login> -i` (204 = yes).
+3. **The deployed webhook is older than the repo.** `frontend/ci-build-me` is one Google Cloud Function serving every branch, deployed by hand (see `frontend/ci-build-me/README.md`). A command that exists in `src/index.js` on your branch does nothing until someone redeploys. Suspect this first for a recently added command; ask whoever owns the deploy rather than retrying.
+4. **PR not cleanly mergeable.** Empirically, a trigger sent seconds after a `git push` — while GitHub reports `mergeStateStatus: UNKNOWN` — can vanish, and the identical command a minute later succeeds. Nothing in the current `src/index.js` gates on mergeability, so treat this as observed behaviour rather than a documented rule: poll until it settles, then re-post.
    ```bash
    gh pr view "$pr" --repo MinaProtocol/mina --json mergeable,mergeStateStatus \
      --jq '{mergeable,mergeStateStatus}'   # want mergeable=MERGEABLE, status not DIRTY/UNKNOWN
    ```
-2. **Author not a public org member.** Most commands require the comment author be a *public* member of the `MinaProtocol` org. Check with `gh api orgs/MinaProtocol/public_members/<login> -i` (204 = yes).
-3. **Webhook lag.** Genuine builds can take a couple of minutes to appear; keep polling by commit SHA (above) before concluding it was skipped.
+5. **Webhook lag.** Genuine builds can take a couple of minutes to appear; keep polling by commit SHA (above) before concluding it was skipped.
 
 Who actually created a build (confirms the webhook fired vs a manual Buildkite trigger):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,8 @@ dune runtest src/lib/mina_lib
 - `packages.o1test.net` - Unsigned, legacy multichannel repo
 
 ## CI/PR Process
-- Full CI run need `!ci-nightly-me` comment for CI to run
-- PRs from main repo need `!ci-build-me` label
+- CI is triggered by a PR **comment**, never by a label: comment `!ci-build-me` for standard CI, `!ci-nightly-me` for the nightly/end-to-end pipeline
+- Most commands are matched against the whole comment body, so post the command alone with no extra prose
+- The comment author must be a public member of the MinaProtocol org
 - Code must be formatted with `make reformat` before commits
 - CI uses Docker images from `europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,13 @@ Maintainers assign reviewers to pull requests and tag the pull requests with
 relevant labels. If you happen to have access to the development Slack,
 you can skip this step by asking reviewers directly in the #review-requests channel.
 
-- If you are PRing from the main remote branch, add the **ci-build-me** label when you want to run CI. 
-- If you are PRing from a fork, ask a core contributor to add the `!ci-build-me` comment to your PR when you're ready for CI to run. 
+- Comment `!ci-build-me` on your pull request when you want to run CI. The
+  comment must be exactly that, with nothing else in it.
+- The comment author must be a *public* member of the MinaProtocol
+  organization. If you are PRing from a fork, ask a core contributor to post it.
 
 **Note:** The `!ci-build-me` comment is required for each and every run of CI.
+Labels do not trigger CI.
 
 After a PR has been reviewed and approved and all CI tests have passed, the PR can be merged
 by a maintainer (or by you, if you have this access).

--- a/README-ci-failures.md
+++ b/README-ci-failures.md
@@ -1,16 +1,25 @@
 ## Jobs not starting
 
-CI jobs are dispatched by a script which responds to both the `ci-build-me`
-label and comments by MinaProtocol organization members containing exactly
-`!ci-build-me`. If your CI job has not started after adding the `ci-build-me`
-label, please comment on the pull request with `!ci-build-me` to attempt to
-re-trigger the script.
+CI jobs are dispatched by a script which responds to **comments** by
+MinaProtocol organization members containing exactly `!ci-build-me`. Adding a
+label does not start a build: the script handles `issue_comment.created` events
+only, and the older label-triggered path no longer exists. If your CI job has
+not started, comment `!ci-build-me` on the pull request.
+
+The comment must be *exactly* the command and nothing else -- most commands are
+matched against the whole comment body, so appending an explanation to it stops
+the script from recognising it. Put any explanation in a separate comment.
+
 If no CI jobs started, check that your membership to O(1) Labs/mina organisation
-is public. If your membership is private, the jobs will not started and
+is public. If your membership is private, the jobs will not start and
 `!ci-build-me` won't have an impact.
 
-If CI jobs are not running after applying both the `ci-build-me` label and
-comment, you may be able to find and fix the error in the script. The script
+Note also that the script is a Google Cloud Function deployed by hand, so a
+command that exists in `src/index.js` on your branch does nothing until someone
+redeploys it.
+
+If CI jobs are still not running, you may be able to find and fix the error in
+the script. The script
 lives in `frontend/ci-build-me/src/index.js`, and instructions for deploying
 the new version are in the readme at `frontend/ci-build-me/README.md`. You
 should still follow normal procedure: submit a pull request and await approval

--- a/docs/uploading-genesis-proofs.md
+++ b/docs/uploading-genesis-proofs.md
@@ -34,7 +34,7 @@ Pull requests on CI will run the ['Build Mina daemon debian package' job](https:
 * `git add genesis_ledgers/phase_three/config.json && git commit`
 * push the branch and open a pull request
   - It's good practice to add a title like `[DO NOT MERGE] Generate genesis proof for foo`
-* set CI to run on the pull request by adding the `ci-build-me` label, or by commenting `!ci-build-me`
+* set CI to run on the pull request by commenting `!ci-build-me` (the comment must be exactly that; labels do not trigger CI)
 * when CI has finished, close the pull request
 
 ### Manually generate the proof and upload to CI

--- a/frontend/ci-build-me/README.md
+++ b/frontend/ci-build-me/README.md
@@ -6,7 +6,11 @@ For JS code, only `src/index.js` was modified.
 
 This proxy listens on a webhook via a Google Cloud Function and conditionally starts the Mina buildkite pipeline.
 
-We currently dispatch a build the moment the `ci-build-me` label is added and any time commits are pushed to a pull-request that has this label attached to it.
+A build is dispatched by a **comment** on a pull request: the function handles
+`issue_comment.created` events and nothing else. Labels do not trigger anything
+-- an earlier version of this function dispatched on the `ci-build-me` label,
+and that handler is gone. The comment author must be a *public* member of the
+`MinaProtocol` organization.
 
 ## Commands
 


### PR DESCRIPTION
## Why

Five documents tell the reader to add a `ci-build-me` label to start CI:

- `CONTRIBUTING.md` — "add the **ci-build-me** label when you want to run CI"
- `README-ci-failures.md` — "responds to both the `ci-build-me` label and comments"
- `frontend/ci-build-me/README.md` — "dispatch a build the moment the `ci-build-me` label is added"
- `CLAUDE.md` — "PRs from main repo need `!ci-build-me` label"
- `docs/uploading-genesis-proofs.md` — "by adding the `ci-build-me` label, or by commenting"

The webhook has no label handler. Every branch in `frontend/ci-build-me/src/index.js` gates on an `issue_comment.created` event; the label-triggered path that these documents describe is gone. Following the instruction leaves a label on the pull request and starts no build, so the PR reads as having had CI requested when it has not. `hasExistingBuilds` in `index.js` is a leftover of the same era — it still queries a pipeline named `mina` that nothing else refers to — but removing dead code is out of scope here.

## What changed

Each document now says a comment is the trigger. Two further facts produce the same silent nothing and were written down nowhere, so they are recorded alongside:

- most commands are compared against the **whole comment body**, so an explanation appended to the command stops it matching;
- the script is a hand-deployed Google Cloud Function, so a command present in `index.js` on a branch does nothing until someone redeploys it.

The second commit corrects `.agents/skills/mina-ci-commands`, which had drifted from `index.js` in three places: `!ci-single-me` was documented as not being handled by the webhook (it is, via the `mina-single-job` pipeline), `!ci-artifacts-me` was absent, and a `!ci-docker-me` missing one of `arch`/`profile`/`codename` was said to fall back to the broad `DockerBuild` filter — `buildEnvFromParams` in fact keeps partial keys, and silently drops an invalid value rather than rejecting it, so a misspelt codename quietly widens the build.

Documentation only; no behaviour changes, and no changelog entry since there is no observable end-user effect.

## Note for reviewers

These edits reach readers only on the branches they are merged into. `compatible`, `master` and the release branches keep the label instructions until this is forward-merged, even though the webhook they describe is the same single deployment for every branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfahNJgSRReBa9Cf7jEgyy