### PR TITLE
rosetta, archive: bootstrap the database with mina-provision

### DIFF
--- a/src/app/archive/docker-compose/README.md
+++ b/src/app/archive/docker-compose/README.md
@@ -108,6 +108,5 @@ See `example.devnet.env` and `example.mainnet.env`. Key differences between netw
 |----------|--------|---------|
 | `MINA_NETWORK` | `devnet` | `mainnet` |
 | `MINA_PEERLIST_URL` | devnet seeds | mainnet bootnodes |
-| `ARCHIVE_DUMP_PREFIX` | `devnet-archive-dump` | `mainnet-archive-dump` |
 | `GUARDIAN_PRECOMPUTED_BLOCKS_URL` | devnet bucket | mainnet bucket |
 | Docker image tags | `*-devnet` | `*-mainnet` |

--- a/src/app/archive/docker-compose/docker-compose.yml
+++ b/src/app/archive/docker-compose/docker-compose.yml
@@ -16,23 +16,20 @@ services:
     ports:
       - '${POSTGRES_PORT}:5432'
 
+  # Downloads the published archive dump, applies the recommended Postgres
+  # tuning, and loads it. mina-provision derives the dump location and file
+  # name from MINA_NETWORK, so no dump URL or prefix is configured here.
   bootstrap_db:
-    image: '${MINA_ARCHIVE_IMAGE}'
+    image: '${MINA_PROVISION_IMAGE}'
     environment:
+      MINA_NETWORK: ${MINA_NETWORK}
       PGPASSWORD: ${POSTGRES_PASSWORD}
     command:
-      - bash
-      - -c
-      - |
-        set -eo pipefail
-        curl -fSL -O ${ARCHIVE_DUMP_BASE_URL}/${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql.tar.gz
-        tar -zxvf ${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql.tar.gz
-        psql postgres://${POSTGRES_USER}@postgres:5432/${POSTGRES_DB} \
-          -c "ALTER SYSTEM SET max_connections = 500" \
-          -c "ALTER SYSTEM SET max_locks_per_transaction = 100" \
-          -c "ALTER SYSTEM SET max_pred_locks_per_relation = 100" \
-          -c "ALTER SYSTEM SET max_pred_locks_per_transaction = 5000"
-        psql postgres://${POSTGRES_USER}@postgres:5432/${POSTGRES_DB} -f ${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql
+      - archive
+      - --pg-uri
+      - postgres://${POSTGRES_USER}@postgres:5432/${POSTGRES_DB}
+      - --work-dir
+      - /tmp
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/app/archive/docker-compose/docker-compose.yml
+++ b/src/app/archive/docker-compose/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       PGPASSWORD: ${POSTGRES_PASSWORD}
     command:
       - archive
+      # Leave an existing archive alone. Without this, every `compose down &&
+      # up` re-downloads the dump and imports it over a database that has
+      # advanced since, losing the blocks collected in between.
+      - --if-present=skip
       - --pg-uri
       - postgres://${POSTGRES_USER}@postgres:5432/${POSTGRES_DB}
       - --work-dir

--- a/src/app/archive/docker-compose/example.devnet.env
+++ b/src/app/archive/docker-compose/example.devnet.env
@@ -7,6 +7,7 @@ POSTGRES_PORT=5433
 # Docker images
 MINA_DAEMON_IMAGE=gcr.io/o1labs-192920/mina-daemon:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ARCHIVE_IMAGE=gcr.io/o1labs-192920/mina-archive:3.3.0-alpha1-6929a7e-bullseye-devnet
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
 
 # Network
 MINA_NETWORK=devnet
@@ -25,5 +26,6 @@ GUARDIAN_PRECOMPUTED_BLOCKS_URL=https://storage.googleapis.com/mina_network_bloc
 # GUARDIAN_SLEEP_INTERVAL=600  # optional, defaults to 600
 
 # Archive DB bootstrap
-ARCHIVE_DUMP_BASE_URL=https://storage.googleapis.com/mina-archive-dumps
-ARCHIVE_DUMP_PREFIX=devnet-archive-dump
+# mina-provision derives the dump location and file name from MINA_NETWORK.
+# To read from a mirror instead, mount a provider file and set
+# MINA_PROVISION_CONFIG; see the mina-provision documentation.

--- a/src/app/archive/docker-compose/example.devnet.env
+++ b/src/app/archive/docker-compose/example.devnet.env
@@ -7,7 +7,7 @@ POSTGRES_PORT=5433
 # Docker images
 MINA_DAEMON_IMAGE=gcr.io/o1labs-192920/mina-daemon:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ARCHIVE_IMAGE=gcr.io/o1labs-192920/mina-archive:3.3.0-alpha1-6929a7e-bullseye-devnet
-MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.3
 
 # Network
 MINA_NETWORK=devnet

--- a/src/app/archive/docker-compose/example.mainnet.env
+++ b/src/app/archive/docker-compose/example.mainnet.env
@@ -7,7 +7,7 @@ POSTGRES_PORT=5433
 # Docker images
 MINA_DAEMON_IMAGE=minaprotocol/mina-daemon:3.3.1-7b34378-noble-mainnet
 MINA_ARCHIVE_IMAGE=minaprotocol/mina-archive:3.3.1-7b34378-noble-mainnet
-MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.3
 
 # Network
 MINA_NETWORK=mainnet

--- a/src/app/archive/docker-compose/example.mainnet.env
+++ b/src/app/archive/docker-compose/example.mainnet.env
@@ -7,6 +7,7 @@ POSTGRES_PORT=5433
 # Docker images
 MINA_DAEMON_IMAGE=minaprotocol/mina-daemon:3.3.1-7b34378-noble-mainnet
 MINA_ARCHIVE_IMAGE=minaprotocol/mina-archive:3.3.1-7b34378-noble-mainnet
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
 
 # Network
 MINA_NETWORK=mainnet
@@ -25,5 +26,6 @@ GUARDIAN_PRECOMPUTED_BLOCKS_URL=https://storage.googleapis.com/mina_network_bloc
 # GUARDIAN_SLEEP_INTERVAL=600  # optional, defaults to 600
 
 # Archive DB bootstrap
-ARCHIVE_DUMP_BASE_URL=https://storage.googleapis.com/mina-archive-dumps
-ARCHIVE_DUMP_PREFIX=mainnet-archive-dump
+# mina-provision derives the dump location and file name from MINA_NETWORK.
+# To read from a mirror instead, mount a provider file and set
+# MINA_PROVISION_CONFIG; see the mina-provision documentation.

--- a/src/app/rosetta/docker-compose/README.md
+++ b/src/app/rosetta/docker-compose/README.md
@@ -116,5 +116,4 @@ Key differences between networks:
 |----------|--------|---------|
 | `MINA_NETWORK` | `devnet` | `mainnet` |
 | `MINA_PEERLIST_URL` | devnet seeds | mainnet bootnodes |
-| `ARCHIVE_DUMP_PREFIX` | `devnet-archive-dump` | `mainnet-archive-dump` |
 | Docker image tags | `*-devnet` | `*-mainnet` |

--- a/src/app/rosetta/docker-compose/docker-compose.yml
+++ b/src/app/rosetta/docker-compose/docker-compose.yml
@@ -16,21 +16,19 @@ services:
     ports:
       - '${POSTGRES_PORT}:5432'
 
+  # Downloads the published archive dump, applies the recommended Postgres
+  # tuning, and loads it. mina-provision derives the dump location and file
+  # name from MINA_NETWORK, so no dump URL or prefix is configured here.
   bootstrap_db:
-    image: '${MINA_ARCHIVE_IMAGE}'
+    image: '${MINA_PROVISION_IMAGE}'
+    environment:
+      MINA_NETWORK: ${MINA_NETWORK}
     command:
-      - bash
-      - -c
-      - |
-        set -eox pipefail
-        curl -fSL -O ${ARCHIVE_DUMP_BASE_URL}/${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql.tar.gz
-        tar -zxvf ${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql.tar.gz
-        psql postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB} \
-          -c "ALTER SYSTEM SET max_connections = 500" \
-          -c "ALTER SYSTEM SET max_locks_per_transaction = 100" \
-          -c "ALTER SYSTEM SET max_pred_locks_per_relation = 100" \
-          -c "ALTER SYSTEM SET max_pred_locks_per_transaction = 5000"
-        psql postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB} -f ${ARCHIVE_DUMP_PREFIX}-$$(date +%F_0000).sql
+      - archive
+      - --pg-uri
+      - postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      - --work-dir
+      - /tmp
     depends_on:
       postgres:
         condition: service_healthy

--- a/src/app/rosetta/docker-compose/docker-compose.yml
+++ b/src/app/rosetta/docker-compose/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       MINA_NETWORK: ${MINA_NETWORK}
     command:
       - archive
+      # Leave an existing archive alone. Without this, every `compose down &&
+      # up` re-downloads the dump and imports it over a database that has
+      # advanced since, losing the blocks collected in between.
+      - --if-present=skip
       - --pg-uri
       - postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - --work-dir

--- a/src/app/rosetta/docker-compose/example.devnet.env
+++ b/src/app/rosetta/docker-compose/example.devnet.env
@@ -8,6 +8,7 @@ POSTGRES_PORT=5433
 MINA_DAEMON_IMAGE=gcr.io/o1labs-192920/mina-daemon:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ARCHIVE_IMAGE=gcr.io/o1labs-192920/mina-archive:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ROSETTA_IMAGE=gcr.io/o1labs-192920/mina-rosetta:3.3.0-alpha1-6929a7e-bullseye-devnet
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
 
 # Network
 MINA_NETWORK=devnet
@@ -31,5 +32,6 @@ GUARDIAN_PRECOMPUTED_BLOCKS_URL=https://storage.googleapis.com/mina_network_bloc
 # GUARDIAN_SLEEP_INTERVAL=600  # optional, defaults to 600
 
 # Archive DB bootstrap
-ARCHIVE_DUMP_BASE_URL=https://storage.googleapis.com/mina-archive-dumps
-ARCHIVE_DUMP_PREFIX=devnet-archive-dump
+# mina-provision derives the dump location and file name from MINA_NETWORK.
+# To read from a mirror instead, mount a provider file and set
+# MINA_PROVISION_CONFIG; see the mina-provision documentation.

--- a/src/app/rosetta/docker-compose/example.devnet.env
+++ b/src/app/rosetta/docker-compose/example.devnet.env
@@ -8,7 +8,7 @@ POSTGRES_PORT=5433
 MINA_DAEMON_IMAGE=gcr.io/o1labs-192920/mina-daemon:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ARCHIVE_IMAGE=gcr.io/o1labs-192920/mina-archive:3.3.0-alpha1-6929a7e-bullseye-devnet
 MINA_ROSETTA_IMAGE=gcr.io/o1labs-192920/mina-rosetta:3.3.0-alpha1-6929a7e-bullseye-devnet
-MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.3
 
 # Network
 MINA_NETWORK=devnet

--- a/src/app/rosetta/docker-compose/example.mainnet.env
+++ b/src/app/rosetta/docker-compose/example.mainnet.env
@@ -8,7 +8,7 @@ POSTGRES_PORT=5433
 MINA_DAEMON_IMAGE=minaprotocol/mina-daemon:3.3.1-7b34378-noble-mainnet
 MINA_ARCHIVE_IMAGE=minaprotocol/mina-archive:3.3.1-7b34378-noble-mainnet
 MINA_ROSETTA_IMAGE=minaprotocol/mina-rosetta:3.3.1-7b34378-noble-mainnet
-MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.3
 
 # Network
 MINA_NETWORK=mainnet

--- a/src/app/rosetta/docker-compose/example.mainnet.env
+++ b/src/app/rosetta/docker-compose/example.mainnet.env
@@ -8,6 +8,7 @@ POSTGRES_PORT=5433
 MINA_DAEMON_IMAGE=minaprotocol/mina-daemon:3.3.1-7b34378-noble-mainnet
 MINA_ARCHIVE_IMAGE=minaprotocol/mina-archive:3.3.1-7b34378-noble-mainnet
 MINA_ROSETTA_IMAGE=minaprotocol/mina-rosetta:3.3.1-7b34378-noble-mainnet
+MINA_PROVISION_IMAGE=ghcr.io/minaprotocol/mina-provision:0.0.2
 
 # Network
 MINA_NETWORK=mainnet
@@ -31,5 +32,6 @@ GUARDIAN_PRECOMPUTED_BLOCKS_URL=https://storage.googleapis.com/mina_network_bloc
 # GUARDIAN_SLEEP_INTERVAL=600  # optional, defaults to 600
 
 # Archive DB bootstrap
-ARCHIVE_DUMP_BASE_URL=https://storage.googleapis.com/mina-archive-dumps
-ARCHIVE_DUMP_PREFIX=mainnet-archive-dump
+# mina-provision derives the dump location and file name from MINA_NETWORK.
+# To read from a mirror instead, mount a provider file and set
+# MINA_PROVISION_CONFIG; see the mina-provision documentation.


### PR DESCRIPTION
Replaces the inline dump-download logic in both docker-compose stacks with the
`mina-provision` image.

Supersedes #18845, which added the tool to this repository. The tool now lives
in [MinaProtocol/mina-provision](https://github.com/MinaProtocol/mina-provision);
this PR is the part that belongs here.

## What it replaces

Both stacks inlined the same twelve lines in a `bash -c` block: curl the dump
for today's date, untar it, run four `ALTER SYSTEM` statements, `psql -f` the
result. That is exactly `mina-provision archive`.

```yaml
  bootstrap_db:
    image: '${MINA_PROVISION_IMAGE}'
    environment:
      MINA_NETWORK: ${MINA_NETWORK}
    command:
      - archive
      - --pg-uri
      - postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
      - --work-dir
      - /tmp
```

## What changes for an operator

| Variable | Before | After |
|---|---|---|
| `ARCHIVE_DUMP_BASE_URL` | had to be set | gone — derived from `MINA_NETWORK` |
| `ARCHIVE_DUMP_PREFIX` | had to be set | gone — derived from `MINA_NETWORK` |
| `MINA_PROVISION_IMAGE` | — | new |

Reading from a mirror no longer means editing the compose file: mount a
provider file and set `MINA_PROVISION_CONFIG`.

## Unchanged

The four tuning values are identical, and the service gating is untouched —
`missing_blocks_guardian`, `mina_archive`, `mina_node` and `mina_rosetta` all
still wait on `bootstrap_db` completing successfully.

## Verified

Ran the published image with the exact command the compose file now issues. It
resolves the network, builds the right object name, and reaches the download:

```
$ docker run --rm -e MINA_NETWORK=mainnet ghcr.io/minaprotocol/mina-provision:0.0.2 \
    archive --pg-uri postgres://... --work-dir /tmp --date 1999-01-01
msg="fetching archive dump" from=gs://mina-archive-dumps \
  object=mainnet-archive-dump-1999-01-01_0000.sql.tar.gz
Error: fetch: stat gs://...: storage: object doesn't exist
```

A date with no dump was used deliberately, to prove the path without pulling
several gigabytes. `psql` is present in the image (PostgreSQL 15.19), which the
`archive` command shells out to.

Both compose files still parse, and the `depends_on` graph was checked
programmatically rather than by eye.

## Ready

`ghcr.io/minaprotocol/mina-provision` is public, verified with an anonymous
pull carrying no credentials. The stacks pin `0.0.3`, the release that
introduced `--if-present`.

