### PR TITLE
Pin the git environment in every entrypoint

### DIFF
--- a/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
+++ b/buildkite/scripts/entrypoints/run-hardfork-package-gen.sh
@@ -102,6 +102,24 @@ if [[ -n "${GENESIS_TIMESTAMP:-}" && ! "${GENESIS_TIMESTAMP}" =~ Z$ ]]; then
   usage "GENESIS_TIMESTAMP must be in UTC format (ending with 'Z'), got: ${GENESIS_TIMESTAMP}"
 fi
 
+# Fix one git identity for this run, before the pipeline that reads it is
+# uploaded, so every job it emits agrees on one. This is what
+# Command/PinGitEnv.dhall does for the entrypoints that are pipelines; here the
+# entrypoint is this script, so it calls pin.sh itself.
+#
+# USE_ARTIFACTS_FROM_BUILDKITE_BUILD names a build whose artifacts this run
+# takes instead of making its own, and when it does, the identity of this run
+# is that build's rather than this checkout's. GITHASH_CONFIG is why that
+# matters: it names the genesis config the daemon auto-loads, so it has to name
+# the commit the binaries came from. It is spelled out rather than left to
+# pin.sh because the name is this pipeline's own; empty, and pin.sh pins this
+# checkout.
+#
+# Done here rather than further down because the value is rewritten into a
+# Dhall Optional just below and stops being a build id.
+MINA_READ_CACHE_ROOT="${USE_ARTIFACTS_FROM_BUILDKITE_BUILD:-}" \
+  ./buildkite/scripts/git-env/pin.sh
+
 # Format GENESIS_TIMESTAMP as Optional Text for Dhall
 if [[ -z "${GENESIS_TIMESTAMP:-}" ]]; then
   GENESIS_TIMESTAMP="(None Text)"

--- a/buildkite/src/Entrypoints/PromoteNightly.dhall
+++ b/buildkite/src/Entrypoints/PromoteNightly.dhall
@@ -17,6 +17,8 @@ let Cmd = ../Lib/Cmds.dhall
 
 let Command = ../Command/Base.dhall
 
+let PinGitEnv = ../Command/PinGitEnv.dhall
+
 let ContainerImages = ../Constants/ContainerImages.dhall
 
 let FixPermissions = ../Command/FixPermissions.dhall
@@ -87,6 +89,13 @@ let promote_nightly =
                     ++  "./scripts/docker/update-gar-whitelist.sh"
                   )
 
+          let promotion =
+              -- The promoter renders one pipeline for each branch and profile
+              -- it is asked for, so a constant key would collide the moment a
+              -- build promotes more than one. The step below already carries
+              -- both; the pin carries the same.
+                "-${branch}-${profile}"
+
           let pipeline =
                 Pipeline.build
                   Pipeline.Config::{
@@ -97,8 +106,11 @@ let promote_nightly =
                     , tags = [ PipelineTag.Type.Promote ]
                     }
                   , steps =
-                    [ Command.build
+                    [ PinGitEnv.step promotion
+                    , Command.build
                         Command.Config::{
+                        , depends_on =
+                            PinGitEnv.dependsOn "PromoteNightly" promotion
                         , commands =
                               [ FixPermissions.command Architecture.Type.Amd64 ]
                             # [ buildGoBinaryCmd ]
@@ -106,7 +118,7 @@ let promote_nightly =
                             # [ publishDockersCmd ]
                             # [ updateGarWhitelistCmd ]
                         , label = "Promote Nightly (${branch}/${profile})"
-                        , key = "promote-nightly-${branch}-${profile}"
+                        , key = "promote-nightly${promotion}"
                         , target = Size.Small
                         }
                     ]

--- a/buildkite/src/Entrypoints/RunSelection.dhall
+++ b/buildkite/src/Entrypoints/RunSelection.dhall
@@ -43,6 +43,8 @@ let Cmd = ../Lib/Cmds.dhall
 
 let Command = ../Command/Base.dhall
 
+let PinGitEnv = ../Command/PinGitEnv.dhall
+
 let Docker = ../Command/Docker/Type.dhall
 
 let JobSpec = ../Pipeline/JobSpec.dhall
@@ -63,16 +65,20 @@ let commands =
       Cmd.run
         "./buildkite/scripts/entrypoints/run-selection.sh --jobs ./buildkite/src/gen --debug "
 
+let jobName = "run-selection"
+
 let config
     : Pipeline.Config.Type
     = Pipeline.Config::{
       , spec = JobSpec::{
-        , name = "run-selection"
+        , name = jobName
         , dirtyWhen = [ SelectFiles.everything ]
         }
       , steps =
-        [ Command.build
+        [ PinGitEnv.step ""
+        , Command.build
             Command.Config::{
+            , depends_on = PinGitEnv.dependsOn jobName ""
             , commands = prefixCommands # [ commands ]
             , label = "Run selection"
             , key = "cmds"

--- a/buildkite/src/Entrypoints/RunSingleJob.dhall
+++ b/buildkite/src/Entrypoints/RunSingleJob.dhall
@@ -4,6 +4,8 @@ let Cmd = ../Lib/Cmds.dhall
 
 let Command = ../Command/Base.dhall
 
+let PinGitEnv = ../Command/PinGitEnv.dhall
+
 let Docker = ../Command/Docker/Type.dhall
 
 let JobSpec = ../Pipeline/JobSpec.dhall
@@ -40,8 +42,11 @@ in      \(args : { name : Text })
                   , dirtyWhen = [ SelectFiles.everything ]
                   }
                 , steps =
-                  [ Command.build
+                  [ PinGitEnv.step ""
+                  , Command.build
                       Command.Config::{
+                      , depends_on =
+                          PinGitEnv.dependsOn "run-single-job-${args.name}" ""
                       , commands = prefixCommands # [ commands args.name ]
                       , label = "Run Single Job ${args.name}"
                       , key = "cmds"


### PR DESCRIPTION
**Stacked on #19331.** Retarget to `develop` once that merges.

## Coverage

#19331 pins the git identity in `Prepare.dhall`, which covers **26 of 36 pipelines**. This closes the rest.

| Entrypoint | Pipelines | Takes another build's output? | Now |
|---|---|---|---|
| `Entrypoints/RunSelection.dhall` | `mina-artifacts` | **yes — `--from`** | `PinGitEnv.step` |
| `Entrypoints/RunSingleJob.dhall` | `mina-single-job` | possible, depends on the job | `PinGitEnv.step` |
| `Entrypoints/PromoteNightly.dhall` | `promote-package` | no | `PinGitEnv.step` |
| `run-hardfork-package-gen.sh` | `hardfork-generation-ci`, `hardfork-package-generation-new` | **yes — `USE_ARTIFACTS_FROM_BUILDKITE_BUILD`** | calls `pin.sh` |
| `Entrypoints/GenerateHardforkPackage.dhall` | — | — | reached only through that script |

Every entrypoint pins now, whether or not it takes another build's output. A pipeline that does derive its own identity is still deriving it once per job, against a tag that can move underneath it — `find_most_recent_numeric_tag` fetches tags on every call, and 45 files source that script.

## Why this matters most for `mina-artifacts`

`run-selection.sh --from` writes `MINA_READ_CACHE_ROOT` onto **every step it uploads**:

```bash
pruned="$(echo "$pruned" | yq -o=yaml ".steps |= map(.env.MINA_READ_CACHE_ROOT = \"${FROM_BUILD}\")")"
```

That is "take the binaries and the packages from build X" — the same thing a packaging-only release pipeline does by hand, carrying the same hazard. `GITHASH_CONFIG` names the genesis config the daemon auto-loads, so derived from this checkout the package holds a config its own daemon will not look for.

## Shape

`Command/PinGitEnv.dhall` (added in #19331) holds the step, so a pipeline entrypoint costs three lines:

```dhall
      , steps =
        [ PinGitEnv.step
        , Command.build
            Command.Config::{
            , depends_on = PinGitEnv.dependsOn jobName
```

The step it depends on is always the one that uploads or runs everything else, so a step it waits for finishes before anything that reads the file exists — a barrier, not an ordering to reason about.

Nothing is passed to the step; `pin.sh` reads `BUILDKITE_PIPELINE_FROM_BUILD` itself, so no entrypoint has to spell a shell expansion through Dhall's escaping.

**`run-hardfork-package-gen.sh` is the exception**, because there the entrypoint *is* the script: it calls `pin.sh` directly, and has to do so before `USE_ARTIFACTS_FROM_BUILDKITE_BUILD` is rewritten into a Dhall `Optional` and stops being a build id. `run-nightly-promoter.sh` does not need a call — the step in `PromoteNightly.dhall` covers what it uploads, and it renders its pipeline on standard output, where a `pin.sh` call would have had to be redirected.

That standard-output constraint is real and is fixed in #19331: these scripts are run as `<entrypoint>.sh | buildkite-agent pipeline upload`, so a single line on stdout from anything they call is uploaded as part of the pipeline. `pin.sh` now says everything on stderr, with a test covering all three of its paths.

## Two entrypoints deliberately left alone

Both are already unreachable, so wiring a pin into them would be adding correctness machinery to something that should be deleted:

- **`Entrypoints/PublishPackages.dhall`** is reached only from `run_promote_build_job.sh`, which imports `./buildkite/src/Constants/Artifacts.dhall` — a path that no longer exists (it moved to `Constants/Artifact/Artifacts.dhall`), so it cannot render. `Jobs/Release/PublishDebians.dhall` replaces it and is covered already.
- **`infra-docker-and-debian-healthcheck`** runs `./buildkite/scripts/entrypoints/run-verify-artifacts.sh`, which is not in the repository.

Worth deleting or fixing separately; flagging rather than touching here.

## Testing

`make all` in `buildkite/` green (105 jobs exported, 18 pipeline tests / 48 assertions). Rendered YAML checked directly for the step key and its dependency. `shellcheck -S warning` clean. #19331's suite passes unchanged (13 tests, 28 assertions).