### PR TITLE
Stop shipping /etc/bash_completion.d/mina in the daemon packages

### DIFF
--- a/changes/19335.md
+++ b/changes/19335.md
@@ -1,0 +1,3 @@
+Remove the unused bash completion file from the daemon packages
+
+The daemon packages no longer install `/etc/bash_completion.d/mina`. The file never provided completion for the `mina` command: it registered itself under the build's internal staging path rather than the command name, and it would only have been read at all if the `bash-completion` package happened to be installed, which no mina package depends on or suggests. Nothing else changes, and dpkg removes the stale file on upgrade.

--- a/scripts/debian/builder-helpers.sh
+++ b/scripts/debian/builder-helpers.sh
@@ -261,25 +261,6 @@ install_mina_service() {
     ../scripts/mina.service > "${BUILDDIR}/usr/lib/systemd/user/mina.service"
 }
 
-# Copies hardfork scripts and generates bash completion into a debian package.
-# Does NOT install mina.service (the config package owns it, see
-# install_mina_service).
-copy_common_daemon_utils() {
-  echo "copy_common_daemon_utils inputs:"
-
-  local MINA_BIN="${1:-${BUILDDIR}/usr/local/bin/mina}"
-
-  copy_hf_related_scripts
-
-  # Support bash completion
-  # NOTE: We do not list bash-completion as a required package,
-  #       but it needs to be present for this to be effective
-  mkdir -p "${BUILDDIR}/etc/bash_completion.d"
-  env COMMAND_OUTPUT_INSTALLATION_BASH=1 "${MINA_BIN}" > \
-    "${BUILDDIR}/etc/bash_completion.d/mina"
-
-}
-
 # Copies common daemon binaries only to debian package
 copy_common_daemon_apps() {
 
@@ -876,9 +857,9 @@ copy_common_daemon_post_automode_apps_and_configs() {
     fi
   fi
 
-  # Generate bash completion for the postfork runtime. mina.service is shipped
-  # by the mina-<network>-config package, not here, to avoid dpkg conflicts.
-  copy_common_daemon_utils "${automode_postfork_dir}/mina"
+  # mina.service is shipped by the mina-<network>-config package, not here, to
+  # avoid dpkg conflicts.
+  copy_hf_related_scripts
 
 }
 
@@ -892,11 +873,11 @@ build_daemon_postfork_deb() {
 
   echo "--- Building ${network} postfork deb for hardfork automode:"
 
-  # The postfork runtime ships /etc/bash_completion.d/mina (and shares the
-  # /usr/local/bin/mina dispatcher), which also lives in the network-free
-  # mina-generic package. Declare Replaces/Breaks on mina-generic so the two are
-  # mutually exclusive and the automode<->generic transition resolves cleanly
-  # instead of failing with a dpkg "trying to overwrite" file conflict.
+  # The postfork runtime shares the /usr/local/bin/mina dispatcher, which also
+  # lives in the network-free mina-generic package. Declare Replaces/Breaks on
+  # mina-generic so the two are mutually exclusive and the automode<->generic
+  # transition resolves cleanly instead of failing with a dpkg "trying to
+  # overwrite" file conflict.
   create_control_file "$package_name" "${SHARED_DEPS}${DAEMON_DEPS}" \
     'Mina Protocol Client and Daemon' "${SUGGESTED_DEPS}" "mina-generic"
 
@@ -1023,7 +1004,7 @@ build_daemon_generic_deb() {
 
   copy_common_daemon_apps
 
-  copy_common_daemon_utils
+  copy_hf_related_scripts
 
   build_deb "${MINA_GENERIC_DEB_NAME}"
 

--- a/scripts/debian/tests/test_builder_helpers.sh
+++ b/scripts/debian/tests/test_builder_helpers.sh
@@ -152,7 +152,6 @@ assert_daemon_utils() {
     local captured_files="$1"
     assert_file_captured "$captured_files" "usr/local/bin/mina-hf-create-runtime-config"
     assert_file_captured "$captured_files" "usr/local/bin/mina-verify-packaged-fork-config"
-    assert_file_captured "$captured_files" "etc/bash_completion.d/mina"
 }
 
 assert_archive_binaries() {
@@ -325,10 +324,6 @@ MOCKGIT
         mkdir -p "$(dirname "${base}/${path}")"
         cat > "${base}/${path}" << 'MOCKEXE'
 #!/bin/bash
-if [[ "${COMMAND_OUTPUT_INSTALLATION_BASH:-}" == "1" ]]; then
-    echo "# mock bash completion for mina"
-    exit 0
-fi
 echo "mock binary"
 MOCKEXE
         chmod +x "${base}/${path}"


### PR DESCRIPTION
The Debian build generated `/etc/bash_completion.d/mina` by executing the freshly built daemon with `COMMAND_OUTPUT_INSTALLATION_BASH=1`. That file has never worked, for two independent reasons.

**The compspec is registered under the staging path.** Core's completion template interpolates `argv[0]` verbatim, and `MINA_BIN` is `${BUILDDIR}/usr/local/bin/mina` with the build running from `_build`. A published package confirms it (`mina-devnet_3.4.0-beta1-23162b0_amd64.deb`):

```bash
COMP_WORDS[0]=deb_build/usr/local/bin/mina
...
complete -F _jsautocom_29971 deb_build/usr/local/bin/mina
```

Bash's compspec lookup only degrades from a typed full pathname to the basename, never the reverse, so a compspec registered under a path is unreachable from the bare word `mina`.

**Nothing sources the file.** `/etc/bash_completion.d/` is read only when the `bash-completion` package is installed, and the deleted code says so itself — it is in neither `SHARED_DEPS` nor `DAEMON_DEPS`.

Removing rather than fixing was a deliberate call: the mechanism re-executes the mina binary on every TAB (that is inherent — the command tree lives in the binary), a fix would need `bash-completion` added as a new runtime dependency for a feature nobody has ever had, and this is the only step in the whole deb build that runs a mina binary.

### Changes

- Delete the completion block from `copy_common_daemon_utils`. That left the function doing nothing but calling `copy_hf_related_scripts`, so it is gone and both call sites — the generic and postfork daemon packages — call `copy_hf_related_scripts` directly.
- Drop the corresponding assertion and the mock executable's `COMMAND_OUTPUT_INSTALLATION_BASH` branch from `tests/test_builder_helpers.sh`.

### Deliberately unchanged

The `Replaces`/`Breaks` on `mina-generic` in `build_daemon_postfork_deb`. Its comment gave two reasons — the shared completion file and the shared `/usr/local/bin/mina` dispatcher — and only the first goes away. The postfork package still ships that dispatcher symlink while `mina-generic` ships the real binary there, so the file conflict remains. Only the comment is edited.

### Upgrade behaviour

No maintainer scripts needed. `builder-helpers.sh` never writes `DEBIAN/conffiles`, so despite living under `/etc` this is an ordinary packaged file and dpkg removes it on a normal upgrade. No `dpkg-maintscript-helper rm_conffile` required.

### Testing

`scripts/debian/tests/test_builder_helpers.sh` passes (36 tests, 277 assertions). The captured staging trees contain no `bash_completion` path and still contain `mina-hf-create-runtime-config` and `mina-verify-packaged-fork-config`. `shellcheck -S warning` is clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XUdFfzewBasj7c56va6da