### PR TITLE
Uptime Service: stamp the submitter's sok digest into the zkApp segment

### DIFF
--- a/changes/19342.md
+++ b/changes/19342.md
@@ -1,0 +1,3 @@
+Fix uptime service SNARK submissions being rejected for blocks ending in a zkApp command
+
+When the last transaction in a block was a zkApp command, the uptime service produced its proof against an empty SNARK-work message instead of the submitter's, so the uptime backend rejected the submission and the block did not count towards uptime. Affected node operators will now have those submissions accepted.

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -351,7 +351,11 @@ let send_block_and_transaction_snark ~logger ~constraint_constants ~interruptor
                       in
                       make_interruptible
                       @@ Uptime_snark_worker.perform_partitioned snark_worker
-                           (witness, input, zkapp_command, staged_ledger_hash)
+                           ( message
+                           , witness
+                           , input
+                           , zkapp_command
+                           , staged_ledger_hash )
                   | Ok (`Transaction single_spec) ->
                       make_interruptible
                       @@ Uptime_snark_worker.perform_single snark_worker

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -45,7 +45,8 @@ module Worker = struct
           F.t
       ; perform_partitioned :
           ( 'w
-          , Transaction_witness.Stable.Latest.t
+          , Sok_message.t
+            * Transaction_witness.Stable.Latest.t
             * Mina_state.Snarked_ledger_state.Stable.Latest.t
             * Zkapp_command.Stable.Latest.t
             * Staged_ledger_hash.t
@@ -77,7 +78,7 @@ module Worker = struct
         Impl.perform_single ~message state single_spec
 
       let perform_partitioned (state : Worker_state.t)
-          (witness, statement, zkapp_command, staged_ledger_hash) =
+          (message, witness, statement, zkapp_command, staged_ledger_hash) =
         let zkapp_command =
           Zkapp_command.write_all_proofs_to_disk
             ~signature_kind:state.signature_kind
@@ -90,6 +91,12 @@ module Worker = struct
                 ~m:(module S)
                 ~witness ~input:statement ~zkapp_command ~staged_ledger_hash
               |> Deferred.return
+            in
+            (* [zkapp_command_witnesses_exn] emits [Sok_message.Digest.default];
+               stamping the submitter's digest here is what makes the proof
+               attest to the right sok message (mina#19299). *)
+            let statement =
+              { statement with sok_digest = Sok_message.digest message }
             in
 
             Snark_worker.Impl.measure_runtime ~logger:state.logger
@@ -128,7 +135,8 @@ module Worker = struct
         ; perform_partitioned =
             f
               ( [%bin_type_class:
-                  Transaction_witness.Stable.Latest.t
+                  Sok_message.Stable.Latest.t
+                  * Transaction_witness.Stable.Latest.t
                   * Mina_state.Snarked_ledger_state.Stable.Latest.t
                   * Zkapp_command.Stable.Latest.t
                   * Staged_ledger_hash.Stable.Latest.t]


### PR DESCRIPTION
Minimal backport of the `#19299` fix from #19325 to `release/mesa`.

`Transaction_snark.zkapp_command_witnesses_exn` cannot know the fee or the prover, so the segment statements it emits carry `Sok_message.Digest.default` — 32 zero bytes. `Uptime_snark_worker.perform_partitioned` proved the terminal segment over that placeholder, so every uptime submission for a block whose last transaction is a zkApp command produced a valid proof of the *empty* sok message, and `delegation_verify` rejected it with "proof's sok message digest does not match the sok message".

The sok message was already computed by the caller for `perform_single`; this threads it into `perform_partitioned` too and stamps its digest onto the statement before proving.

### Scope vs #19325

#19325 fixed this on `develop` by making the witness generator return a sok-less `Statement.t` and dropping the placeholder from the `Sub_zkapp_spec` wire format (`Rpc_get_work` V4 → V5). None of that is here: this is the behavioural fix only, no versioned type changes, no rollout ordering constraint between daemons and snark workers. The `perform_partitioned` RPC that changes shape is `rpc_parallel`-internal to the daemon's own uptime worker process, not a network RPC.

### Verification

- `dune build @check` clean.
- Regression tests are not backported — they live on the sok-less `Statement.t` type introduced by #19325 and do not compile here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnRLb91RXyf2t5nwmt8VB1