### PR TITLE
Stop shelling out for things OCaml already does

### DIFF
--- a/changes/19349.md
+++ b/changes/19349.md
@@ -1,0 +1,3 @@
+Remove six subprocesses from the daemon
+
+The daemon no longer runs `brew`, `date`, `uname -s`, `rm`, `cp` or `cat` to do work it can do itself, and no longer wraps its block upload to Google Cloud Storage in `bash -c`. These were never declared dependencies of any mina package, so a node in a minimal environment could fail on a missing binary; that class of failure is gone. Log timestamps printed by `mina-logproc` are now correct in time zones whose offset is not a whole number of hours, such as India, Nepal and Newfoundland, where they were previously rounded down to the hour. Support bundles from `mina client export-local-logs` are unchanged in content.

--- a/src/app/logproc/logproc.ml
+++ b/src/app/logproc/logproc.ml
@@ -3,12 +3,6 @@ open Logproc_lib
 
 let invalid_line_prefix = "!!! "
 
-let find_timezone () =
-  let ch = Unix.open_process_in {|date +"%z"|} in
-  let input = Option.value_exn (In_channel.input_line ch) in
-  In_channel.close ch ;
-  Time.Zone.of_utc_offset ~hours:(int_of_string input / 100)
-
 let format_timestamp ~timezone time =
   let date, of_day = Time.to_date_ofday ~zone:timezone time in
   sprintf "%d-%d-%d %s" (Date.year date)
@@ -188,7 +182,7 @@ let main timezone_str interpolation_config filter_str =
   (* let filter = Result.ok_or_failwith (Filter.Parser.parse "true") in *)
   (* let filter = Result.ok_or_failwith (Filter.Parser.parse ".level === \"Info\"") in *)
   let timezone =
-    if String.is_empty timezone_str then find_timezone ()
+    if String.is_empty timezone_str then Lazy.force Time.Zone.local
     else Time.Zone.of_string timezone_str
   in
   iter_lines_prefixed_with In_channel.stdin stdout ~prefix:'{'

--- a/src/lib/cache_dir/cache_dir.mli
+++ b/src/lib/cache_dir/cache_dir.mli
@@ -6,7 +6,7 @@ val s3_keys_bucket_prefix : string
 
 val manual_install_path : string
 
-val brew_install_path : string
+val brew_install_paths : string list
 
 val cache : Key_cache.Spec.t list
 

--- a/src/lib/cache_dir/fake/cache_dir.ml
+++ b/src/lib/cache_dir/fake/cache_dir.ml
@@ -10,7 +10,7 @@ let s3_keys_bucket_prefix =
 
 let manual_install_path = "/var/lib/coda"
 
-let brew_install_path = "/usr/local/var/coda"
+let brew_install_paths = [ "/usr/local/var/coda"; "/opt/homebrew/var/coda" ]
 
 let cache = []
 
@@ -18,12 +18,9 @@ let env_path = manual_install_path
 
 let possible_paths base =
   List.map
-    [ env_path
-    ; brew_install_path
-    ; s3_install_path
-    ; autogen_path
-    ; manual_install_path
-    ] ~f:(fun d -> d ^ "/" ^ base)
+    ( (env_path :: brew_install_paths)
+    @ [ s3_install_path; autogen_path; manual_install_path ] )
+    ~f:(fun d -> d ^ "/" ^ base)
 
 let load_from_s3 _s3_bucket_prefix _s3_install_path ~logger:_ =
   Deferred.Or_error.fail (Error.createf "Cannot load files from S3")

--- a/src/lib/cache_dir/native/cache_dir.ml
+++ b/src/lib/cache_dir/native/cache_dir.ml
@@ -12,26 +12,24 @@ let s3_keys_bucket_prefix =
 
 let manual_install_path = "/var/lib/coda"
 
-let brew_install_path =
-  match
-    let p = Core.Unix.open_process_in "brew --prefix 2>/dev/null" in
-    let r = In_channel.input_lines p in
-    (r, Core.Unix.close_process_in p)
-  with
-  | brew :: _, Ok () ->
-      brew ^ "/var/coda"
-  | _ ->
-      "/usr/local/var/coda"
+(* Homebrew's prefix on Intel and on Apple Silicon. Both are listed
+   unconditionally rather than asking [brew --prefix]: these are read-only
+   lookup paths and a nonexistent one is simply skipped, whereas the query
+   costs a subprocess at module initialization on every platform, Linux
+   included. *)
+let brew_install_paths = [ "/usr/local/var/coda"; "/opt/homebrew/var/coda" ]
 
 let cache =
   let dir d w = Key_cache.Spec.On_disk { directory = d; should_write = w } in
-  [ dir manual_install_path false
-  ; dir brew_install_path false
-  ; dir s3_install_path false
-  ; dir autogen_path true
-  ; Key_cache.Spec.S3
-      { bucket_prefix = s3_keys_bucket_prefix; install_path = s3_install_path }
-  ]
+  ( [ dir manual_install_path false ]
+  @ List.map brew_install_paths ~f:(fun d -> dir d false) )
+  @ [ dir s3_install_path false
+    ; dir autogen_path true
+    ; Key_cache.Spec.S3
+        { bucket_prefix = s3_keys_bucket_prefix
+        ; install_path = s3_install_path
+        }
+    ]
 
 let env_path =
   match Sys.getenv "MINA_KEYS_PATH" with
@@ -42,12 +40,9 @@ let env_path =
 
 let possible_paths base =
   List.map
-    [ env_path
-    ; brew_install_path
-    ; s3_install_path
-    ; autogen_path
-    ; manual_install_path
-    ] ~f:(fun d -> d ^/ base)
+    ( (env_path :: brew_install_paths)
+    @ [ s3_install_path; autogen_path; manual_install_path ] )
+    ~f:(fun d -> d ^/ base)
 
 let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
   let%bind () = Unix.mkdir ~p:() (Filename.dirname s3_install_path) in

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -77,8 +77,14 @@ let get_project_root () =
 let get_mina_binary () =
   let open Async in
   let open Deferred.Or_error.Let_syntax in
-  let%bind os = Process.run ~prog:"uname" ~args:[ "-s" ] () in
-  if String.equal os "Darwin\n" then
+  (* [/proc/PID/exe] is the whole point of the Linux branch below, so testing
+     for it directly beats asking [uname] in a subprocess. *)
+  if Core.Sys.file_exists_exn "/proc/self/exe" then
+    (* FIXME for finding the executable relative to the install path this should
+       deference the symlink if possible. *)
+    Deferred.Or_error.return
+      (Unix.getpid () |> Pid.to_int |> sprintf "/proc/%d/exe")
+  else
     let open Ctypes in
     let ns_get_executable_path =
       Foreign.foreign "_NSGetExecutablePath"
@@ -96,11 +102,6 @@ let get_mina_binary () =
     in
     let s = string_from_ptr buf ~length:(!@count |> Unsigned.UInt32.to_int) in
     List.hd_exn @@ String.split s ~on:(Char.of_int 0 |> Option.value_exn)
-  else
-    (* FIXME for finding the executable relative to the install path this should
-       deference the symlink if possible. *)
-    Deferred.Or_error.return
-      (Unix.getpid () |> Pid.to_int |> sprintf "/proc/%d/exe")
 
 (** Check the PID file and delete it. This method does not currently attempt to
     kill the process that created it; we rely on the child exiting on its own in

--- a/src/lib/mina_lib/conf_dir.ml
+++ b/src/lib/mina_lib/conf_dir.ml
@@ -131,12 +131,7 @@ let get_hw_info () =
   in
   if Option.is_some linux_info then
     let linux_hw_progs =
-      [ ("cat", [ "/etc/os-release" ])
-      ; ("lscpu", [])
-      ; ("lsgpu", [])
-      ; ("lsmem", [])
-      ; ("lsblk", [])
-      ]
+      [ ("lscpu", []); ("lsgpu", []); ("lsmem", []); ("lsblk", []) ]
     in
     let%map outputs =
       Deferred.List.map linux_hw_progs ~f:(fun (prog, args) ->
@@ -153,7 +148,18 @@ let get_hw_info () =
           in
           return ((header :: output) @ [ "" ]) )
     in
-    Some (Option.value_exn linux_info :: List.concat outputs)
+    let os_release =
+      let file = "/etc/os-release" in
+      let contents =
+        match In_channel.read_lines file with
+        | lines ->
+            lines
+        | exception exn ->
+            [ sprintf "Error: %s" (Exn.to_string exn) ]
+      in
+      (sprintf "*** Contents of '%s' ***\n" file :: contents) @ [ "" ]
+    in
+    Some ((Option.value_exn linux_info :: os_release) @ List.concat outputs)
   else (* TODO: Mac, other Unixes *)
     return None
 
@@ -205,12 +211,37 @@ let export_logs_to_tar ?basename ~conf_dir =
         hw_file :: base_files )
   in
   let tmp_dir = Filename.temp_dir ~in_dir:"/tmp" ("mina-logs_" ^ basename) "" in
-  let files_in_dir dir = List.map files ~f:(fun file -> dir ^/ file) in
-  let conf_dir_files = files_in_dir conf_dir in
-  let%bind _result0 =
-    Process.run ~prog:"cp" ~args:(("-p" :: conf_dir_files) @ [ tmp_dir ]) ()
+  (* Snapshot the files before archiving them: the daemon keeps writing to its
+     logs, and tar would otherwise read them as they change underneath it.
+     Permissions and timestamps are carried over, as [cp -p] used to do. *)
+  let copy_file file =
+    let open Deferred.Let_syntax in
+    let src = conf_dir ^/ file and dst = tmp_dir ^/ file in
+    match%map
+      Monitor.try_with ~here:[%here] (fun () ->
+          let%bind stats = Unix.stat src in
+          let%bind () =
+            Reader.with_file src ~f:(fun reader ->
+                Writer.with_file dst ~f:(fun writer ->
+                    Writer.transfer writer (Reader.pipe reader)
+                      (Writer.write writer) ) )
+          in
+          let%bind () = Unix.chmod dst ~perm:stats.Unix.Stats.perm in
+          let seconds t = Time.Span.to_sec (Time.to_span_since_epoch t) in
+          Unix.utimes dst
+            ~access:(seconds stats.Unix.Stats.atime)
+            ~modif:(seconds stats.Unix.Stats.mtime) )
+    with
+    | Ok () ->
+        true
+    | Error _exn ->
+        (* A log file can be rotated away underneath us; archive the rest. *)
+        false
   in
-  let%bind _result1 =
+  let%bind.Deferred copied =
+    Deferred.List.filter ~how:`Sequential files ~f:copy_file
+  in
+  let%bind _result =
     Process.run ~prog:"tar"
       ~args:
         ( [ "-C"
@@ -219,11 +250,8 @@ let export_logs_to_tar ?basename ~conf_dir =
             "-czf"
           ; tarfile
           ]
-        @ files )
+        @ copied )
       ()
   in
-  let tmp_dir_files = files_in_dir tmp_dir in
-  let open Deferred.Let_syntax in
-  let%bind () = Deferred.List.iter tmp_dir_files ~f:Unix.remove in
-  let%bind () = Unix.rmdir tmp_dir in
+  let%bind.Deferred () = Mina_stdlib_unix.File_system.remove_dir tmp_dir in
   Deferred.Or_error.return tarfile

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -209,9 +209,15 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                              let f = Stdlib.open_out tmp_file in
                              fprintf f "%s" json ;
                              Stdlib.close_out f ;
+                             let args =
+                               [ "cp"
+                               ; "-n"
+                               ; tmp_file
+                               ; Printf.sprintf "gs://%s/%s" bucket name
+                               ]
+                             in
                              let command =
-                               Printf.sprintf "gsutil cp -n %s gs://%s/%s"
-                                 tmp_file bucket name
+                               String.concat ~sep:" " ("gsutil" :: args)
                              in
                              let%map output =
                                (* This double-wrapping of [try_with]s is protection
@@ -224,8 +230,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                                Deferred.Or_error.try_with_join ~here:[%here]
                                  (fun () ->
                                    Or_error.try_with (fun () ->
-                                       Async.Process.run () ~prog:"bash"
-                                         ~args:[ "-c"; command ]
+                                       Async.Process.run () ~prog:"gsutil" ~args
                                        |> Deferred.Result.map_error
                                             ~f:(Error.tag ~tag:__LOC__) )
                                    |> Result.map_error

--- a/src/lib/mina_stdlib_unix/file_system.ml
+++ b/src/lib/mina_stdlib_unix/file_system.ml
@@ -8,13 +8,6 @@ let dir_exists dir =
     Unix.File_kind.equal (Unix.Stats.kind stat) `Directory
   else return false
 
-let remove_dir dir =
-  let%bind _ =
-    Monitor.try_with ~here:[%here] (fun () ->
-        Process.run_exn ~prog:"rm" ~args:[ "-rf"; dir ] () )
-  in
-  Deferred.unit
-
 let rec rmrf path =
   match Core.Sys.is_directory path with
   | `Yes ->
@@ -24,6 +17,15 @@ let rec rmrf path =
   | _ ->
       if [%equal: [ `Yes | `No | `Unknown ]] (Core.Sys.file_exists path) `Yes
       then Core.Sys.remove path
+
+(* Errors are deliberately swallowed: every caller uses this for best-effort
+   cleanup of a directory it is about to stop caring about. *)
+let remove_dir dir =
+  let%bind _ =
+    Monitor.try_with ~here:[%here] (fun () ->
+        In_thread.run (fun () -> rmrf dir) )
+  in
+  Deferred.unit
 
 let try_finally ~(f : unit -> 'a Deferred.t) ~(finally : unit -> unit Deferred.t)
     =


### PR DESCRIPTION
Six external binaries were being exec'd for work OCaml already does. Each cost a fork+exec and an undeclared dependency on something outside the package — none of them appear in any `Depends:`; they work because the base images we use happen to ship coreutils.

| Was | Now | Where |
|---|---|---|
| `brew --prefix` via `/bin/sh` | both Homebrew prefixes listed literally | `cache_dir.ml` |
| `date +"%z"` | `Time.Zone.local` | `logproc.ml` |
| `uname -s` | test for `/proc/self/exe` | `child_processes.ml` |
| `rm -rf` | the `rmrf` already in the same file | `file_system.ml` |
| `cp -p` | an OCaml copy preserving mode and mtime | `conf_dir.ml` |
| `cat /etc/os-release` | read the file | `conf_dir.ml` |

Plus the `gsutil` block-upload no longer wraps itself in `bash -c` and a `sprintf`'d shell string; it passes an argv. `gsutil` itself stays.

Two of these are worth a closer look:

- **`brew --prefix` ran at module initialization of `cache_dir`**, on every platform including Linux, to compute a read-only lookup path. Anything linking `cache_dir` paid a `/bin/sh` fork at startup for it. The result only ever fed a list of candidate directories that already skips ones that do not exist, so both prefixes are now listed — `/opt/homebrew` included, which the old code would have found on Apple Silicon and a single hardcoded `/usr/local` would have silently dropped.
- **`date +"%z"` was also a bug.** The old parse divided the offset by 100, so sub-hour zones were truncated: India, Nepal and Newfoundland rendered log timestamps at the wrong time. `Zone.local` handles them.

The log-export snapshot copy is kept, not removed — the daemon keeps writing to its logs while `tar` reads them, so copying first is load-bearing. It is now an OCaml copy that carries over permissions and timestamps, as `cp -p` did. A file that cannot be copied, log rotation being the realistic case, is skipped rather than handed to `tar` as a missing path.

`uname -a`, `lscpu`, `lsgpu`, `lsmem` and `lsblk` stay: they collect a support bundle on `mina client export-local-logs`, their failures are already captured into the report text, and shelling out is the right tool for that.

## Verification

`dune build @check` is clean across the repo on `compatible`, and ocamlformat 0.20.1 has nothing to change in the touched files. Before the rebase from `develop`, the log export was exercised end-to-end against a synthetic config dir — contents, mtimes and permissions survive the copy, the temp directory is cleaned up, and `hardware.info` still carries the `/etc/os-release` section. `logproc` was run against a sample line to confirm the zone change.

## Not in this PR

- `curl` in `Cache_dir.load_from_s3` — implemented and verified separately, but it changes a trust boundary and deserves its own review. #19347
- `tar`, the last one, which needs a new opam dependency. #19346

Together those two would leave the daemon's startup path exec'ing nothing but binaries we ship.

