### PR TITLE
Scan state hash: serialize each job in a single bin_write_t pass

### DIFF
--- a/changes/19363.md
+++ b/changes/19363.md
@@ -1,0 +1,14 @@
+Scan state hash serializes each job in one pass
+
+Computing the staged ledger's scan state hash serialized every ledger proof
+and transaction witness twice: once to size the buffer and once to write it.
+For a Pickles proof the sizing pass converts every field element, so it cost
+about as much as the write. Each job is now written in a single pass into a
+shared buffer that grows on demand.
+
+The hash itself is unchanged, since the digested bytes are identical.
+
+On the `staged_ledger` inline tests, allocation fell from 144.8 GB to
+134.2 GB (7.3% less), with peak memory and wall clock unchanged within
+noise. Nodes that hash the scan state often, such as block producers
+building diffs, allocate proportionally less garbage.

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
@@ -97,6 +97,7 @@ module Make
     let bin_write_t buf ~pos t =
       let bytes = to_bytes t in
       let len = length_in_bytes in
+      Bin_prot.Common.check_next buf (pos + len) ;
       Bigstring.From_bytes.blit ~src:bytes ~src_pos:0 ~len:length_in_bytes
         ~dst:buf ~dst_pos:pos ;
       pos + len

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -214,11 +214,32 @@ module Stable = struct
 
     let to_latest = Fn.id
 
+    (* Serialize in a single [bin_write_t] pass into a shared buffer, growing
+       it on [Buffer_short]. This yields exactly the bytes [Binable.to_string]
+       would, but skips the [bin_size_t] pass, which for proofs is as expensive
+       as the write itself. *)
+    let single_pass_writer (type a) buf (module M : Binable.S with type t = a)
+        (x : a) : string =
+      let rec go () =
+        match M.bin_write_t !buf ~pos:0 x with
+        | len ->
+            Bigstring.To_string.sub !buf ~pos:0 ~len
+        | exception Bin_prot.Common.Buffer_short ->
+            buf := Bigstring.create (2 * Bigstring.length !buf) ;
+            go ()
+      in
+      go ()
+
     let hash (t : t) =
+      let buf = ref (Bigstring.create (1 lsl 16)) in
+      let proof_to_string =
+        single_pass_writer buf (module Ledger_proof_with_sok_message.Stable.V2)
+      in
+      let witness_to_string =
+        single_pass_writer buf (module Transaction_with_witness.Stable.V2)
+      in
       let state_hash =
-        Parallel_scan.State.hash t.scan_state
-          (Binable.to_string (module Ledger_proof_with_sok_message.Stable.V2))
-          (Binable.to_string (module Transaction_with_witness.Stable.V2))
+        Parallel_scan.State.hash t.scan_state proof_to_string witness_to_string
       in
       let ( previous_incomplete_zkapp_updates
           , `Border_block_continued_in_the_next_tree continue_in_next_tree ) =
@@ -227,8 +248,7 @@ module Stable = struct
       let incomplete_updates =
         List.fold ~init:(Digestif.SHA256.init ())
           previous_incomplete_zkapp_updates ~f:(fun h t ->
-            Digestif.SHA256.feed_string h
-            @@ Binable.to_string (module Transaction_with_witness.Stable.V2) t )
+            Digestif.SHA256.feed_string h @@ witness_to_string t )
         |> Digestif.SHA256.get
       in
       let continue_in_next_tree =


### PR DESCRIPTION
Fixes #19360.

`Transaction_snark_scan_state.Stable.V2.hash` serialized every ledger proof and transaction witness with `Binable.to_string`, which runs `bin_size_t` and then `bin_write_t`. For a Pickles proof the sizing pass does the full field-element conversion, so it costs about as much as the write.

Each job is now written with a single `bin_write_t` into a shared growable bigstring, retrying on `Buffer_short`. The digested bytes are unchanged, so the staged ledger hash is unchanged. The Pasta bigint `bin_write_t` now calls `Bin_prot.Common.check_next` before blitting, so a short buffer raises `Buffer_short` per the bin_prot writer contract instead of `Invalid_argument`.

## Benchmarks

Workload: `dune build @src/lib/staged_ledger/runtest` (the `staged_ledger` inline tests, the cheapest test that exercises the scan state hash). Base is 1e83915c08 (the `compatible` commit this branch is cut from), head is 2cc0e07e26. Each commit was checked out, built, and run 3 times on the same arm64 macOS machine with an otherwise idle tree. Allocation comes from the runtime's GC counters (`OCAMLRUNPARAM=v=0x400`, exact and deterministic); wall clock and peak RSS from `/usr/bin/time -l`, median of the 3 runs.

| Metric | Base | Head | Change |
| --- | --- | --- | --- |
| Words allocated (GB) | 144.79 | 134.16 | -10.62 (-7.3%) |
| Top heap words (M) | 58.0 | 50.5 | -13% |
| Wall clock, median (s) | 132.85 | 132.92 | +0.1% (spread 0.1–1.2 s) |
| Peak RSS (MB) | 2936.9 | 2943.8 | +0.2% |

The allocation saving is the removed `bin_size_t` pass. Wall clock is unchanged within noise: this test is dominated by proving and ledger application, so the hash's share is too small to move the total. Peak RSS is unchanged because the saved allocation is short-lived garbage.

https://claude.ai/code/session_01JRgkfKVJroFkSM5zcdW1cr
