### PR TITLE
Shrink the toolchain image: drop the repo clone, trim gcloud, strip unused payloads

### DIFF
--- a/dockerfiles/toolchain/1-build-deps
+++ b/dockerfiles/toolchain/1-build-deps
@@ -183,19 +183,13 @@ ENV PATH="$PATH:/usr/lib/go/bin:$HOME/.cargo/bin"
 # --- OCaml install of a given OCAML_VERSION via opam switch
 # additionally initializes opam with sandboxing disabled, as we did not install
 # bubblewrap above.
-RUN git clone \
-  https://github.com/ocaml/opam-repository.git \
-  --depth 1 \
-  /home/opam/opam-repository
-# Pin OPAM repo to specific commit, o.w. after this commit some of our direct
-# dependencies are removed
-WORKDIR /home/opam/opam-repository
-RUN git fetch origin "${OPAM_REPOSITORY_COMMIT}" \
-  && git checkout "${OPAM_REPOSITORY_COMMIT}"
-
+# The repository is pinned to a specific commit, o.w. after that commit some of
+# our direct dependencies are removed. opam fetches the commit itself, so there
+# is no separate clone to keep around: a standalone clone would only be a second
+# copy of the same index (~385 MB) next to the one under ~/.opam/repo/default.
 RUN opam init --disable-sandboxing \
     -k git \
-    -a /home/opam/opam-repository \
+    -a "https://github.com/ocaml/opam-repository.git#${OPAM_REPOSITORY_COMMIT}" \
     --bare
 # We pin the opam-repo SHA so this step gets 
 # cache-busted when we update the opam repo

--- a/dockerfiles/toolchain/1-build-deps
+++ b/dockerfiles/toolchain/1-build-deps
@@ -41,11 +41,6 @@ ARG GO_CAPNP_VERSION=v3.0.0-alpha.5
 # - src/lib/crypto/kimchi_bindings/stubs/rust-toolchain.toml
 # - src/lib/crypto/proof-systems/rust-toolchain.toml
 ARG RUST_VERSION=1.92.0
-# Nightly Rust Version used for WebAssembly builds
-# This should stay in line with the value of the variable
-# $NIGHTLY_RUST_VERSION defined in:
-# - src/lib/crypto/proof-systems/Makefile
-ARG RUST_NIGHTLY=2024-09-05
 
 # --- OS package dependencies
 # Organized as two alphabetized lists, first libraries and then tools/other packages
@@ -129,10 +124,25 @@ RUN case "${TARGETARCH}" in \
 
 # --- Golang install of a given GO_VERSION (add -v for spam output of each file from the go dist)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -xz -C /usr/lib/
+# test/, api/, doc/ and misc/ (30 MB) are not needed to compile anything, so they
+# are never extracted -- cheaper than writing and then deleting them, and a layer
+# only reclaims what it deletes itself anyway. --anchored is load-bearing: tar
+# matches exclude patterns against every path suffix by default, so a bare
+# "go/doc" also removes src/go/doc, and the stdlib stops compiling. Unasserted on
+# purpose otherwise: a check for these paths' absence would pass whether they were
+# excluded or renamed upstream, and 30 MB does not warrant a check that cannot
+# tell those apart -- `go version` and the capnp build below do catch a bad cut.
+RUN curl -s "https://dl.google.com/go/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" \
+  | tar -xz -C /usr/lib/ --anchored \
+      --exclude "go/test" --exclude "go/api" --exclude "go/doc" --exclude "go/misc" \
+  && /usr/lib/go/bin/go version
 
 # --- Rust install via rustup-init to a given RUST_VERSION
-# --- Additionally, install RUST_NIGHTLY via rustup
+# Stable only, and without rust-src or the wasm32 target: nothing in this repo
+# builds wasm from this image. The one nightly consumer,
+# src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml, pins its own nightly,
+# and src/lib/crypto/proof-systems/Makefile adds rust-src for that nightly
+# itself, so rustup fetches what it needs when someone actually builds wasm.
 # For more about rustup-init see: https://github.com/rust-lang/rustup/blob/master/README.md
 # As opposed to introducing another shell script here (that mostly just determines the platform)
 # we just download the binary for the only platform we care about in this docker environment
@@ -149,13 +159,6 @@ RUN case "${TARGETARCH}" in \
   && /tmp/rustup-init -y --default-toolchain \
     "${RUST_VERSION}" \
     --profile minimal \
-    --component rust-src \
-    --target wasm32-unknown-unknown \
-  && "$HOME/.cargo/bin/rustup" toolchain install "nightly-${RUST_NIGHTLY}" \
-    --profile minimal \
-    --component rust-src \
-    --target wasm32-unknown-unknown \
-    --no-self-update \
   && rm /tmp/rustup-init
 USER root
 
@@ -187,19 +190,23 @@ ENV PATH="$PATH:/usr/lib/go/bin:$HOME/.cargo/bin"
 # our direct dependencies are removed. opam fetches the commit itself, so there
 # is no separate clone to keep around: a standalone clone would only be a second
 # copy of the same index (~385 MB) next to the one under ~/.opam/repo/default.
+# One RUN on purpose: the package index this fetches is ~90 MB and is dead
+# weight once the switch exists, and a layer only reclaims what it deletes
+# itself -- deleting it in any later layer would leave it in this one.
+# We pin the opam-repo SHA so this step gets
+# cache-busted when we update the opam repo
 RUN opam init --disable-sandboxing \
     -k git \
     -a "https://github.com/ocaml/opam-repository.git#${OPAM_REPOSITORY_COMMIT}" \
-    --bare
-# We pin the opam-repo SHA so this step gets 
-# cache-busted when we update the opam repo
-RUN opam repository add --yes \
+    --bare \
+  && opam repository add --yes \
     --all \
     --set-default o1-labs \
     https://github.com/o1-labs/opam-repository.git#${O1LABS_OPAM_REPOSITORY_COMMIT} \
   && opam switch create "${OCAML_VERSION}${OCAML_REVISION}" \
     "${OCAML_PACKAGE}${OCAML_VERSION}${OCAML_REVISION}${OCAML_VARIANT}" \
-  && opam switch "${OCAML_VERSION}${OCAML_REVISION}"
+  && opam switch "${OCAML_VERSION}${OCAML_REVISION}" \
+  && rm -r /home/opam/.opam/repo/default /home/opam/.opam/repo/state-*.cache
 
 WORKDIR /home/opam
 

--- a/dockerfiles/toolchain/2-opam-deps
+++ b/dockerfiles/toolchain/2-opam-deps
@@ -1,25 +1,19 @@
 #################################################################################################
 # The "opam-deps" Stage
 # - Continues from the build-deps image
-# - Installs all opam dependencies and pins from mina's github
-# - Includes the entire mina codebase and submodules in "${MINA_DIR}" (must be writable by opam user)
+# - Installs all opam dependencies from the repo's opam.export
 # - Largely mirrors/replaces ./scripts/setup-opam.sh
 #################################################################################################
 FROM build-deps AS opam-deps
 
-# location of repo used for pins and external package commits
+# location of the directory holding opam.export
 ARG MINA_DIR=mina
-# branch to checkout for opam dependencies
+# Declared but unused: scripts/docker/build.sh passes --build-arg MINA_BRANCH and
+# MINA_REPO to every service, and an undeclared build arg warns on each build.
 ARG MINA_BRANCH=compatible
-# mina repository to pull from
 ARG MINA_REPO=https://github.com/MinaProtocol/mina
 
-# location of external packages
-ARG EXTERNAL_PKG_DIR=$MINA_DIR/src/external
-
-# don't keep build directories
-# to force reinstall of pinned packages from Mina sources
-# and to keep Docker image reasonable size
+# don't keep build directories, to keep the image size reasonable
 ENV OPAMKEEPBUILDDIR false
 ENV OPAMREUSEBUILDDIR false
 # Limit logs for opam install errors to 20 lines per error
@@ -29,27 +23,20 @@ ENV OPAMERRLOGLEN 20
 
 USER opam
 
-# --- Shallow clone the Mina repo, only focused on the given MINA_BRANCH
-# git will clone into an empty dir, but this also helps us set the workdir in advance
-RUN git clone \
-  -b "${MINA_BRANCH}" \
-  --depth 1 \
-  --shallow-submodules \
-  --recurse-submodules \
-  "${MINA_REPO}" "${HOME}/${MINA_DIR}"
-
 WORKDIR $HOME/$MINA_DIR
+
+# opam.export is the only file the switch import needs: it contains no git or
+# pinned packages, so no mina sources or submodules have to be present. Copying
+# it (instead of cloning a branch HEAD) also keeps the multi-hour switch layer
+# below cache-keyed on this file's content rather than on a moving branch tip.
+# scripts/docker/build.sh stages opam.export into the "dockerfiles/" build context.
+COPY --chown=opam:opam opam.export ./
 
 # Set environment variables *before* running OPAM commands
 ENV OPAMYES=1
 
-# Update repo and install the switch (sources must be available locally!)
-RUN opam update && \
-    opam switch import opam.export --yes
-
-# --- Pin external packages / submodules
-# TODO: Would be really nice to pull this script, the git submodules, and opam.export exclusively in this stage
-# Remove .ppx and the .ppx-cache so they can be built on each run
-RUN eval "$(opam config env)" \
-  && scripts/pin-external-packages.sh \
+# Update repo and install the switch. Cleaning in the same layer so the build
+# logs and caches never land in an image layer.
+RUN opam update \
+  && opam switch import opam.export --yes \
   && opam clean --logs -cs --quiet

--- a/dockerfiles/toolchain/2-opam-deps
+++ b/dockerfiles/toolchain/2-opam-deps
@@ -35,8 +35,13 @@ COPY --chown=opam:opam opam.export ./
 # Set environment variables *before* running OPAM commands
 ENV OPAMYES=1
 
-# Update repo and install the switch. Cleaning in the same layer so the build
-# logs and caches never land in an image layer.
+# Update repo and install the switch. `opam update` re-fetches the package index
+# that stage 1 deleted after creating the compiler switch: the index is ~90 MB
+# and is dead weight once the switch is built, but a layer only reclaims what it
+# deletes itself, so it has to be fetched and dropped inside this one RUN.
+# Cleaning here likewise keeps the build logs and caches out of the image.
 RUN opam update \
   && opam switch import opam.export --yes \
-  && opam clean --logs -cs --quiet
+  && opam clean --logs -cs --quiet \
+  && rm -r "$HOME/.opam/repo/default" "$HOME"/.opam/repo/state-*.cache \
+  && opam switch list

--- a/dockerfiles/toolchain/3-toolchain
+++ b/dockerfiles/toolchain/3-toolchain
@@ -27,7 +27,6 @@ RUN apt-get update --yes \
     libgmp10 \
     libgomp1 \
     lsb-release \
-    pandoc \
     patchelf \
     postgresql \
     postgresql-contrib \
@@ -92,8 +91,7 @@ RUN case "${TARGETARCH}" in \
 # over the bundle, and python3 is already installed above, so the bundle is never
 # used -- it is excluded at extraction rather than deleted afterwards, so the
 # 253 MB is never written on either arch. gcloud and gsutil themselves stay: CI
-# uses both (buildkite/scripts/gsutil-upload.sh and friends). gcloud and gsutil
-# are both used by CI (buildkite/scripts/gsutil-upload.sh and friends) and stay.
+# uses both (buildkite/scripts/gsutil-upload.sh and friends).
 ENV CLOUDSDK_PYTHON=/usr/bin/python3
 
 # What cannot be excluded is trimmed in the install's own RUN layer, or the layer
@@ -162,6 +160,7 @@ RUN case "${TARGETARCH}" in \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-${AWS_ARCH}.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install \
-    && rm -rf awscliv2.zip aws
+    && rm -r awscliv2.zip aws \
+    && aws --version
 
 USER opam

--- a/dockerfiles/toolchain/3-toolchain
+++ b/dockerfiles/toolchain/3-toolchain
@@ -63,11 +63,9 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 # --- influx db tool
 # Custom version, with lock only on manifest upload
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -L -o influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz https://download.influxdata.com/influxdb/releases/influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz \
-    && mkdir -p "influx_dir" && tar xvzf influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz -C influx_dir \
-    && cp influx_dir/influx /usr/local/bin/ \
-    && rm influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz \
-    && rm -rf influx_dir
+RUN curl -sSfL "https://download.influxdata.com/influxdb/releases/influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin ./influx \
+    && influx version
 
 # --- Docker CLI
 # Only the client: no CI job reaches a daemon from inside this image. Jobs that

--- a/dockerfiles/toolchain/3-toolchain
+++ b/dockerfiles/toolchain/3-toolchain
@@ -70,14 +70,21 @@ RUN curl -L -o influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.
     && rm influxdb2-client-${INFLUXDB_CLI_VERSION}-linux-${TARGETARCH}.tar.gz \
     && rm -rf influx_dir
 
-# --- Docker Daemon
+# --- Docker CLI
+# Only the client: no CI job reaches a daemon from inside this image. Jobs that
+# run docker (scripts/docker/build.sh, buildx, the cache verifier) are host-level
+# Cmd.run steps using the agent's docker, and the two ways a step runs *in* this
+# image -- Cmd.runInDocker and the docker#v3.5.0 plugin -- mount no docker
+# socket. So dockerd, containerd, ctr, runc and docker-proxy in the static
+# bundle (~130 MB of its ~175 MB) have nothing to do here.
 RUN case "${TARGETARCH}" in \
         "amd64") DOCKER_ARCH="x86_64" ;; \
         "arm64") DOCKER_ARCH="aarch64" ;; \
         *) echo "Unsupported arch: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     curl -sL https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-${DOCKER_VERSION}.tgz \
-    | tar --extract --gzip --strip-components 1 --directory=/usr/bin --file=-
+    | tar --extract --gzip --strip-components 1 --directory=/usr/bin --file=- docker/docker \
+    && docker --version
 
 # --- Google Cloud tools
 # The amd64 SDK ships its own CPython under platform/bundledpythonunix (253 MB);

--- a/dockerfiles/toolchain/3-toolchain
+++ b/dockerfiles/toolchain/3-toolchain
@@ -80,14 +80,41 @@ RUN case "${TARGETARCH}" in \
     | tar --extract --gzip --strip-components 1 --directory=/usr/bin --file=-
 
 # --- Google Cloud tools
+# The amd64 SDK ships its own CPython under platform/bundledpythonunix (253 MB);
+# the arm64 one bundles no interpreter at all. bin/gcloud prefers $CLOUDSDK_PYTHON
+# over the bundle, and python3 is already installed above, so the bundle is never
+# used -- it is excluded at extraction rather than deleted afterwards, so the
+# 253 MB is never written on either arch. gcloud and gsutil themselves stay: CI
+# uses both (buildkite/scripts/gsutil-upload.sh and friends). gcloud and gsutil
+# are both used by CI (buildkite/scripts/gsutil-upload.sh and friends) and stay.
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
+
+# What cannot be excluded is trimmed in the install's own RUN layer, or the layer
+# would keep the untrimmed size anyway. That includes .install/.backup: the
+# components commands below leave a full rollback copy of the SDK there, 611 MB,
+# which is worth more than everything else this stage trims put together. bq has no caller in this repo and does
+# not survive a `components update` being run in this image, which CI never does.
+# The bundle's absence is asserted by glob, not by the literal path: an SDK that
+# renames the directory would slip past --exclude and past a path-equality check
+# (the old name is absent either way), and go on shipping 253 MB unnoticed. The
+# glob fails the build instead.
 RUN case "${TARGETARCH}" in \
         "amd64") GCLOUD_ARCH="x86_64" ;; \
         "arm64") GCLOUD_ARCH="arm" ;; \
         *) echo "Unsupported arch: ${TARGETARCH}"; exit 1 ;; \
     esac; \
     curl -sSfL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-${GCLOUD_ARCH}.tar.gz" | \
-    tar -xz -C /opt/ && \
-    /opt/google-cloud-sdk/bin/gcloud components install kubectl --quiet
+    tar -xz -C /opt/ --anchored \
+      --exclude "google-cloud-sdk/platform/bundledpythonunix" \
+      --exclude "google-cloud-sdk/RELEASE_NOTES" \
+    && test -z "$(find /opt/google-cloud-sdk/platform -maxdepth 1 -name 'bundledpython*' -print -quit)" \
+    && test ! -e /opt/google-cloud-sdk/RELEASE_NOTES \
+    && /opt/google-cloud-sdk/bin/gcloud components install kubectl --quiet \
+    && /opt/google-cloud-sdk/bin/gcloud components remove bq --quiet \
+    && rm -r /opt/google-cloud-sdk/.install/.backup \
+    && /opt/google-cloud-sdk/bin/gcloud version \
+    && /opt/google-cloud-sdk/bin/gsutil version \
+    && find /opt/google-cloud-sdk -type d -name __pycache__ -prune -exec rm -rf {} +
 
 ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -25,8 +25,9 @@ source "${SCRIPTPATH}"/../../buildkite/scripts/docker/gar-cache.sh
 # into a temp file (see the SERVICE case below); they all assign the same
 # variable, so one trap cleans up whichever branch ran -- including on the early
 # `exit 1` paths and on a failed docker build, where a tail-of-script rm would be
-# skipped and leak the file. Expands to a no-op rm when no temp file was made.
-trap 'rm -f "${TEMP_DOCKERFILE:-}"' EXIT
+# skipped and leak the file. The same trap removes any file staged into the build
+# context. Expands to a no-op rm when neither was made.
+trap 'rm -f "${TEMP_DOCKERFILE:-}" "${STAGED_CONTEXT_FILE:-}"' EXIT
 
 function usage() {
   if [[ -n "$1" ]]; then
@@ -350,6 +351,11 @@ case "${SERVICE}" in
         TEMP_DOCKERFILE=$(mktemp "${TMPDIR:-/tmp}"/Dockerfile-toolchain.XXXXXX)
         cat dockerfiles/toolchain/1-build-deps dockerfiles/toolchain/2-opam-deps dockerfiles/toolchain/3-toolchain > "$TEMP_DOCKERFILE"
         DOCKERFILE_PATH="$TEMP_DOCKERFILE"
+        # 2-opam-deps COPYs opam.export, which lives at the repo root while the
+        # build context is "dockerfiles/". Stage a copy in the context; the EXIT
+        # trap removes it so it never shows up as an untracked file.
+        STAGED_CONTEXT_FILE="${DOCKER_CONTEXT%/}/opam.export"
+        cp opam.export "$STAGED_CONTEXT_FILE"
         ;;
     mina-rosetta)
         # Staged build: rosetta's own heavy base + mina-rosetta stage.

--- a/scripts/docker/tests/test_build.sh
+++ b/scripts/docker/tests/test_build.sh
@@ -450,6 +450,10 @@ test_toolchain_joins_the_stage_files() {
     assert_matches "a temporary Dockerfile holds the joined stages" "$args" \
         "^/tmp/Dockerfile-toolchain\."
     assert_has_line "the toolchain tag has no network" "$args" "testreg/mina-toolchain:3.1.0"
+    # opam.export is copied into the "dockerfiles/" build context for the COPY in
+    # 2-opam-deps, and the EXIT trap must take it back out again.
+    assert_file_absent "the staged opam.export does not stay in the build context" \
+        "${REPO_ROOT}/dockerfiles/opam.export"
 }
 
 test_delegation_verifier() {


### PR DESCRIPTION
Closes #19367
Closes #19368

The toolchain image was 9.77 GB. This removes everything in it that nothing uses, and stops downloading what does not need to be downloaded.

**Measured result: 9.77 GB → 7.28 GB** (`docker image inspect` on the image built by CI), and the build's own steps drop from 698s to 569s for the same job.

## What changes

**`2-opam-deps` no longer clones the mina repo.** It cloned the whole repo with recursive submodules to run `opam switch import opam.export` and `pin-external-packages.sh`. That script does nothing but `git submodule update` now, and `opam.export` holds no git or pinned packages, so no sources have to be present. `COPY opam.export` replaces it: ~450 MB and 60s of clone time. `opam.export` lives at the repo root while the build context is `dockerfiles/`, so `scripts/docker/build.sh` stages a copy there and the existing EXIT trap removes it.

**`1-build-deps` inits opam straight from the pinned commit.** It cloned `ocaml/opam-repository` to `/home/opam/opam-repository` only to hand it to `opam init -a`, which then made its own copy. `opam init -k git --bare -a <url>#<sha>` needs no standalone clone — verified against opam 2.3.0, the version the image installs: `repo/default` lands at exactly the pinned commit with the full package set, and a later `opam update` reports "no changes" and holds the pin.

**The google-cloud-sdk is trimmed, not removed** — CI needs it. It uses the `python3` the stage already installs (`CLOUDSDK_PYTHON`, which `bin/gcloud` prefers over its bundle), so the bundled CPython is excluded at extraction rather than shipped: 253 MB never written. It also loses the `bq` component, `RELEASE_NOTES` and the `__pycache__` trees. `gsutil` stays — four buildkite scripts use it.

**Only the docker client is installed.** The static bundle also ships dockerd, containerd, ctr, runc and docker-proxy, ~130 MB of its ~175 MB. Nothing in the image can reach a daemon: jobs that run docker are host-level `Cmd.run` steps using the agent's docker, and the two ways a step runs *inside* this image — `Cmd.runInDocker` and the `docker#v3.5.0` plugin — mount no docker socket. The repo has no `dockerd`, `ctr` or `runc` invocation anywhere.

**Payloads with no user in this repo are gone:**

- Rust nightly, and `rust-src` + the wasm32 target on stable. No buildkite job builds wasm or invokes nightly. The one nightly consumer, `src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml`, pins `nightly-2025-12-11` while the image installed `nightly-2024-09-05` — it could not have served it regardless — and `proof-systems/Makefile` adds `rust-src` for its own nightly.
- `pandoc`. No caller anywhere; `make ml-docs` uses odoc.
- Go's `test/`, `api/`, `doc/` and `misc/` trees (30 MB), never extracted.
- The opam package index, dead weight once the switch is built.

**The influx client is streamed into place** rather than staged: it was the last download that fetched a tarball, extracted all of it to a scratch directory, copied one binary out and deleted both.

## On layer accounting

A layer commits its own net diff, so deleting a file in a *later* layer reclaims nothing — the earlier layer still ships the bytes and everyone pulls them. Every trim here therefore happens in the same `RUN` as the install it trims, or, better, the file is never extracted at all. The opam index needed one extra step, since stage 1 has to use it to create the compiler switch: stage 1 deletes it before its RUN ends, and stage 2's `opam update` re-fetches it inside the import RUN and drops it there too, so no layer ever carries it.

## Correcting the issues' premise

#19367 argued the branch clone was cache-busting a "multi-hour" `opam switch import` layer. Both halves of that are wrong: the import takes **4.7 minutes**, and `scripts/docker/build.sh` passes `--no-cache` on every toolchain build (zero CACHED steps in any log), so the layer cache never applied. Removing the clone is still right — for the 450 MB and the clone time — just not for cache stability.

#19368 attributed part of gcloud's `bin/` to `anthoscli`. The 476.0.0 tarball ships no such binary; `bin/` is large because `gcloud components install kubectl` bundles four kubectl builds (1.27–1.30) plus a dispatcher, 239 MB.

## Checking

Each step asserts its own result in its own layer — `gcloud version`, `gsutil version`, `docker --version`, `go version`, `aws --version`, `influx version`, `opam switch list` — so a cut that breaks a tool fails the build instead of shipping. Deletions deliberately omit `rm -f`: a no-op deletion must fail loudly, which is how the arm64 difference below was caught. Where a file is excluded at extraction instead of deleted, the *outcome* is asserted by glob (`bundledpython*`) rather than by literal path, since a rename would slip past both `--exclude` and a path-equality check.

Every archive layout the Dockerfiles depend on was checked against the real upstream artifacts on **both** architectures: docker static (`docker/docker`), go (`test/api/doc/misc`), gcloud (bundled python, `RELEASE_NOTES`), influx (flat `./influx`), shellcheck (`shellcheck-v0.11.0/shellcheck`), mina-release-toolkit (`./usr/bin/mina-bench-upload`). That audit found the one real arch difference: **the arm64 gcloud SDK bundles no interpreter at all**, which is why the amd64-only assumption failed CI once and is now handled uniformly by excluding at extraction.

`scripts/docker/tests/test_build.sh` passes at every commit (26 tests, 103 assertions) and gains one case: the staged `opam.export` must not survive the build.

## Deliberately not done

- **kubectl (239 MB)**: no CI job uses it and the original consumer — the GKE integration-test engine — is gone, but out-of-repo pipelines use this image, so it stays.
- **`.cmt`/`.cmti` in the opam switch (781 MB)**: nothing in a build reads them, but they are what merlin/ocamllsp/odoc consume, they cannot be regenerated without reinstalling the packages, and the failure mode would be quietly degraded tooling rather than a loud error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
