### PR TITLE
Serialize Pasta field elements and Pickles vectors in place

### DIFF
--- a/changes/19373.md
+++ b/changes/19373.md
@@ -1,0 +1,3 @@
+Speed up block serialization by encoding proofs in place
+
+Every encode and decode of a proof, whether receiving a block over gossip, computing its body reference, or reading and writing the proof cache, used to convert each field element through two intermediate copies. Field elements and proof vectors are now written to and read from the buffer directly. At mainnet block sizes this cuts the time to encode a block body roughly in half and reduces the memory allocated for it by more than 90%, with matching gains for decoding, body hashing, and proof cache reads. The on-disk and on-wire encoding is unchanged.

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -100,8 +100,22 @@ let
 
   dune-nix = inputs.dune-nix.lib.${pkgs.system};
 
-  base-libs = dune-nix.squashOpamNixDeps scope.ocaml.version
-    (pkgs.lib.attrVals (builtins.attrNames implicit-deps) scope);
+  # Some post-Mesa dependency closures expose duplicate OCaml package dirs,
+  # such as site-lib/toplevel. Keep the first one instead of failing while
+  # squashing the opam dependencies.
+  base-libs =
+    (dune-nix.squashOpamNixDeps scope.ocaml.version
+      (pkgs.lib.attrVals (builtins.attrNames implicit-deps) scope)).overrideAttrs
+      (old: {
+        installPhase = builtins.replaceStrings [
+          ''ln -s "$d" "$out/lib/ocaml/${scope.ocaml.version}/site-lib/"''
+        ] [
+          ''
+            target="$out/lib/ocaml/${scope.ocaml.version}/site-lib/$(basename "$d")"
+            [ -e "$target" ] || ln -s "$d" "$target"
+          ''
+        ] old.installPhase;
+      });
 
   dune-description = pkgs.stdenv.mkDerivation {
     pname = "dune-description";

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -40,6 +40,10 @@ module Kimchi_backend_common : sig
 
       val of_bigint : Bigint.t -> t
 
+      val to_bytes_into : t -> Core.Bigstring.t -> int -> unit
+
+      val of_bytes_from : Core.Bigstring.t -> int -> t
+
       val of_int : int -> t
 
       val add : t -> t -> t

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -40,8 +40,17 @@ module Kimchi_backend_common : sig
 
       val of_bigint : Bigint.t -> t
 
+      (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same
+          32 little-endian bytes as [Bigint.to_bytes (to_bigint t)], to
+          [buf.{pos} .. buf.{pos + 31}], allocating nothing. Raises
+          [Invalid_argument] when that window does not fit in [buf]. *)
       val blit_to_bigstring : t -> Core.Bigstring.t -> int -> unit
 
+      (** [of_bigstring buf pos] reads the element written by
+          [blit_to_bigstring] at [buf.{pos} .. buf.{pos + 31}]. Raises
+          [Invalid_argument] when the window does not fit in [buf], and
+          [Failure] when the bytes are not a canonical element, i.e. encode a
+          value at or above the modulus. *)
       val of_bigstring : Core.Bigstring.t -> int -> t
 
       val of_int : int -> t

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -40,9 +40,9 @@ module Kimchi_backend_common : sig
 
       val of_bigint : Bigint.t -> t
 
-      val to_bytes_into : t -> Core.Bigstring.t -> int -> unit
+      val blit_to_bigstring : t -> Core.Bigstring.t -> int -> unit
 
-      val of_bytes_from : Core.Bigstring.t -> int -> t
+      val of_bigstring : Core.Bigstring.t -> int -> t
 
       val of_int : int -> t
 

--- a/src/lib/crypto/kimchi_backend/kimchi_backend.mli
+++ b/src/lib/crypto/kimchi_backend/kimchi_backend.mli
@@ -44,14 +44,14 @@ module Kimchi_backend_common : sig
           32 little-endian bytes as [Bigint.to_bytes (to_bigint t)], to
           [buf.{pos} .. buf.{pos + 31}], allocating nothing. Raises
           [Invalid_argument] when that window does not fit in [buf]. *)
-      val blit_to_bigstring : t -> Core.Bigstring.t -> int -> unit
+      val blit_to_bigstring : t -> Core_kernel.Bigstring.t -> int -> unit
 
       (** [of_bigstring buf pos] reads the element written by
           [blit_to_bigstring] at [buf.{pos} .. buf.{pos + 31}]. Raises
           [Invalid_argument] when the window does not fit in [buf], and
           [Failure] when the bytes are not a canonical element, i.e. encode a
           value at or above the modulus. *)
-      val of_bigstring : Core.Bigstring.t -> int -> t
+      val of_bigstring : Core_kernel.Bigstring.t -> int -> t
 
       val of_int : int -> t
 

--- a/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
@@ -45,6 +45,26 @@ var caml_bigint_256_to_bytes = tsBindings.caml_bigint_256_to_bytes;
 // Requires: tsBindings
 var caml_bigint_256_of_bytes = tsBindings.caml_bigint_256_of_bytes;
 
+// Provides: caml_bigint_256_to_bytes_into
+// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+function caml_bigint_256_to_bytes_into(x, buf, pos) {
+  var bytes = tsBindings.caml_bigint_256_to_bytes(x);
+  for (var i = 0; i < 32; i++) {
+    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
+  }
+  return 0;
+}
+
+// Provides: caml_bigint_256_of_bytes_from
+// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+function caml_bigint_256_of_bytes_from(buf, pos) {
+  var bytes = caml_create_bytes(32);
+  for (var i = 0; i < 32; i++) {
+    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
+  }
+  return tsBindings.caml_bigint_256_of_bytes(bytes);
+}
+
 // Provides: caml_bigint_256_deep_copy
 // Requires: tsBindings
 var caml_bigint_256_deep_copy = tsBindings.caml_bigint_256_deep_copy

--- a/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
@@ -46,22 +46,17 @@ var caml_bigint_256_to_bytes = tsBindings.caml_bigint_256_to_bytes;
 var caml_bigint_256_of_bytes = tsBindings.caml_bigint_256_of_bytes;
 
 // Provides: caml_bigint_256_blit_to_bigstring
-// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+// Requires: tsBindings, caml_bigstring_blit_bytes_to_ba
 function caml_bigint_256_blit_to_bigstring(x, buf, pos) {
-  var bytes = tsBindings.caml_bigint_256_to_bytes(x);
-  for (var i = 0; i < 32; i++) {
-    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
-  }
+  caml_bigstring_blit_bytes_to_ba(tsBindings.caml_bigint_256_to_bytes(x), 0, buf, pos, 32);
   return 0;
 }
 
 // Provides: caml_bigint_256_of_bigstring
-// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+// Requires: tsBindings, caml_bigstring_blit_ba_to_bytes, caml_create_bytes
 function caml_bigint_256_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
-  for (var i = 0; i < 32; i++) {
-    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
-  }
+  caml_bigstring_blit_ba_to_bytes(buf, pos, bytes, 0, 32);
   return tsBindings.caml_bigint_256_of_bytes(bytes);
 }
 

--- a/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/bigint256.js
@@ -45,9 +45,9 @@ var caml_bigint_256_to_bytes = tsBindings.caml_bigint_256_to_bytes;
 // Requires: tsBindings
 var caml_bigint_256_of_bytes = tsBindings.caml_bigint_256_of_bytes;
 
-// Provides: caml_bigint_256_to_bytes_into
+// Provides: caml_bigint_256_blit_to_bigstring
 // Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
-function caml_bigint_256_to_bytes_into(x, buf, pos) {
+function caml_bigint_256_blit_to_bigstring(x, buf, pos) {
   var bytes = tsBindings.caml_bigint_256_to_bytes(x);
   for (var i = 0; i < 32; i++) {
     caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
@@ -55,9 +55,9 @@ function caml_bigint_256_to_bytes_into(x, buf, pos) {
   return 0;
 }
 
-// Provides: caml_bigint_256_of_bytes_from
+// Provides: caml_bigint_256_of_bigstring
 // Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
-function caml_bigint_256_of_bytes_from(buf, pos) {
+function caml_bigint_256_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
   for (var i = 0; i < 32; i++) {
     caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));

--- a/src/lib/crypto/kimchi_bindings/js/bindings/field.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/field.js
@@ -121,6 +121,26 @@ var caml_pasta_fp_to_bytes = tsBindings.caml_pasta_fp_to_bytes;
 // Requires: tsBindings
 var caml_pasta_fp_of_bytes = tsBindings.caml_pasta_fp_of_bytes;
 
+// Provides: caml_pasta_fp_to_bytes_into
+// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+function caml_pasta_fp_to_bytes_into(x, buf, pos) {
+  var bytes = tsBindings.caml_pasta_fp_to_bytes(x);
+  for (var i = 0; i < 32; i++) {
+    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
+  }
+  return 0;
+}
+
+// Provides: caml_pasta_fp_of_bytes_from
+// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+function caml_pasta_fp_of_bytes_from(buf, pos) {
+  var bytes = caml_create_bytes(32);
+  for (var i = 0; i < 32; i++) {
+    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
+  }
+  return tsBindings.caml_pasta_fp_of_bytes(bytes);
+}
+
 // Provides: caml_pasta_fp_deep_copy
 // Requires: tsBindings
 var caml_pasta_fp_deep_copy = tsBindings.caml_pasta_fp_deep_copy;
@@ -247,6 +267,26 @@ var caml_pasta_fq_to_bytes = tsBindings.caml_pasta_fq_to_bytes;
 // Provides: caml_pasta_fq_of_bytes
 // Requires: tsBindings
 var caml_pasta_fq_of_bytes = tsBindings.caml_pasta_fq_of_bytes;
+
+// Provides: caml_pasta_fq_to_bytes_into
+// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+function caml_pasta_fq_to_bytes_into(x, buf, pos) {
+  var bytes = tsBindings.caml_pasta_fq_to_bytes(x);
+  for (var i = 0; i < 32; i++) {
+    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
+  }
+  return 0;
+}
+
+// Provides: caml_pasta_fq_of_bytes_from
+// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+function caml_pasta_fq_of_bytes_from(buf, pos) {
+  var bytes = caml_create_bytes(32);
+  for (var i = 0; i < 32; i++) {
+    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
+  }
+  return tsBindings.caml_pasta_fq_of_bytes(bytes);
+}
 
 // Provides: caml_pasta_fq_deep_copy
 // Requires: tsBindings

--- a/src/lib/crypto/kimchi_bindings/js/bindings/field.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/field.js
@@ -122,22 +122,17 @@ var caml_pasta_fp_to_bytes = tsBindings.caml_pasta_fp_to_bytes;
 var caml_pasta_fp_of_bytes = tsBindings.caml_pasta_fp_of_bytes;
 
 // Provides: caml_pasta_fp_blit_to_bigstring
-// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+// Requires: tsBindings, caml_bigstring_blit_bytes_to_ba
 function caml_pasta_fp_blit_to_bigstring(x, buf, pos) {
-  var bytes = tsBindings.caml_pasta_fp_to_bytes(x);
-  for (var i = 0; i < 32; i++) {
-    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
-  }
+  caml_bigstring_blit_bytes_to_ba(tsBindings.caml_pasta_fp_to_bytes(x), 0, buf, pos, 32);
   return 0;
 }
 
 // Provides: caml_pasta_fp_of_bigstring
-// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+// Requires: tsBindings, caml_bigstring_blit_ba_to_bytes, caml_create_bytes
 function caml_pasta_fp_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
-  for (var i = 0; i < 32; i++) {
-    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
-  }
+  caml_bigstring_blit_ba_to_bytes(buf, pos, bytes, 0, 32);
   return tsBindings.caml_pasta_fp_of_bytes(bytes);
 }
 
@@ -269,22 +264,17 @@ var caml_pasta_fq_to_bytes = tsBindings.caml_pasta_fq_to_bytes;
 var caml_pasta_fq_of_bytes = tsBindings.caml_pasta_fq_of_bytes;
 
 // Provides: caml_pasta_fq_blit_to_bigstring
-// Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
+// Requires: tsBindings, caml_bigstring_blit_bytes_to_ba
 function caml_pasta_fq_blit_to_bigstring(x, buf, pos) {
-  var bytes = tsBindings.caml_pasta_fq_to_bytes(x);
-  for (var i = 0; i < 32; i++) {
-    caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
-  }
+  caml_bigstring_blit_bytes_to_ba(tsBindings.caml_pasta_fq_to_bytes(x), 0, buf, pos, 32);
   return 0;
 }
 
 // Provides: caml_pasta_fq_of_bigstring
-// Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
+// Requires: tsBindings, caml_bigstring_blit_ba_to_bytes, caml_create_bytes
 function caml_pasta_fq_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
-  for (var i = 0; i < 32; i++) {
-    caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
-  }
+  caml_bigstring_blit_ba_to_bytes(buf, pos, bytes, 0, 32);
   return tsBindings.caml_pasta_fq_of_bytes(bytes);
 }
 

--- a/src/lib/crypto/kimchi_bindings/js/bindings/field.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/field.js
@@ -121,9 +121,9 @@ var caml_pasta_fp_to_bytes = tsBindings.caml_pasta_fp_to_bytes;
 // Requires: tsBindings
 var caml_pasta_fp_of_bytes = tsBindings.caml_pasta_fp_of_bytes;
 
-// Provides: caml_pasta_fp_to_bytes_into
+// Provides: caml_pasta_fp_blit_to_bigstring
 // Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
-function caml_pasta_fp_to_bytes_into(x, buf, pos) {
+function caml_pasta_fp_blit_to_bigstring(x, buf, pos) {
   var bytes = tsBindings.caml_pasta_fp_to_bytes(x);
   for (var i = 0; i < 32; i++) {
     caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
@@ -131,9 +131,9 @@ function caml_pasta_fp_to_bytes_into(x, buf, pos) {
   return 0;
 }
 
-// Provides: caml_pasta_fp_of_bytes_from
+// Provides: caml_pasta_fp_of_bigstring
 // Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
-function caml_pasta_fp_of_bytes_from(buf, pos) {
+function caml_pasta_fp_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
   for (var i = 0; i < 32; i++) {
     caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));
@@ -268,9 +268,9 @@ var caml_pasta_fq_to_bytes = tsBindings.caml_pasta_fq_to_bytes;
 // Requires: tsBindings
 var caml_pasta_fq_of_bytes = tsBindings.caml_pasta_fq_of_bytes;
 
-// Provides: caml_pasta_fq_to_bytes_into
+// Provides: caml_pasta_fq_blit_to_bigstring
 // Requires: tsBindings, caml_ba_set_1, caml_bytes_unsafe_get
-function caml_pasta_fq_to_bytes_into(x, buf, pos) {
+function caml_pasta_fq_blit_to_bigstring(x, buf, pos) {
   var bytes = tsBindings.caml_pasta_fq_to_bytes(x);
   for (var i = 0; i < 32; i++) {
     caml_ba_set_1(buf, pos + i, caml_bytes_unsafe_get(bytes, i));
@@ -278,9 +278,9 @@ function caml_pasta_fq_to_bytes_into(x, buf, pos) {
   return 0;
 }
 
-// Provides: caml_pasta_fq_of_bytes_from
+// Provides: caml_pasta_fq_of_bigstring
 // Requires: tsBindings, caml_ba_get_1, caml_create_bytes, caml_bytes_unsafe_set
-function caml_pasta_fq_of_bytes_from(buf, pos) {
+function caml_pasta_fq_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
   for (var i = 0; i < 32; i++) {
     caml_bytes_unsafe_set(bytes, i, caml_ba_get_1(buf, pos + i));

--- a/src/lib/crypto/kimchi_bindings/js/bindings/field.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings/field.js
@@ -133,7 +133,10 @@ function caml_pasta_fp_blit_to_bigstring(x, buf, pos) {
 function caml_pasta_fp_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
   caml_bigstring_blit_ba_to_bytes(buf, pos, bytes, 0, 32);
-  return tsBindings.caml_pasta_fp_of_bytes(bytes);
+  // The TS bindings implement to_bytes for fields as the bigint encoding and
+  // leave of_bytes unimplemented; read back through the same bigint path.
+  // of_bigint rejects values at or above the modulus, matching the Rust stub.
+  return tsBindings.caml_pasta_fp_of_bigint(tsBindings.caml_bigint_256_of_bytes(bytes));
 }
 
 // Provides: caml_pasta_fp_deep_copy
@@ -275,7 +278,8 @@ function caml_pasta_fq_blit_to_bigstring(x, buf, pos) {
 function caml_pasta_fq_of_bigstring(buf, pos) {
   var bytes = caml_create_bytes(32);
   caml_bigstring_blit_ba_to_bytes(buf, pos, bytes, 0, 32);
-  return tsBindings.caml_pasta_fq_of_bytes(bytes);
+  // See caml_pasta_fp_of_bigstring.
+  return tsBindings.caml_pasta_fq_of_bigint(tsBindings.caml_bigint_256_of_bytes(bytes));
 }
 
 // Provides: caml_pasta_fq_deep_copy

--- a/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
+++ b/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
@@ -16,6 +16,29 @@ module Pasta_fq_index = Protocol.Index.Fq
 module Pasta_fp_verifier_index = Protocol.VerifierIndex.Fp
 module Pasta_fq_verifier_index = Protocol.VerifierIndex.Fq
 
+(* Writes [x] into a sentinel-filled bigstring at a nonzero offset with the
+   in-place codec, checks that exactly the 32 bytes of [to_bytes x] landed
+   there and nothing else was touched, and reads it back. This is the only
+   test of the jsoo glue behind [blit_to_bigstring] / [of_bigstring]. *)
+let check_bigstring_roundtrip ~to_bytes ~blit_to_bigstring ~of_bigstring ~equal
+    x =
+  let open Stdlib.Bigarray in
+  let pos = 4 in
+  let len = 32 in
+  let sentinel = '\xab' in
+  let buf = Array1.create char c_layout (pos + len + 4) in
+  Array1.fill buf sentinel ;
+  blit_to_bigstring x buf pos ;
+  let bytes = to_bytes x in
+  assert (Bytes.length bytes = len) ;
+  for i = 0 to Array1.dim buf - 1 do
+    let expected =
+      if i >= pos && i < pos + len then Bytes.get bytes (i - pos) else sentinel
+    in
+    assert (Char.equal (Array1.get buf i) expected)
+  done ;
+  assert (equal (of_bigstring buf pos) x)
+
 (* NOTE: For nodejs, we need to manually add the following line to the javascript bindings, after imports['env'] has been declared.
    imports['env']['memory'] = new WebAssembly.Memory({initial: 18, maximum: 16384, shared: true});
 *)
@@ -259,6 +282,13 @@ let _ =
          assert (test_bit five 2) ;
          let ten_bytes = to_bytes ten in
          assert (compare (of_bytes ten_bytes) ten = 0) ;
+         let equal a b = compare a b = 0 in
+         check_bigstring_roundtrip ~to_bytes ~blit_to_bigstring ~of_bigstring
+           ~equal ten ;
+         check_bigstring_roundtrip ~to_bytes ~blit_to_bigstring ~of_bigstring
+           ~equal
+           (of_decimal_string
+              "115792089237316195423570985008687907853269984665640564039457584007913129639935" ) ;
          assert (compare (deep_copy six) six = 0)
     end )
 
@@ -317,6 +347,10 @@ let _ =
          assert (equal (of_bytes (to_bytes root_of_unity)) root_of_unity) ;
          let gen = domain_generator 2 in
          assert (equal (of_bytes (to_bytes gen)) gen) ;
+         List.iter
+           (check_bigstring_roundtrip ~to_bytes ~blit_to_bigstring ~of_bigstring
+              ~equal )
+           [ of_int 0; one; rand1; gen; sub (of_int 0) one ] ;
          assert (equal (deep_copy rand2) rand2)
     end )
 
@@ -375,6 +409,10 @@ let _ =
          assert (equal (of_bytes (to_bytes root_of_unity)) root_of_unity) ;
          let gen = domain_generator 2 in
          assert (equal (of_bytes (to_bytes gen)) gen) ;
+         List.iter
+           (check_bigstring_roundtrip ~to_bytes ~blit_to_bigstring ~of_bigstring
+              ~equal )
+           [ of_int 0; one; rand1; gen; sub (of_int 0) one ] ;
          assert (equal (deep_copy rand2) rand2)
     end )
 

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "hex",
  "internal-tracing",
  "itertools 0.12.1",
+ "libc",
  "log",
  "mina-curves",
  "mina-poseidon",

--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
@@ -25,6 +25,23 @@ module BigInt256 = struct
 
   external of_bytes : bytes -> t = "caml_bigint_256_of_bytes"
 
+  external to_bytes_into :
+       t
+    -> ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> unit = "caml_bigint_256_to_bytes_into"
+
+  external of_bytes_from :
+       ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> t = "caml_bigint_256_of_bytes_from"
+
   external deep_copy : t -> t = "caml_bigint_256_deep_copy"
 end
 
@@ -94,6 +111,23 @@ module Fp = struct
 
   external of_bytes : bytes -> t = "caml_pasta_fp_of_bytes"
 
+  external to_bytes_into :
+       t
+    -> ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> unit = "caml_pasta_fp_to_bytes_into"
+
+  external of_bytes_from :
+       ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> t = "caml_pasta_fp_of_bytes_from"
+
   external deep_copy : t -> t = "caml_pasta_fp_deep_copy"
 end
 
@@ -162,6 +196,23 @@ module Fq = struct
   external to_bytes : t -> bytes = "caml_pasta_fq_to_bytes"
 
   external of_bytes : bytes -> t = "caml_pasta_fq_of_bytes"
+
+  external to_bytes_into :
+       t
+    -> ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> unit = "caml_pasta_fq_to_bytes_into"
+
+  external of_bytes_from :
+       ( char
+       , Stdlib.Bigarray.int8_unsigned_elt
+       , Stdlib.Bigarray.c_layout )
+       Stdlib.Bigarray.Array1.t
+    -> int
+    -> t = "caml_pasta_fq_of_bytes_from"
 
   external deep_copy : t -> t = "caml_pasta_fq_deep_copy"
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/pasta_bindings.ml
@@ -25,22 +25,22 @@ module BigInt256 = struct
 
   external of_bytes : bytes -> t = "caml_bigint_256_of_bytes"
 
-  external to_bytes_into :
+  external blit_to_bigstring :
        t
     -> ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> unit = "caml_bigint_256_to_bytes_into"
+    -> unit = "caml_bigint_256_blit_to_bigstring"
 
-  external of_bytes_from :
+  external of_bigstring :
        ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> t = "caml_bigint_256_of_bytes_from"
+    -> t = "caml_bigint_256_of_bigstring"
 
   external deep_copy : t -> t = "caml_bigint_256_deep_copy"
 end
@@ -111,22 +111,22 @@ module Fp = struct
 
   external of_bytes : bytes -> t = "caml_pasta_fp_of_bytes"
 
-  external to_bytes_into :
+  external blit_to_bigstring :
        t
     -> ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> unit = "caml_pasta_fp_to_bytes_into"
+    -> unit = "caml_pasta_fp_blit_to_bigstring"
 
-  external of_bytes_from :
+  external of_bigstring :
        ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> t = "caml_pasta_fp_of_bytes_from"
+    -> t = "caml_pasta_fp_of_bigstring"
 
   external deep_copy : t -> t = "caml_pasta_fp_deep_copy"
 end
@@ -197,22 +197,22 @@ module Fq = struct
 
   external of_bytes : bytes -> t = "caml_pasta_fq_of_bytes"
 
-  external to_bytes_into :
+  external blit_to_bigstring :
        t
     -> ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> unit = "caml_pasta_fq_to_bytes_into"
+    -> unit = "caml_pasta_fq_blit_to_bigstring"
 
-  external of_bytes_from :
+  external of_bigstring :
        ( char
        , Stdlib.Bigarray.int8_unsigned_elt
        , Stdlib.Bigarray.c_layout )
        Stdlib.Bigarray.Array1.t
     -> int
-    -> t = "caml_pasta_fq_of_bytes_from"
+    -> t = "caml_pasta_fq_of_bigstring"
 
   external deep_copy : t -> t = "caml_pasta_fq_deep_copy"
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -156,6 +156,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_bigint_256_test_bit => "test_bit");
         decl_func!(w, env, caml_bigint_256_to_bytes => "to_bytes");
         decl_func!(w, env, caml_bigint_256_of_bytes => "of_bytes");
+        decl_func!(w, env, caml_bigint_256_to_bytes_into => "to_bytes_into");
+        decl_func!(w, env, caml_bigint_256_of_bytes_from => "of_bytes_from");
         decl_func!(w, env, caml_bigint_256_deep_copy => "deep_copy");
     });
 
@@ -193,6 +195,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fp_domain_generator => "domain_generator");
         decl_func!(w, env, caml_pasta_fp_to_bytes => "to_bytes");
         decl_func!(w, env, caml_pasta_fp_of_bytes => "of_bytes");
+        decl_func!(w, env, caml_pasta_fp_to_bytes_into => "to_bytes_into");
+        decl_func!(w, env, caml_pasta_fp_of_bytes_from => "of_bytes_from");
         decl_func!(w, env, caml_pasta_fp_deep_copy => "deep_copy");
     });
 
@@ -230,6 +234,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fq_domain_generator => "domain_generator");
         decl_func!(w, env, caml_pasta_fq_to_bytes => "to_bytes");
         decl_func!(w, env, caml_pasta_fq_of_bytes => "of_bytes");
+        decl_func!(w, env, caml_pasta_fq_to_bytes_into => "to_bytes_into");
+        decl_func!(w, env, caml_pasta_fq_of_bytes_from => "of_bytes_from");
         decl_func!(w, env, caml_pasta_fq_deep_copy => "deep_copy");
     });
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -156,8 +156,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_bigint_256_test_bit => "test_bit");
         decl_func!(w, env, caml_bigint_256_to_bytes => "to_bytes");
         decl_func!(w, env, caml_bigint_256_of_bytes => "of_bytes");
-        decl_func!(w, env, caml_bigint_256_to_bytes_into => "to_bytes_into");
-        decl_func!(w, env, caml_bigint_256_of_bytes_from => "of_bytes_from");
+        decl_func!(w, env, caml_bigint_256_blit_to_bigstring => "blit_to_bigstring");
+        decl_func!(w, env, caml_bigint_256_of_bigstring => "of_bigstring");
         decl_func!(w, env, caml_bigint_256_deep_copy => "deep_copy");
     });
 
@@ -195,8 +195,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fp_domain_generator => "domain_generator");
         decl_func!(w, env, caml_pasta_fp_to_bytes => "to_bytes");
         decl_func!(w, env, caml_pasta_fp_of_bytes => "of_bytes");
-        decl_func!(w, env, caml_pasta_fp_to_bytes_into => "to_bytes_into");
-        decl_func!(w, env, caml_pasta_fp_of_bytes_from => "of_bytes_from");
+        decl_func!(w, env, caml_pasta_fp_blit_to_bigstring => "blit_to_bigstring");
+        decl_func!(w, env, caml_pasta_fp_of_bigstring => "of_bigstring");
         decl_func!(w, env, caml_pasta_fp_deep_copy => "deep_copy");
     });
 
@@ -234,8 +234,8 @@ fn generate_pasta_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_func!(w, env, caml_pasta_fq_domain_generator => "domain_generator");
         decl_func!(w, env, caml_pasta_fq_to_bytes => "to_bytes");
         decl_func!(w, env, caml_pasta_fq_of_bytes => "of_bytes");
-        decl_func!(w, env, caml_pasta_fq_to_bytes_into => "to_bytes_into");
-        decl_func!(w, env, caml_pasta_fq_of_bytes_from => "of_bytes_from");
+        decl_func!(w, env, caml_pasta_fq_blit_to_bigstring => "blit_to_bigstring");
+        decl_func!(w, env, caml_pasta_fq_of_bigstring => "of_bigstring");
         decl_func!(w, env, caml_pasta_fq_deep_copy => "deep_copy");
     });
 

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
@@ -24,6 +24,11 @@ module type Bindings = sig
   val to_bytes : t -> Bytes.t
 
   val of_bytes : Bytes.t -> t
+
+  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  val to_bytes_into : t -> Bigstring.t -> int -> unit
+
+  val of_bytes_from : Bigstring.t -> int -> t
 end
 
 module type Intf = sig
@@ -95,21 +100,18 @@ module Make
     let bin_size_t _ = length_in_bytes
 
     let bin_write_t buf ~pos t =
-      let bytes = to_bytes t in
       let len = length_in_bytes in
-      Bigstring.From_bytes.blit ~src:bytes ~src_pos:0 ~len:length_in_bytes
-        ~dst:buf ~dst_pos:pos ;
+      Bin_prot.Common.check_next buf (pos + len) ;
+      to_bytes_into t buf pos ;
       pos + len
 
     let bin_read_t buf ~pos_ref =
-      let remaining_bytes = Bigstring.length buf - !pos_ref in
       let len = length_in_bytes in
-      if remaining_bytes < len then
-        failwithf "Bigint.bin_read_t: Expected %d bytes, got %d"
-          M.length_in_bytes remaining_bytes () ;
-      let bytes = Bigstring.To_bytes.sub ~pos:!pos_ref ~len buf in
-      pos_ref := len + !pos_ref ;
-      of_bytes bytes
+      let pos = !pos_ref in
+      Bin_prot.Common.check_next buf (pos + len) ;
+      let t = of_bytes_from buf pos in
+      pos_ref := pos + len ;
+      t
   end)
 
   let of_numeral s ~base = of_numeral s (String.length s) base

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
@@ -26,9 +26,9 @@ module type Bindings = sig
   val of_bytes : Bytes.t -> t
 
   (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
-  val to_bytes_into : t -> Bigstring.t -> int -> unit
+  val blit_to_bigstring : t -> Bigstring.t -> int -> unit
 
-  val of_bytes_from : Bigstring.t -> int -> t
+  val of_bigstring : Bigstring.t -> int -> t
 end
 
 module type Intf = sig
@@ -102,14 +102,14 @@ module Make
     let bin_write_t buf ~pos t =
       let len = length_in_bytes in
       Bin_prot.Common.check_next buf (pos + len) ;
-      to_bytes_into t buf pos ;
+      blit_to_bigstring t buf pos ;
       pos + len
 
     let bin_read_t buf ~pos_ref =
       let len = length_in_bytes in
       let pos = !pos_ref in
       Bin_prot.Common.check_next buf (pos + len) ;
-      let t = of_bytes_from buf pos in
+      let t = of_bigstring buf pos in
       pos_ref := pos + len ;
       t
   end)

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.ml
@@ -25,9 +25,15 @@ module type Bindings = sig
 
   val of_bytes : Bytes.t -> t
 
-  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same 32
+      little-endian bytes as [to_bytes t], to [buf.{pos} .. buf.{pos + 31}],
+      allocating nothing. Raises [Invalid_argument] when that window does not
+      fit in [buf]. *)
   val blit_to_bigstring : t -> Bigstring.t -> int -> unit
 
+  (** [of_bigstring buf pos] reads the value written by [blit_to_bigstring]
+      at [buf.{pos} .. buf.{pos + 31}]. Raises [Invalid_argument] when the
+      window does not fit in [buf]. *)
   val of_bigstring : Bigstring.t -> int -> t
 end
 

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
@@ -22,6 +22,18 @@ module type Bindings = sig
   val to_bytes : t -> bytes
 
   val of_bytes : bytes -> t
+
+  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  val to_bytes_into :
+       t
+    -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> unit
+
+  val of_bytes_from :
+       (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> t
 end
 
 module type Intf = sig
@@ -62,6 +74,18 @@ module type Intf = sig
   val to_bytes : t -> bytes
 
   val of_bytes : bytes -> t
+
+  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  val to_bytes_into :
+       t
+    -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> unit
+
+  val of_bytes_from :
+       (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> t
 
   val num_limbs : int
 
@@ -125,6 +149,18 @@ module Make : functor
   val to_bytes : t -> bytes
 
   val of_bytes : bytes -> t
+
+  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  val to_bytes_into :
+       t
+    -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> unit
+
+  val of_bytes_from :
+       (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+    -> int
+    -> t
 
   val num_limbs : int
 

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
@@ -23,13 +23,19 @@ module type Bindings = sig
 
   val of_bytes : bytes -> t
 
-  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same 32
+      little-endian bytes as [to_bytes t], to [buf.{pos} .. buf.{pos + 31}],
+      allocating nothing. Raises [Invalid_argument] when that window does not
+      fit in [buf]. *)
   val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
+  (** [of_bigstring buf pos] reads the value written by [blit_to_bigstring]
+      at [buf.{pos} .. buf.{pos + 31}]. Raises [Invalid_argument] when the
+      window does not fit in [buf]. *)
   val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
@@ -75,13 +81,19 @@ module type Intf = sig
 
   val of_bytes : bytes -> t
 
-  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same 32
+      little-endian bytes as [to_bytes t], to [buf.{pos} .. buf.{pos + 31}],
+      allocating nothing. Raises [Invalid_argument] when that window does not
+      fit in [buf]. *)
   val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
+  (** [of_bigstring buf pos] reads the value written by [blit_to_bigstring]
+      at [buf.{pos} .. buf.{pos + 31}]. Raises [Invalid_argument] when the
+      window does not fit in [buf]. *)
   val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
@@ -150,13 +162,19 @@ module Make : functor
 
   val of_bytes : bytes -> t
 
-  (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
+  (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same 32
+      little-endian bytes as [to_bytes t], to [buf.{pos} .. buf.{pos + 31}],
+      allocating nothing. Raises [Invalid_argument] when that window does not
+      fit in [buf]. *)
   val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
+  (** [of_bigstring buf pos] reads the value written by [blit_to_bigstring]
+      at [buf.{pos} .. buf.{pos + 31}]. Raises [Invalid_argument] when the
+      window does not fit in [buf]. *)
   val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/bigint.mli
@@ -24,13 +24,13 @@ module type Bindings = sig
   val of_bytes : bytes -> t
 
   (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
-  val to_bytes_into :
+  val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
-  val of_bytes_from :
+  val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> t
@@ -76,13 +76,13 @@ module type Intf = sig
   val of_bytes : bytes -> t
 
   (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
-  val to_bytes_into :
+  val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
-  val of_bytes_from :
+  val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> t
@@ -151,13 +151,13 @@ module Make : functor
   val of_bytes : bytes -> t
 
   (** Same encoding as [to_bytes], written at [buf.{pos}]. *)
-  val to_bytes_into :
+  val blit_to_bigstring :
        t
     -> (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> unit
 
-  val of_bytes_from :
+  val of_bigstring :
        (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
     -> int
     -> t

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
@@ -15,6 +15,11 @@ module type Input_intf = sig
 
   val of_bigint : Bigint.t -> t
 
+  (** Same encoding as [Bigint.to_bytes (to_bigint t)], written at [buf.{pos}]. *)
+  val to_bytes_into : t -> Bigstring.t -> int -> unit
+
+  val of_bytes_from : Bigstring.t -> int -> t
+
   val of_int : int -> t
 
   val domain_generator : int -> t
@@ -195,6 +200,33 @@ module Make (F : Input_intf) :
 
             let of_binable = of_bigint
           end)
+
+      (* Same encoding as the [Of_binable] instance above, without the
+         intermediate bigint and bytes. *)
+      let bin_size_t (_ : t) = Bigint.length_in_bytes
+
+      let bin_write_t buf ~pos (x : t) =
+        let len = Bigint.length_in_bytes in
+        Bin_prot.Common.check_next buf (pos + len) ;
+        to_bytes_into x buf pos ;
+        pos + len
+
+      let bin_read_t buf ~pos_ref : t =
+        let len = Bigint.length_in_bytes in
+        let pos = !pos_ref in
+        Bin_prot.Common.check_next buf (pos + len) ;
+        let x = of_bytes_from buf pos in
+        pos_ref := pos + len ;
+        x
+
+      let bin_writer_t : t Bin_prot.Type_class.writer =
+        { size = bin_size_t; write = bin_write_t }
+
+      let bin_reader_t : t Bin_prot.Type_class.reader =
+        { read = bin_read_t; vtag_read = __bin_read_t__ }
+
+      let bin_t : t Bin_prot.Type_class.t =
+        { shape = bin_shape_t; writer = bin_writer_t; reader = bin_reader_t }
 
       include
         Sexpable.Of_sexpable

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
@@ -16,9 +16,9 @@ module type Input_intf = sig
   val of_bigint : Bigint.t -> t
 
   (** Same encoding as [Bigint.to_bytes (to_bigint t)], written at [buf.{pos}]. *)
-  val to_bytes_into : t -> Bigstring.t -> int -> unit
+  val blit_to_bigstring : t -> Bigstring.t -> int -> unit
 
-  val of_bytes_from : Bigstring.t -> int -> t
+  val of_bigstring : Bigstring.t -> int -> t
 
   val of_int : int -> t
 
@@ -208,14 +208,14 @@ module Make (F : Input_intf) :
       let bin_write_t buf ~pos (x : t) =
         let len = Bigint.length_in_bytes in
         Bin_prot.Common.check_next buf (pos + len) ;
-        to_bytes_into x buf pos ;
+        blit_to_bigstring x buf pos ;
         pos + len
 
       let bin_read_t buf ~pos_ref : t =
         let len = Bigint.length_in_bytes in
         let pos = !pos_ref in
         Bin_prot.Common.check_next buf (pos + len) ;
-        let x = of_bytes_from buf pos in
+        let x = of_bigstring buf pos in
         pos_ref := pos + len ;
         x
 

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/field.ml
@@ -15,9 +15,16 @@ module type Input_intf = sig
 
   val of_bigint : Bigint.t -> t
 
-  (** Same encoding as [Bigint.to_bytes (to_bigint t)], written at [buf.{pos}]. *)
+  (** [blit_to_bigstring t buf pos] writes the encoding of [t], the same 32
+      little-endian bytes as [Bigint.to_bytes (to_bigint t)], to
+      [buf.{pos} .. buf.{pos + 31}], allocating nothing. Raises
+      [Invalid_argument] when that window does not fit in [buf]. *)
   val blit_to_bigstring : t -> Bigstring.t -> int -> unit
 
+  (** [of_bigstring buf pos] reads the element written by [blit_to_bigstring]
+      at [buf.{pos} .. buf.{pos + 31}]. Raises [Invalid_argument] when the
+      window does not fit in [buf], and [Failure] when the bytes are not a
+      canonical element, i.e. encode a value at or above the modulus. *)
   val of_bigstring : Bigstring.t -> int -> t
 
   val of_int : int -> t

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/test/dune
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/test/dune
@@ -1,5 +1,5 @@
 (tests
- (names test_bigint test_field)
+ (names test_bigint test_field test_serialization)
  (libraries
   alcotest
   bin_prot.shape

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
@@ -1,0 +1,305 @@
+(* The bin_prot instances of [Field] and [Bigint] write to and read from the
+   buffer in place. These tests pin their encoding to [Bigint.to_bytes] on the
+   values where a limb-wise implementation can go wrong: around zero, around
+   the modulus, and with every subset of the four 64-bit limbs populated. *)
+
+open Core
+
+(* Every subset of the four limbs: "min" sets the lowest bit of each chosen
+   limb, "max" saturates it. The top limb of "max" is capped at 2^62 - 1 so
+   that every value is below both Pasta moduli. *)
+let limb_patterns =
+  [ ("limbs 0 min", "1")
+  ; ("limbs 0 max", "18446744073709551615")
+  ; ("limbs 1 min", "18446744073709551616")
+  ; ("limbs 1 max", "340282366920938463444927863358058659840")
+  ; ("limbs 01 min", "18446744073709551617")
+  ; ("limbs 01 max", "340282366920938463463374607431768211455")
+  ; ("limbs 2 min", "340282366920938463463374607431768211456")
+  ; ("limbs 2 max", "6277101735386680763495507056286727952638980837032266301440")
+  ; ("limbs 02 min", "340282366920938463463374607431768211457")
+  ; ( "limbs 02 max"
+    , "6277101735386680763495507056286727952657427581105975853055" )
+  ; ("limbs 12 min", "340282366920938463481821351505477763072")
+  ; ( "limbs 12 max"
+    , "6277101735386680763835789423207666416083908700390324961280" )
+  ; ("limbs 012 min", "340282366920938463481821351505477763073")
+  ; ( "limbs 012 max"
+    , "6277101735386680763835789423207666416102355444464034512895" )
+  ; ("limbs 3 min", "6277101735386680763835789423207666416102355444464034512896")
+  ; ( "limbs 3 max"
+    , "28948022309329048849615644516785296199481706743202474593762040557514247897088"
+    )
+  ; ( "limbs 03 min"
+    , "6277101735386680763835789423207666416102355444464034512897" )
+  ; ( "limbs 03 max"
+    , "28948022309329048849615644516785296199481706743202474593780487301587957448703"
+    )
+  ; ( "limbs 13 min"
+    , "6277101735386680763835789423207666416120802188537744064512" )
+  ; ( "limbs 13 max"
+    , "28948022309329048849615644516785296199821989110123413057206968420872306556928"
+    )
+  ; ( "limbs 013 min"
+    , "6277101735386680763835789423207666416120802188537744064513" )
+  ; ( "limbs 013 max"
+    , "28948022309329048849615644516785296199821989110123413057225415164946016108543"
+    )
+  ; ( "limbs 23 min"
+    , "6277101735386680764176071790128604879565730051895802724352" )
+  ; ( "limbs 23 max"
+    , "28948022309329048855892746252171976962977213799489202546401021394546514198528"
+    )
+  ; ( "limbs 023 min"
+    , "6277101735386680764176071790128604879565730051895802724353" )
+  ; ( "limbs 023 max"
+    , "28948022309329048855892746252171976962977213799489202546419468138620223750143"
+    )
+  ; ( "limbs 123 min"
+    , "6277101735386680764176071790128604879584176795969512275968" )
+  ; ( "limbs 123 max"
+    , "28948022309329048855892746252171976963317496166410141009845949257904572858368"
+    )
+  ; ( "limbs 0123 min"
+    , "6277101735386680764176071790128604879584176795969512275969" )
+  ; ( "limbs 0123 max"
+    , "28948022309329048855892746252171976963317496166410141009864396001978282409983"
+    )
+  ]
+
+(* The "max" patterns with the top limb saturated too: above both moduli, so
+   only valid for [Bigint]. The last one is 2^256 - 1. *)
+let full_width_patterns =
+  [ ( "limbs 3 max full"
+    , "115792089237316195417293883273301227089434195242432897623355228563449095127040"
+    )
+  ; ( "limbs 03 max full"
+    , "115792089237316195417293883273301227089434195242432897623373675307522804678655"
+    )
+  ; ( "limbs 13 max full"
+    , "115792089237316195417293883273301227089774477609353836086800156426807153786880"
+    )
+  ; ( "limbs 013 max full"
+    , "115792089237316195417293883273301227089774477609353836086818603170880863338495"
+    )
+  ; ( "limbs 23 max full"
+    , "115792089237316195423570985008687907852929702298719625575994209400481361428480"
+    )
+  ; ( "limbs 023 max full"
+    , "115792089237316195423570985008687907852929702298719625576012656144555070980095"
+    )
+  ; ( "limbs 123 max full"
+    , "115792089237316195423570985008687907853269984665640564039439137263839420088320"
+    )
+  ; ( "limbs 0123 max full"
+    , "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+    )
+  ]
+
+let around_zero = [ ("zero", "0"); ("one", "1"); ("two", "2") ]
+
+(* Write at a nonzero offset so that a wrong base offset shows up, and fill
+   the buffer with a sentinel so that bytes outside the element show up. *)
+let offset = 3
+
+let sentinel = '\xAA'
+
+let fresh_buffer len = Bigstring.of_string (String.make (offset + len) sentinel)
+
+let bytes_at buf ~len = Bigstring.To_string.sub buf ~pos:offset ~len
+
+let prefix_of buf = Bigstring.To_string.sub buf ~pos:0 ~len:offset
+
+module Bigint = Kimchi_pasta_snarky_backend.Bigint256
+
+let len = Bigint.length_in_bytes
+
+let check_bigint (name, decimal) =
+  let b = Bigint.of_decimal_string decimal in
+  let expected = Bytes.to_string (Bigint.to_bytes b) in
+  Alcotest.(check bool)
+    (name ^ ": of_bytes inverts to_bytes")
+    true
+    (Bigint.compare b (Bigint.of_bytes (Bigint.to_bytes b)) = 0) ;
+  Alcotest.(check int) (name ^ ": bin_size_t") len (Bigint.bin_size_t b) ;
+  let buf = fresh_buffer len in
+  let pos = Bigint.bin_write_t buf ~pos:offset b in
+  Alcotest.(check int) (name ^ ": bin_write_t advances") (offset + len) pos ;
+  Alcotest.(check string)
+    (name ^ ": bin_write_t matches to_bytes")
+    expected (bytes_at buf ~len) ;
+  Alcotest.(check string)
+    (name ^ ": bin_write_t leaves the prefix alone")
+    (String.make offset sentinel)
+    (prefix_of buf) ;
+  let pos_ref = ref offset in
+  let b' = Bigint.bin_read_t buf ~pos_ref in
+  Alcotest.(check bool)
+    (name ^ ": bin_read_t inverts bin_write_t")
+    true
+    (Bigint.compare b b' = 0) ;
+  Alcotest.(check int) (name ^ ": bin_read_t advances") (offset + len) !pos_ref ;
+  let buf' = fresh_buffer len in
+  Bigint.to_bytes_into b buf' offset ;
+  Alcotest.(check string)
+    (name ^ ": to_bytes_into matches to_bytes")
+    expected (bytes_at buf' ~len) ;
+  Alcotest.(check bool)
+    (name ^ ": of_bytes_from inverts to_bytes_into")
+    true
+    (Bigint.compare b (Bigint.of_bytes_from buf' offset) = 0)
+
+let test_bigint_values () =
+  List.iter ~f:check_bigint (around_zero @ limb_patterns @ full_width_patterns)
+
+let test_bigint_buffer_short () =
+  let b = Bigint.of_decimal_string "1" in
+  let short = Bigstring.create (offset + len - 1) in
+  Alcotest.check_raises "bin_write_t on a short buffer"
+    Bin_prot.Common.Buffer_short (fun () ->
+      ignore (Bigint.bin_write_t short ~pos:offset b : int) ) ;
+  Alcotest.check_raises "bin_read_t on a short buffer"
+    Bin_prot.Common.Buffer_short (fun () ->
+      ignore (Bigint.bin_read_t short ~pos_ref:(ref offset) : Bigint.t) )
+
+module Make_field
+    (Field : Kimchi_pasta_snarky_backend.Field.S_with_version)
+    (M : sig
+      val p_minus_1 : string
+
+      val p_minus_2 : string
+
+      val half_p_minus_1 : string
+
+      val half_p_plus_1 : string
+    end) =
+struct
+  module Bigint = Field.Bigint
+
+  let check_field (name, decimal) =
+    let b = Bigint.of_decimal_string decimal in
+    let x = Field.of_bigint b in
+    let expected = Bytes.to_string (Bigint.to_bytes b) in
+    Alcotest.(check string)
+      (name ^ ": to_bigint round trip")
+      expected
+      (Bytes.to_string (Bigint.to_bytes (Field.to_bigint x))) ;
+    Alcotest.(check int)
+      (name ^ ": bin_size_t") len
+      (Field.Stable.Latest.bin_size_t x) ;
+    let buf = fresh_buffer len in
+    let pos = Field.Stable.Latest.bin_write_t buf ~pos:offset x in
+    Alcotest.(check int) (name ^ ": bin_write_t advances") (offset + len) pos ;
+    Alcotest.(check string)
+      (name ^ ": bin_write_t matches Bigint.to_bytes")
+      expected (bytes_at buf ~len) ;
+    Alcotest.(check string)
+      (name ^ ": bin_write_t leaves the prefix alone")
+      (String.make offset sentinel)
+      (prefix_of buf) ;
+    let pos_ref = ref offset in
+    let x' = Field.Stable.Latest.bin_read_t buf ~pos_ref in
+    Alcotest.(check bool)
+      (name ^ ": bin_read_t inverts bin_write_t")
+      true (Field.equal x x') ;
+    Alcotest.(check int)
+      (name ^ ": bin_read_t advances")
+      (offset + len) !pos_ref ;
+    let buf' = fresh_buffer len in
+    Field.to_bytes_into x buf' offset ;
+    Alcotest.(check string)
+      (name ^ ": to_bytes_into matches Bigint.to_bytes")
+      expected (bytes_at buf' ~len) ;
+    Alcotest.(check bool)
+      (name ^ ": of_bytes_from inverts to_bytes_into")
+      true
+      (Field.equal x (Field.of_bytes_from buf' offset))
+
+  (* The negatives, with their decimal values cross-checked against field
+     arithmetic so that a wrong constant cannot pass. *)
+  let around_modulus =
+    [ ("p - 1 (-1)", M.p_minus_1, Field.negate Field.one)
+    ; ("p - 2 (-2)", M.p_minus_2, Field.negate (Field.of_int 2))
+    ; ("(p - 1) / 2", M.half_p_minus_1, Field.(negate one / of_int 2))
+    ; ("(p + 1) / 2 (1/2)", M.half_p_plus_1, Field.inv (Field.of_int 2))
+    ]
+
+  let test_around_zero () = List.iter ~f:check_field around_zero
+
+  let test_around_modulus () =
+    List.iter around_modulus ~f:(fun (name, decimal, computed) ->
+        let from_decimal = Field.of_bigint (Bigint.of_decimal_string decimal) in
+        Alcotest.(check bool)
+          (name ^ ": decimal constant agrees with field arithmetic")
+          true
+          (Field.equal from_decimal computed) ;
+        check_field (name, decimal) )
+
+  let test_limb_patterns () = List.iter ~f:check_field limb_patterns
+
+  let test_buffer_short () =
+    let x = Field.one in
+    let short = Bigstring.create (offset + len - 1) in
+    Alcotest.check_raises "bin_write_t on a short buffer"
+      Bin_prot.Common.Buffer_short (fun () ->
+        ignore (Field.Stable.Latest.bin_write_t short ~pos:offset x : int) ) ;
+    Alcotest.check_raises "bin_read_t on a short buffer"
+      Bin_prot.Common.Buffer_short (fun () ->
+        ignore
+          (Field.Stable.Latest.bin_read_t short ~pos_ref:(ref offset) : Field.t) )
+
+  let tests =
+    let open Alcotest in
+    [ test_case "around zero" `Quick test_around_zero
+    ; test_case "around the modulus" `Quick test_around_modulus
+    ; test_case "limb patterns" `Quick test_limb_patterns
+    ; test_case "buffer short" `Quick test_buffer_short
+    ]
+end
+
+(* Vesta_based_plonk.Field is Fp; Pallas_based_plonk.Field is Fq. *)
+module Fp =
+  Make_field
+    (Kimchi_pasta_snarky_backend.Vesta_based_plonk.Field)
+    (struct
+      let p_minus_1 =
+        "28948022309329048855892746252171976963363056481941560715954676764349967630336"
+
+      let p_minus_2 =
+        "28948022309329048855892746252171976963363056481941560715954676764349967630335"
+
+      let half_p_minus_1 =
+        "14474011154664524427946373126085988481681528240970780357977338382174983815168"
+
+      let half_p_plus_1 =
+        "14474011154664524427946373126085988481681528240970780357977338382174983815169"
+    end)
+
+module Fq =
+  Make_field
+    (Kimchi_pasta_snarky_backend.Pallas_based_plonk.Field)
+    (struct
+      let p_minus_1 =
+        "28948022309329048855892746252171976963363056481941647379679742748393362948096"
+
+      let p_minus_2 =
+        "28948022309329048855892746252171976963363056481941647379679742748393362948095"
+
+      let half_p_minus_1 =
+        "14474011154664524427946373126085988481681528240970823689839871374196681474048"
+
+      let half_p_plus_1 =
+        "14474011154664524427946373126085988481681528240970823689839871374196681474049"
+    end)
+
+let () =
+  let open Alcotest in
+  run "Serialization"
+    [ ( "Bigint256"
+      , [ test_case "around zero, limb patterns, full width" `Quick
+            test_bigint_values
+        ; test_case "buffer short" `Quick test_bigint_buffer_short
+        ] )
+    ; ("Fp", Fp.tests)
+    ; ("Fq", Fq.tests)
+    ]

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
@@ -3,7 +3,7 @@
    values where a limb-wise implementation can go wrong: around zero, around
    the modulus, and with every subset of the four 64-bit limbs populated. *)
 
-open Core
+open Core_kernel
 
 (* Every subset of the four limbs: "min" sets the lowest bit of each chosen
    limb, "max" saturates it. The top limb of "max" is capped at 2^62 - 1 so

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
@@ -140,14 +140,14 @@ let check_bigint (name, decimal) =
     (Bigint.compare b b' = 0) ;
   Alcotest.(check int) (name ^ ": bin_read_t advances") (offset + len) !pos_ref ;
   let buf' = fresh_buffer len in
-  Bigint.to_bytes_into b buf' offset ;
+  Bigint.blit_to_bigstring b buf' offset ;
   Alcotest.(check string)
-    (name ^ ": to_bytes_into matches to_bytes")
+    (name ^ ": blit_to_bigstring matches to_bytes")
     expected (bytes_at buf' ~len) ;
   Alcotest.(check bool)
-    (name ^ ": of_bytes_from inverts to_bytes_into")
+    (name ^ ": of_bigstring inverts blit_to_bigstring")
     true
-    (Bigint.compare b (Bigint.of_bytes_from buf' offset) = 0)
+    (Bigint.compare b (Bigint.of_bigstring buf' offset) = 0)
 
 let test_bigint_values () =
   List.iter ~f:check_bigint (around_zero @ limb_patterns @ full_width_patterns)
@@ -206,14 +206,14 @@ struct
       (name ^ ": bin_read_t advances")
       (offset + len) !pos_ref ;
     let buf' = fresh_buffer len in
-    Field.to_bytes_into x buf' offset ;
+    Field.blit_to_bigstring x buf' offset ;
     Alcotest.(check string)
-      (name ^ ": to_bytes_into matches Bigint.to_bytes")
+      (name ^ ": blit_to_bigstring matches Bigint.to_bytes")
       expected (bytes_at buf' ~len) ;
     Alcotest.(check bool)
-      (name ^ ": of_bytes_from inverts to_bytes_into")
+      (name ^ ": of_bigstring inverts blit_to_bigstring")
       true
-      (Field.equal x (Field.of_bytes_from buf' offset))
+      (Field.equal x (Field.of_bigstring buf' offset))
 
   (* The negatives, with their decimal values cross-checked against field
      arithmetic so that a wrong constant cannot pass. *)

--- a/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
+++ b/src/lib/crypto/kimchi_pasta_snarky_backend/test/test_serialization.ml
@@ -114,8 +114,7 @@ module Bigint = Kimchi_pasta_snarky_backend.Bigint256
 
 let len = Bigint.length_in_bytes
 
-let check_bigint (name, decimal) =
-  let b = Bigint.of_decimal_string decimal in
+let check_bigint_value name b =
   let expected = Bytes.to_string (Bigint.to_bytes b) in
   Alcotest.(check bool)
     (name ^ ": of_bytes inverts to_bytes")
@@ -149,8 +148,24 @@ let check_bigint (name, decimal) =
     true
     (Bigint.compare b (Bigint.of_bigstring buf' offset) = 0)
 
+let check_bigint (name, decimal) =
+  check_bigint_value name (Bigint.of_decimal_string decimal)
+
 let test_bigint_values () =
   List.iter ~f:check_bigint (around_zero @ limb_patterns @ full_width_patterns)
+
+(* Seeded pseudo-random 32-byte strings, on top of the hand-picked values:
+   every bit pattern is a valid [Bigint], so this sweeps beyond the limb
+   boundaries, and a failure names its seed. *)
+let random_bytes seed =
+  let rs = Random.State.make [| seed |] in
+  Bytes.init len ~f:(fun _ -> Char.of_int_exn (Random.State.int rs 256))
+
+let test_bigint_random () =
+  for seed = 0 to 999 do
+    check_bigint_value (sprintf "seed %d" seed)
+      (Bigint.of_bytes (random_bytes seed))
+  done
 
 let test_bigint_buffer_short () =
   let b = Bigint.of_decimal_string "1" in
@@ -176,14 +191,8 @@ module Make_field
 struct
   module Bigint = Field.Bigint
 
-  let check_field (name, decimal) =
-    let b = Bigint.of_decimal_string decimal in
-    let x = Field.of_bigint b in
-    let expected = Bytes.to_string (Bigint.to_bytes b) in
-    Alcotest.(check string)
-      (name ^ ": to_bigint round trip")
-      expected
-      (Bytes.to_string (Bigint.to_bytes (Field.to_bigint x))) ;
+  let check_field_value name x =
+    let expected = Bytes.to_string (Bigint.to_bytes (Field.to_bigint x)) in
     Alcotest.(check int)
       (name ^ ": bin_size_t") len
       (Field.Stable.Latest.bin_size_t x) ;
@@ -214,6 +223,24 @@ struct
       (name ^ ": of_bigstring inverts blit_to_bigstring")
       true
       (Field.equal x (Field.of_bigstring buf' offset))
+
+  let check_field (name, decimal) =
+    let b = Bigint.of_decimal_string decimal in
+    let x = Field.of_bigint b in
+    Alcotest.(check string)
+      (name ^ ": to_bigint round trip")
+      (Bytes.to_string (Bigint.to_bytes b))
+      (Bytes.to_string (Bigint.to_bytes (Field.to_bigint x))) ;
+    check_field_value name x
+
+  (* Seeded pseudo-random elements, on top of the hand-picked values: the
+     in-place instances must agree with [Bigint.to_bytes] on arbitrary
+     elements, not only at the limb boundaries, and a failure names its
+     seed. *)
+  let test_random_elements () =
+    for seed = 0 to 999 do
+      check_field_value (sprintf "rng seed %d" seed) (Field.rng seed)
+    done
 
   (* The negatives, with their decimal values cross-checked against field
      arithmetic so that a wrong constant cannot pass. *)
@@ -253,6 +280,7 @@ struct
     [ test_case "around zero" `Quick test_around_zero
     ; test_case "around the modulus" `Quick test_around_modulus
     ; test_case "limb patterns" `Quick test_limb_patterns
+    ; test_case "random elements" `Quick test_random_elements
     ; test_case "buffer short" `Quick test_buffer_short
     ]
 end
@@ -298,6 +326,7 @@ let () =
     [ ( "Bigint256"
       , [ test_case "around zero, limb patterns, full width" `Quick
             test_bigint_values
+        ; test_case "random bytes" `Quick test_bigint_random
         ; test_case "buffer short" `Quick test_bigint_buffer_short
         ] )
     ; ("Fp", Fp.tests)

--- a/src/lib/crypto/plonkish_prelude/test/test_vector.ml
+++ b/src/lib/crypto/plonkish_prelude/test/test_vector.ml
@@ -23,11 +23,65 @@ let test_split () =
   assert (
     List.for_all2_exn v_4_list (List.init 4 ~f:(fun i -> 6 + i)) ~f:Int.equal )
 
+(* [Vector_n.Stable.V1] encodes the elements in order followed by the unit
+   byte, the layout the [Cata] nested-pair combinators produced before the
+   sizer, writer and reader were hand-rolled. These pin the literal bytes:
+   a self-consistent change to writer and reader still round-trips, but
+   would split from nodes running the old code, since [Vector_2] through
+   [Vector_32] are in the proof encoding. *)
+let test_bin_prot_layout () =
+  let module V4 = Plonkish_prelude.Vector.Vector_4 in
+  let v = V4.of_list_exn [ 1; 2; 3; 4 ] in
+  let expected = "\001\002\003\004\000" in
+  Alcotest.(check int)
+    "bin_size_t" (String.length expected)
+    (V4.Stable.V1.bin_size_t Int.bin_size_t v) ;
+  let buf = Bigstring.create 32 in
+  let len = V4.Stable.V1.bin_write_t Int.bin_write_t buf ~pos:0 v in
+  Alcotest.(check string)
+    "bin_write_t bytes" expected
+    (Bigstring.To_string.sub buf ~pos:0 ~len) ;
+  let pos_ref = ref 0 in
+  let v' = V4.Stable.V1.bin_read_t Int.bin_read_t buf ~pos_ref in
+  Alcotest.(check (list int))
+    "bin_read_t inverts" [ 1; 2; 3; 4 ] (V4.to_list v') ;
+  Alcotest.(check int) "bin_read_t consumes the unit byte" len !pos_ref
+
+(* Nested vectors keep the inner unit byte after each inner vector, then the
+   outer one. *)
+let test_bin_prot_layout_nested () =
+  let module V2 = Plonkish_prelude.Vector.Vector_2 in
+  let module V4 = Plonkish_prelude.Vector.Vector_4 in
+  let vv =
+    V2.of_list_exn
+      [ V4.of_list_exn [ 1; 2; 3; 4 ]; V4.of_list_exn [ 5; 6; 7; 8 ] ]
+  in
+  let expected = "\001\002\003\004\000\005\006\007\008\000\000" in
+  let inner_write = V4.Stable.V1.bin_write_t Int.bin_write_t in
+  let inner_read = V4.Stable.V1.bin_read_t Int.bin_read_t in
+  Alcotest.(check int)
+    "bin_size_t" (String.length expected)
+    (V2.Stable.V1.bin_size_t (V4.Stable.V1.bin_size_t Int.bin_size_t) vv) ;
+  let buf = Bigstring.create 32 in
+  let len = V2.Stable.V1.bin_write_t inner_write buf ~pos:0 vv in
+  Alcotest.(check string)
+    "bin_write_t bytes" expected
+    (Bigstring.To_string.sub buf ~pos:0 ~len) ;
+  let pos_ref = ref 0 in
+  let vv' = V2.Stable.V1.bin_read_t inner_read buf ~pos_ref in
+  Alcotest.(check (list (list int)))
+    "bin_read_t inverts"
+    [ [ 1; 2; 3; 4 ]; [ 5; 6; 7; 8 ] ]
+    (List.map (V2.to_list vv') ~f:V4.to_list) ;
+  Alcotest.(check int) "bin_read_t consumes both unit bytes" len !pos_ref
+
 let tests =
   let open Alcotest in
   [ ( "Vectors"
     , [ test_case "test initialize with correct size" `Quick
           test_initialize_with_correct_size
       ; test_case "test split" `Quick test_split
+      ; test_case "bin_prot layout" `Quick test_bin_prot_layout
+      ; test_case "bin_prot layout, nested" `Quick test_bin_prot_layout_nested
       ] )
   ]

--- a/src/lib/crypto/plonkish_prelude/vector.ml
+++ b/src/lib/crypto/plonkish_prelude/vector.ml
@@ -258,16 +258,6 @@ module Make = struct
   struct
     open Bin_prot
 
-    module Tc = Cata (struct
-      type 'a t = 'a Type_class.t
-
-      let pair = Type_class.bin_pair
-
-      let cnv t = Type_class.cnv Fn.id t
-
-      let unit = Type_class.bin_unit
-    end)
-
     module Shape = Cata (struct
       type _ t = Shape.t
 
@@ -278,73 +268,59 @@ module Make = struct
       let unit = Shape.bin_shape_unit
     end)
 
-    module Size = Cata (struct
-      type 'a t = 'a Size.sizer
-
-      let pair = Size.bin_size_pair
-
-      let cnv a_to_b _b_to_a b_sizer a = b_sizer (a_to_b a)
-
-      let unit = Size.bin_size_unit
-    end)
-
-    module Write = Cata (struct
-      type 'a t = 'a Write.writer
-
-      let pair = Write.bin_write_pair
-
-      let cnv a_to_b _b_to_a b_writer buf ~pos a = b_writer buf ~pos (a_to_b a)
-
-      let unit = Write.bin_write_unit
-    end)
-
-    module Writer = Cata (struct
-      type 'a t = 'a Type_class.writer
-
-      let pair = Type_class.bin_writer_pair
-
-      let cnv a_to_b _b_to_a b_writer = Type_class.cnv_writer a_to_b b_writer
-
-      let unit = Type_class.bin_writer_unit
-    end)
-
-    module Reader = Cata (struct
-      type 'a t = 'a Type_class.reader
-
-      let pair = Type_class.bin_reader_pair
-
-      let cnv _a_to_b b_to_a b_reader = Type_class.cnv_reader b_to_a b_reader
-
-      let unit = Type_class.bin_reader_unit
-    end)
-
-    module Read = Cata (struct
-      type 'a t = 'a Read.reader
-
-      let pair = Read.bin_read_pair
-
-      let cnv _a_to_b b_to_a b_reader buf ~pos_ref =
-        b_to_a (b_reader buf ~pos_ref)
-
-      let unit = Read.bin_read_unit
-    end)
-
     let bin_shape_t sh = Shape.f N.n sh
 
-    let bin_size_t sz = Size.f N.n sz
+    (* Encoding: the elements in order, then [unit] (the [Cata] nested-pair
+       layout). *)
+    let bin_size_t : type a. a Size.sizer -> (a, N.n) t -> int =
+     fun sz v ->
+      let rec go : type n. int -> (a, n) t -> int =
+       fun acc -> function
+         | [] ->
+             acc + Size.bin_size_unit ()
+         | x :: xs ->
+             go (acc + sz x) xs
+      in
+      go 0 v
 
-    let bin_write_t wr = Write.f N.n wr
+    let bin_write_t : type a. a Write.writer -> (a, N.n) t Write.writer =
+     fun wr buf ~pos v ->
+      let rec go : type n. int -> (a, n) t -> int =
+       fun pos -> function
+         | [] ->
+             Write.bin_write_unit buf ~pos ()
+         | x :: xs ->
+             go (wr buf ~pos x) xs
+      in
+      go pos v
 
-    let bin_writer_t wr = Writer.f N.n wr
-
-    let bin_t tc = Tc.f N.n tc
-
-    let bin_reader_t re = Reader.f N.n re
-
-    let bin_read_t re = Read.f N.n re
+    let bin_read_t : type a. a Read.reader -> (a, N.n) t Read.reader =
+     fun re buf ~pos_ref ->
+      let rec go : type n. n Nat.t -> (a, n) t = function
+        | Z ->
+            Read.bin_read_unit buf ~pos_ref ;
+            []
+        | S n ->
+            let x = re buf ~pos_ref in
+            let xs = go n in
+            x :: xs
+      in
+      go N.n
 
     let __bin_read_t__ _f _buf ~pos_ref _vint =
       Common.raise_variant_wrong_type "vector" !pos_ref
+
+    let bin_writer_t (wr : _ Type_class.writer) : _ Type_class.writer =
+      { size = bin_size_t wr.size; write = bin_write_t wr.write }
+
+    let bin_reader_t (re : _ Type_class.reader) : _ Type_class.reader =
+      { read = bin_read_t re.read; vtag_read = __bin_read_t__ re.read }
+
+    let bin_t (tc : _ Type_class.t) : _ Type_class.t =
+      { shape = bin_shape_t tc.shape
+      ; writer = bin_writer_t tc.writer
+      ; reader = bin_reader_t tc.reader
+      }
   end
 end
 

--- a/src/lib/crypto/plonkish_prelude/vector.ml
+++ b/src/lib/crypto/plonkish_prelude/vector.ml
@@ -296,6 +296,10 @@ module Make = struct
 
     let bin_read_t : type a. a Read.reader -> (a, N.n) t Read.reader =
      fun re buf ~pos_ref ->
+      (* The element read and the recursive call are sequenced with [let]s
+         on purpose: [re buf ~pos_ref :: go n] would leave the order to
+         OCaml's unspecified constructor-argument evaluation and read the
+         vector backwards. *)
       let rec go : type n. n Nat.t -> (a, n) t = function
         | Z ->
             Read.bin_read_unit buf ~pos_ref ;


### PR DESCRIPTION
Supersedes #19363 (which only covered the scan-state hash). Fixes #19360 at the source instead: every bin_prot encode and decode of a Pasta field element or Pickles vector, wherever it happens. Targets `compatible`; the branch was cut from `develop` and rebased onto `compatible` on 2026-09-10 so that o1js, whose Mina pin is a sibling of `compatible`, can build against it.

## What was wrong

- `Field.Stable.V1` got its bin_prot instance from `Binable.Of_binable (Bigint)`. `bin_size_t` converted the element to a bigint and then to a fresh `Bytes` just to return the constant 32; `bin_write_t` did the same conversion again and blitted; `bin_read_t` copied the bytes out of the buffer into a `Bytes`, then a bigint, then a field element.
- `Vector.Make.Binable` built its sizer, writer, and reader from `Cata` combinators, allocating a chain of nested-pair closures on every call.

## What this PR does

- Adds in-place stubs `caml_pasta_{fp,fq}_{blit_to_bigstring,of_bigstring}` and `caml_bigint_256_{blit_to_bigstring,of_bigstring}` (proof-systems, o1-labs/proof-systems#3628, fixes o1-labs/proof-systems#3627) and exposes them as `blit_to_bigstring` / `of_bigstring` on `Field` and `Bigint`.
- `Field.Stable.V1` and `Bigint` now have a constant `bin_size_t`, and `bin_write_t` / `bin_read_t` work on the bin_prot buffer directly, guarded by `Bin_prot.Common.check_next`.
- `Vector.Make.Binable` walks the vector directly for size, write, and read.
- jsoo glue for the six new primitives: one `caml_bigstring_blit_bytes_to_ba` / `caml_bigstring_blit_ba_to_bytes` per element around the existing TS `to_bytes`, and on the read side `caml_bigint_256_of_bytes` followed by `of_bigint`, the same pair the old `Of_binable (Bigint)` path used. o1js's TS `caml_pasta_{fp,fq}_of_bytes` is an unimplemented stub, which the first o1js probe run caught as `Invalid rich scalar: Public_key ...` on the first base58 key parsed. o1js is at parity with the old path.
- Cherry-picks 228c409a16 (`nix: use duplicate-safe target check`, from `florian/nix-squash-dup-fix`), which o1js's Mina pin already carries and `compatible` lacks; without it Mina's nix dependency squash fails on `site-lib/toplevel` and o1js cannot build the bindings.

The encoding is unchanged: elements are 32 little-endian bytes as before, vectors are elements in order followed by the unit byte, exactly the layout the `Cata` nested pairs produced.

Tests:

- `test_serialization.ml` pins the new `Field` and `Bigint` instances to `Bigint.to_bytes` on the values where a limb-wise implementation can go wrong, for Fp, Fq, and the raw bigint: 0, 1, 2; p-1, p-2, (p-1)/2, (p+1)/2 (with the decimal constants cross-checked against field arithmetic); every subset of the four 64-bit limbs populated, minimal and saturated; and for `Bigint` the full-width patterns up to 2^256-1. On top of those, a seeded sweep of 1000 pseudo-random values each for `Bigint` (arbitrary 32-byte strings), Fp and Fq (`Field.rng`). Each value is written at a nonzero offset into a sentinel-filled buffer and read back, and short buffers must raise `Buffer_short`.
- `test_vector.ml` pins the `Vector` layout to literal bytes: a `Vector_4` of ints must encode as `\001\002\003\004\000`, and a `Vector_2` of `Vector_4` keeps each inner unit byte followed by the outer one. Round-trip tests cannot catch a layout drift there, because writer and reader changed together.
- `bindings_js_test.ml` (the jsoo nodejs test, not run by CI) round-trips `Bigint_256`, `Fp` and `Fq` through `blit_to_bigstring` / `of_bigstring` at a nonzero offset into a sentinel-filled bigstring.
- The existing bin_io round-trip tests also pass.

## Benchmarks

Measured before the rebase, on the `develop` base aed679341e; the serialization code is identical on `compatible`. Same method as #19363: 3 runs each, allocation from `OCAMLRUNPARAM=v=0x400`, wall clock and RSS from `/usr/bin/time -l`, medians, arm64 macOS.

**Per call, allocation:** `bin_size_t` of a `Proofs_verified_2` proof 46.5 KB → 3.9 KB; `bin_write_t` 78 KB → 4.6 KB.

**`staged_ledger` inline tests** (the same workload as #19363; dominated by proving and ledger application, so the serialization share is small):

| Metric | Base | Head | Change |
| --- | --- | --- | --- |
| Words allocated (GB) | 112.74 | 110.51 | -2.0% |
| Top heap words (M) | 58.0 | 58.0 | 0 |
| Wall clock, median (s) | 118.76 | 118.84 | noise |
| Peak RSS (MB) | 2753 | 2789 | noise |

**Per full block at mainnet parameters** (a fixture that builds 256-proof blocks with `ledger_depth` 35, `transaction_capacity_log_2` 7, `work_delay` 2, proofs in an LMDB proof cache; steady-state mean over 8 blocks):

| Operation | Time before → after | Allocation before → after |
| --- | --- | --- |
| Read all 256 proofs from the LMDB cache | 12.5 → 9.2 ms | 27.7 → 9.1 MB |
| `Body.compute_reference` | 11.4 → 8.4 ms | 36.7 → 2.6 MB |
| Encode body (`to_binio_bigstring`) | 12.3 → 6.7 ms | 36.7 → 2.6 MB |
| Decode body | 15.9 → 12.6 ms | 29.1 → 9.9 MB |
| Write all proofs to the LMDB cache | unchanged (one LMDB commit per proof dominates) | 35.6 → 2.4 MB |

These are the paths every received block goes through (gossip decode, body reference hash, proof cache write), plus catchup, bootstrap, and persistent-frontier restore.

The speedup is native-only. In JS the field-to-bytes conversion still goes through o1js's TS `to_bytes` / `of_bytes`, so o1js gets parity with the old path, not a gain; a real JS gain would need a TS binding that reads and writes the bigarray directly.

## Review notes

- Readers now raise `Bin_prot.Common.Buffer_short` on a truncated buffer, per the bin_prot reader contract, where the old `Bigint.bin_read_t` raised `Failure`.
- `of_bigstring` is stricter than the old `of_bigint` path for non-canonical 32-byte encodings (values ≥ p): it raises `Failure "caml_pasta_fp_of_bigstring: not a canonical field element"` (likewise for fq). No valid writer produces those.
- The jsoo glue is exercised by the o1js probe o1-labs/o1js#2912, which pins this branch.
- The proof-systems submodule points at 5464fd427b on `martyall/fix-3627-compatible`: the three o1-labs/proof-systems#3628 commits replayed onto ab84160fa2, the pin `compatible` already uses, with the codec files byte-identical to #3628's head. #3628 as it stands is based on master, and compatible's pickles does not compile against master (public evaluations became vectors in #3577), so the master-based head cannot be used here. #3628 or its compatible-based twin needs to land in proof-systems before this can merge.

https://claude.ai/code/session_011hLYDNEykhZxLbLyEywMMr
https://claude.ai/code/session_016yA7z2fNMo7hfhtuwYWM4R
