### PR TITLE
Give each upload its own pin key

### DIFF
--- a/buildkite/src/Command/PinGitEnv.dhall
+++ b/buildkite/src/Command/PinGitEnv.dhall
@@ -15,11 +15,13 @@
 -- that does the entrypoint's work depend on it, with `dependsOn`.
 --
 --     , steps =
---       [ PinGitEnv.step
+--       [ PinGitEnv.step stage
 --       , Command.build
 --           Command.Config::{
---           , depends_on = PinGitEnv.dependsOn jobName
+--           , depends_on = PinGitEnv.dependsOn jobName stage
 --           , ...
+--
+-- where `stage` is the discriminator described below.
 --
 -- The depended-on step is always the one that uploads or runs everything else,
 -- which is what makes this a barrier rather than an ordering to reason about:

--- a/buildkite/src/Command/PinGitEnv.dhall
+++ b/buildkite/src/Command/PinGitEnv.dhall
@@ -31,8 +31,23 @@
 -- inside one.
 --
 -- Which identity gets pinned is buildkite/scripts/git-env/pin.sh's decision,
--- not this file's. Nothing is passed here, so there is no environment to
--- escape and no way for an entrypoint to disagree with another about it.
+-- not this file's. Nothing is passed to the script, so there is no environment
+-- to escape and no way for an entrypoint to disagree with another about it.
+--
+-- The discriminator is the one thing a caller must supply. Buildkite step keys
+-- are unique per BUILD, not per upload, and an entrypoint can be uploaded more
+-- than once in one build: a release pipeline uploads Prepare.dhall for each of
+-- its stages, and the second upload of a constant key is rejected with
+--
+--   422 The key "_prepare-pin-git-env" has already been used by another step
+--
+-- which fails the build rather than the step. So pass whatever already makes
+-- that entrypoint's own step key unique -- for Prepare.dhall that is the
+-- stage's selection, tag filter and scope -- and pass "" only where the
+-- entrypoint really is uploaded once per build.
+--
+-- Running the pin once per stage costs nothing: pin.sh finds the identity the
+-- first stage wrote and keeps it.
 
 let Cmd = ../Lib/Cmds.dhall
 
@@ -42,21 +57,26 @@ let Docker = ./Docker/Type.dhall
 
 let Size = ./Size.dhall
 
-let key = "pin-git-env"
+let keyFor
+    : Text -> Text
+    = \(discriminator : Text) -> "pin-git-env${discriminator}"
 
 let step
-    : Command.Type
-    = Command.build
-        Command.Config::{
-        , commands = [ Cmd.run "./buildkite/scripts/git-env/pin.sh" ]
-        , label = "Pin the git environment"
-        , key = key
-        , target = Size.Small
-        , docker = None Docker.Type
-        }
+    : Text -> Command.Type
+    =     \(discriminator : Text)
+      ->  Command.build
+            Command.Config::{
+            , commands = [ Cmd.run "./buildkite/scripts/git-env/pin.sh" ]
+            , label = "Pin the git environment"
+            , key = keyFor discriminator
+            , target = Size.Small
+            , docker = None Docker.Type
+            }
 
 let dependsOn
-    : Text -> List Command.TaggedKey.Type
-    = \(jobName : Text) -> [ Command.TaggedKey::{ name = jobName, key = key } ]
+    : Text -> Text -> List Command.TaggedKey.Type
+    =     \(jobName : Text)
+      ->  \(discriminator : Text)
+      ->  [ Command.TaggedKey::{ name = jobName, key = keyFor discriminator } ]
 
-in  { key = key, step = step, dependsOn = dependsOn }
+in  { keyFor = keyFor, step = step, dependsOn = dependsOn }

--- a/buildkite/src/Entrypoints/PromoteNightly.dhall
+++ b/buildkite/src/Entrypoints/PromoteNightly.dhall
@@ -89,6 +89,13 @@ let promote_nightly =
                     ++  "./scripts/docker/update-gar-whitelist.sh"
                   )
 
+          let promotion =
+              -- The promoter renders one pipeline for each branch and profile
+              -- it is asked for, so a constant key would collide the moment a
+              -- build promotes more than one. The step below already carries
+              -- both; the pin carries the same.
+                "-${branch}-${profile}"
+
           let pipeline =
                 Pipeline.build
                   Pipeline.Config::{
@@ -99,10 +106,11 @@ let promote_nightly =
                     , tags = [ PipelineTag.Type.Promote ]
                     }
                   , steps =
-                    [ PinGitEnv.step
+                    [ PinGitEnv.step promotion
                     , Command.build
                         Command.Config::{
-                        , depends_on = PinGitEnv.dependsOn "PromoteNightly"
+                        , depends_on =
+                            PinGitEnv.dependsOn "PromoteNightly" promotion
                         , commands =
                               [ FixPermissions.command Architecture.Type.Amd64 ]
                             # [ buildGoBinaryCmd ]
@@ -110,7 +118,7 @@ let promote_nightly =
                             # [ publishDockersCmd ]
                             # [ updateGarWhitelistCmd ]
                         , label = "Promote Nightly (${branch}/${profile})"
-                        , key = "promote-nightly-${branch}-${profile}"
+                        , key = "promote-nightly${promotion}"
                         , target = Size.Small
                         }
                     ]

--- a/buildkite/src/Entrypoints/RunSelection.dhall
+++ b/buildkite/src/Entrypoints/RunSelection.dhall
@@ -75,10 +75,10 @@ let config
         , dirtyWhen = [ SelectFiles.everything ]
         }
       , steps =
-        [ PinGitEnv.step
+        [ PinGitEnv.step ""
         , Command.build
             Command.Config::{
-            , depends_on = PinGitEnv.dependsOn jobName
+            , depends_on = PinGitEnv.dependsOn jobName ""
             , commands = prefixCommands # [ commands ]
             , label = "Run selection"
             , key = "cmds"

--- a/buildkite/src/Entrypoints/RunSingleJob.dhall
+++ b/buildkite/src/Entrypoints/RunSingleJob.dhall
@@ -42,11 +42,11 @@ in      \(args : { name : Text })
                   , dirtyWhen = [ SelectFiles.everything ]
                   }
                 , steps =
-                  [ PinGitEnv.step
+                  [ PinGitEnv.step ""
                   , Command.build
                       Command.Config::{
                       , depends_on =
-                          PinGitEnv.dependsOn "run-single-job-${args.name}"
+                          PinGitEnv.dependsOn "run-single-job-${args.name}" ""
                       , commands = prefixCommands # [ commands args.name ]
                       , label = "Run Single Job ${args.name}"
                       , key = "cmds"

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -36,6 +36,13 @@ let filterMode = env:BUILDKITE_PIPELINE_FILTER_MODE as Text ? "Any"
 
 let jobName = "prepare"
 
+let stage =
+    -- What distinguishes one stage's upload of this file from another's. The
+    -- triage step's key already carries it; the pin's has to as well, because
+    -- a release pipeline uploads this file once per stage and buildkite
+    -- rejects a key it has already seen in the build.
+      "-${selection}-${tagFilter}-${scopeFilter}"
+
 let config
     : Pipeline.Config.Type
     = Pipeline.Config::{
@@ -44,10 +51,10 @@ let config
         , dirtyWhen = [ SelectFiles.everything ]
         }
       , steps =
-        [ PinGitEnv.step
+        [ PinGitEnv.step stage
         , Command.build
             Command.Config::{
-            , depends_on = PinGitEnv.dependsOn jobName
+            , depends_on = PinGitEnv.dependsOn jobName stage
             , commands =
               [ Cmd.run "./buildkite/scripts/pipeline/validate-release-env.sh"
               , Cmd.run "export BUILDKITE_PIPELINE_MODE=${mode}"
@@ -59,7 +66,7 @@ let config
                   "./buildkite/scripts/pipeline/upload.sh '(./buildkite/src/Monorepo.dhall) { selection=(./buildkite/src/Pipeline/JobSelection.dhall).Type.${selection}, tagFilter=(./buildkite/src/Pipeline/TagFilter.dhall).Type.${tagFilter}, scopeFilter=(./buildkite/src/Pipeline/ScopeFilter.dhall).Type.${scopeFilter}, filterMode=(./buildkite/src/Pipeline/FilterMode.dhall).Type.${filterMode} }'"
               ]
             , label = "Prepare monorepo triage"
-            , key = "monorepo-${selection}-${tagFilter}-${scopeFilter}"
+            , key = "monorepo${stage}"
             , target = Size.Multi
             , docker = Some Docker::{
               , image = (./Constants/ContainerImages.dhall).toolchainBase

--- a/scripts/tests/test_export_git_env_vars.sh
+++ b/scripts/tests/test_export_git_env_vars.sh
@@ -349,6 +349,43 @@ test_a_cache_without_a_pin_is_not_an_error() {
 }
 
 ################################################################################
+# Step keys
+################################################################################
+
+# Buildkite step keys are unique per build, not per upload, and a release
+# pipeline uploads Prepare.dhall once for each of its stages. A constant pin key
+# was rejected on the second upload with
+#
+#   422 The key "_prepare-pin-git-env" has already been used by another step
+#
+# which fails the build rather than the step. Every stage must render a key of
+# its own, the way the triage step already did.
+test_each_stage_renders_its_own_pin_key() {
+    if ! command -v dhall-to-yaml >/dev/null 2>&1; then
+        echo -n "(no dhall-to-yaml, skipped) "
+        return 0
+    fi
+
+    local first second
+    first="$( cd "$REPO_ROOT" && BUILDKITE_PIPELINE_FILTER=FastOnly \
+        dhall-to-yaml --quoted <<< './buildkite/src/Prepare.dhall' \
+        | grep -o "_prepare-pin-git-env[^']*" | head -1 )"
+    second="$( cd "$REPO_ROOT" && BUILDKITE_PIPELINE_FILTER=LongAndVeryLong \
+        dhall-to-yaml --quoted <<< './buildkite/src/Prepare.dhall' \
+        | grep -o "_prepare-pin-git-env[^']*" | head -1 )"
+
+    if [[ -z "$first" || -z "$second" ]]; then
+        log_fail "no pin step was rendered"
+        return 0
+    fi
+    if [[ "$first" == "$second" ]]; then
+        log_fail "two stages rendered the same key '${first}'; the second upload is rejected"
+    else
+        log_pass
+    fi
+}
+
+################################################################################
 
 main() {
     setup
@@ -366,6 +403,7 @@ main() {
     run_test test_the_pin_says_nothing_on_standard_output
     run_test test_wrapping_an_unpinned_build_is_an_error
     run_test test_a_cache_without_a_pin_is_not_an_error
+    run_test test_each_stage_renders_its_own_pin_key
 
     teardown
 


### PR DESCRIPTION
Fixes the failure #19362 introduced on this branch:

```
FATAL  Failed to upload and process pipeline: 422
The key "_prepare-pin-git-env" has already been used by another step in this build
```

## Cause

A Buildkite step key is unique per **build**, not per upload. A release pipeline uploads `Prepare.dhall` once for each of its stages — `mina-alpha` does it four times — and every upload carried the same pin key, so the second was rejected. It fails the build, not the step.

The triage step sitting beside it never had the problem: its key already carried the stage's selection, tag filter and scope. Mine did not.

## Fix

`PinGitEnv.step` and `PinGitEnv.dependsOn` take a discriminator, so each caller passes whatever already makes its own key unique:

| Entrypoint | Discriminator | Why |
|---|---|---|
| `Prepare.dhall` | `-${selection}-${tagFilter}-${scopeFilter}` | uploaded once per stage |
| `RunSelection.dhall` | `""` | one upload per build |
| `RunSingleJob.dhall` | `""` | one upload, and the job name already varies |
| `PromoteNightly.dhall` | `-${branch}-${profile}` | the promoter renders one pipeline per pair |

The triage and promote keys are now written in terms of the same value, so the pin and the step it gates cannot drift apart.

Pinning once per stage costs nothing: `pin.sh` finds the identity the first stage wrote and keeps it — case 1 of its resolution order, which the suite already covers.

## Verification

The four stage filters `mina-alpha` uses now render four distinct keys:

```
_prepare-pin-git-env-Triaged-FastOnly-All
_prepare-pin-git-env-Triaged-LongAndVeryLong-All
_prepare-pin-git-env-Triaged-PackagingAmd64Devnet-All
_prepare-pin-git-env-Triaged-Publish-All
```

New test `test_each_stage_renders_its_own_pin_key` renders `Prepare.dhall` under two stage filters and fails if the keys match — the failure itself, not a proxy for it. Red-proofed by setting the discriminator back to `""`.

`make all` green on this branch. Suite now 14 tests / 29 assertions.

Same fix is on #19331 and #19334.