### PR TITLE
Survive EOL-codename mirrors in the debian verify container (develop port)

### DIFF
--- a/buildkite/scripts/debian/update.sh
+++ b/buildkite/scripts/debian/update.sh
@@ -270,8 +270,16 @@ run_apt_update() {
     # Bypass any configured APT proxy for localhost
     eval "$(./buildkite/scripts/debian/apt-proxy-bypass.sh localhost)"
 
+    # bullseye left LTS at the end of Aug 2026 and its security Release file is
+    # no longer re-signed, so apt rejects the stale metadata outright.  Drop
+    # only the freshness check, and only there; signatures are still verified.
+    local stale_opts=""
+    if grep -q '^VERSION_CODENAME=bullseye$' /etc/os-release 2>/dev/null; then
+        stale_opts="-o Acquire::Check-Valid-Until=false"
+    fi
+
     log "Running apt-get update..."
-    if ! ${SUDO_CMD} apt-get update $APT_PROXY_BYPASS_OPTS; then
+    if ! ${SUDO_CMD} apt-get update $stale_opts $APT_PROXY_BYPASS_OPTS; then
         error "apt-get update failed"
         return 1
     fi

--- a/scripts/debian/verify-inside-docker/setup.sh
+++ b/scripts/debian/verify-inside-docker/setup.sh
@@ -15,6 +15,13 @@ TRUSTED_FLAG="${7:-[trusted=yes]}"
 
 echo "Installing $PACKAGE=$VERSION from $REPO ($CODENAME/$CHANNEL)"
 
+# bullseye left LTS at the end of Aug 2026 and its security Release file is no
+# longer re-signed, so apt rejects the stale metadata outright.  Drop only the
+# freshness check, and only there; signatures are still verified.
+if [[ "$CODENAME" == "bullseye" ]]; then
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-valid-until
+fi
+
 apt-get update
 
 # ca-certificates alone is enough to fetch from an https repo with

--- a/scripts/debian/verify-inside-docker/setup.sh
+++ b/scripts/debian/verify-inside-docker/setup.sh
@@ -16,9 +16,16 @@ TRUSTED_FLAG="${7:-[trusted=yes]}"
 echo "Installing $PACKAGE=$VERSION from $REPO ($CODENAME/$CHANNEL)"
 
 apt-get update
-apt-get install -y lsb-release ca-certificates wget gnupg
+
+# ca-certificates alone is enough to fetch from an https repo with
+# [trusted=yes]; wget/gnupg are only needed to import the signing key for
+# signed repos.  Keep the installs separate: on EOL codenames (e.g. bullseye
+# after Aug 2026) parts of the security pool 404, and one unrelated 404 in a
+# shared apt transaction would take ca-certificates down with it.
+apt-get install -y ca-certificates
 
 if [[ "$SIGNED" == "1" ]]; then
+  apt-get install -y wget gnupg
   wget -q "https://${REPO}/repo-signing-key.gpg" -O /etc/apt/trusted.gpg.d/minaprotocol.gpg
   TRUSTED_FLAG=""
 fi


### PR DESCRIPTION
Port of #19375 to `develop`. Same two fixes; the only difference is that `develop` already dropped the `> /dev/null` redirections on the apt calls in the verify container, so this branch keeps them dropped.

bullseye left LTS at the end of August 2026, and its security pool on `deb.debian.org` has been decaying since. Two distinct failures fall out of that.

**1. 404s take unrelated packages down with them.** The debian verify container (`scripts/debian/verify-inside-docker/setup.sh`) installed `lsb-release ca-certificates wget gnupg` in **one** apt transaction, and a 404 on the gnupg2 packages took `ca-certificates` down with it — after which the https fetch from the package repository failed on TLS.

Effect: **Release Manager Tests failed deterministically on every run** (`E: Unable to locate package mina-devnet` after `W: No system certificates available`).

Fix: `ca-certificates` alone is enough for an https repo with `[trusted=yes]`, so it installs on its own; `wget`/`gnupg` move under the signed-repo branch, the only place they're used. `lsb-release` had no consumer at all.

**2. The `bullseye-security` Release file is now expired.** It stopped being re-signed, so as of 2026-09-08 apt rejects it outright (`E: Release file ... is expired`) and the whole `apt-get update` fails. This kills **Debian upgrade test (bullseye)** ([build 42160](https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/42160)) and would kill the verify container's first `apt-get update` too.

Fix: drop only the freshness check — `Acquire::Check-Valid-Until=false` in the shared `buildkite/scripts/debian/update.sh` helper and in the verify container, and only when the codename is bullseye. Every other codename keeps the check, and repository signatures are still verified everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jd4ihkrdUEiob7BTqzBmH