### PR TITLE
fix(logger): drop the pretty processor's trailing blank line

### DIFF
--- a/src/lib/logger/native/logger.ml
+++ b/src/lib/logger/native/logger.ml
@@ -188,6 +188,23 @@ module Processor = struct
 
     let create ~log_level ~config = { log_level; config }
 
+    (* the metadata interpolation left over, one "key: value" per line. Printed
+       inside the record's vertical box, so the cuts carry its indentation.
+
+       The block is introduced by its own cut rather than by one in the record's
+       format string: a cut in a vertical box always breaks, so an
+       unconditional one would end every record with no leftover metadata --
+       one with no metadata at all, or whose every field was interpolated into
+       the message -- on a newline and the box's indent. *)
+    let pp_extra ppf = function
+      | [] ->
+          ()
+      | extra ->
+          Format.fprintf ppf "@,%a"
+            (Format.pp_print_list ~pp_sep:Format.pp_print_cut (fun ppf (k, v) ->
+                 Format.fprintf ppf "%s: %s" k v ) )
+            extra
+
     let process { log_level; config } (msg : Message.t) =
       let open Message in
       if Level.compare msg.level log_level < 0 then None
@@ -204,11 +221,8 @@ module Processor = struct
         | Ok (str, extra) ->
             let msg =
               (* The previously existing \t has been changed to 2 spaces. *)
-              Format.asprintf "@[<v 2>%a [%a] %s@,%a@]" Time.pp msg.timestamp
-                Level.pp msg.level str
-                (Format.pp_print_list ~pp_sep:Format.pp_print_cut
-                   (fun ppf (k, v) -> Format.fprintf ppf "%s: %s" k v) )
-                extra
+              Format.asprintf "@[<v 2>%a [%a] %s%a@]" Time.pp msg.timestamp
+                Level.pp msg.level str pp_extra extra
             in
             Some msg
   end

--- a/src/lib/logger/test/dune
+++ b/src/lib/logger/test/dune
@@ -7,6 +7,7 @@
   core
   core_kernel
   ;; local libraries
+  interpolator_lib
   logger
   logger.file_system)
  (preprocess

--- a/src/lib/logger/test/logger_test.ml
+++ b/src/lib/logger/test/logger_test.ml
@@ -85,6 +85,57 @@ let test_dumb_logrotate_resumes_from_oldest () =
         "mina.log.2 was preserved (newest)" "newest\n"
         (get_contents "mina.log.2") )
 
+(* a fixed timestamp, so a rendered record can be compared in full *)
+let message ?(level = Logger.Level.Info) ?(metadata = []) text =
+  { Logger.Message.timestamp = Logger.Time.epoch
+  ; level
+  ; source = Some (Logger.Source.create ~module_:__MODULE__ ~location:__LOC__)
+  ; message = text
+  ; metadata = String.Map.of_alist_exn metadata
+  ; event_id = None
+  }
+
+(* renders one message through a pretty consumer of its own and returns what
+   the transport was handed *)
+let pretty_render ~id ?(mode = Interpolator_lib.Interpolator.Inline) msg =
+  let emitted = ref None in
+  Logger.Consumer_registry.register ~id
+    ~processor:
+      (Logger.Processor.pretty ~log_level:Logger.Level.Spam
+         ~config:
+           { Interpolator_lib.Interpolator.mode
+           ; max_interpolation_length = 50
+           ; pretty_print = true
+           } )
+    ~transport:(Logger.Transport.raw (fun line -> emitted := Some line))
+    () ;
+  Logger.raw (Logger.create ~id ()) msg ;
+  Option.value_exn !emitted ~message:"the pretty processor emitted nothing"
+
+let test_pretty_renders_a_record_without_metadata_on_one_line () =
+  Alcotest.(check string)
+    "no trailing line"
+    "1970-01-01 00:00:00 UTC [Error] block get: one of --index or --hash is \
+     required"
+    (pretty_render ~id:"pretty_no_metadata"
+       (message ~level:Logger.Level.Error
+          "block get: one of --index or --hash is required" ) )
+
+let test_pretty_renders_interpolated_metadata_on_one_line () =
+  Alcotest.(check string)
+    "no trailing line" {|1970-01-01 00:00:00 UTC [Info] connected to "1.2.3.4"|}
+    (pretty_render ~id:"pretty_interpolated"
+       (message ~metadata:[ ("peer", `String "1.2.3.4") ] "connected to $peer") )
+
+let test_pretty_keeps_metadata_left_over_by_interpolation () =
+  Alcotest.(check string)
+    "each leftover key on its own indented line"
+    "1970-01-01 00:00:00 UTC [Info] rotated\n  count: 2\n  reason: \"size\""
+    (pretty_render ~id:"pretty_extra" ~mode:Interpolator_lib.Interpolator.After
+       (message
+          ~metadata:[ ("count", `Int 2); ("reason", `String "size") ]
+          "rotated" ) )
+
 let () =
   let open Alcotest in
   run "Logger"
@@ -93,5 +144,13 @@ let () =
             test_dumb_logrotate_rotates_logs_when_expected
         ; test_case "resumes rotation from oldest log" `Quick
             test_dumb_logrotate_resumes_from_oldest
+        ] )
+    ; ( "pretty"
+      , [ test_case "renders a record without metadata on one line" `Quick
+            test_pretty_renders_a_record_without_metadata_on_one_line
+        ; test_case "renders interpolated metadata on one line" `Quick
+            test_pretty_renders_interpolated_metadata_on_one_line
+        ; test_case "keeps metadata left over by interpolation" `Quick
+            test_pretty_keeps_metadata_left_over_by_interpolation
         ] )
     ]


### PR DESCRIPTION
`Logger.Processor.pretty` ended every record with a newline and two spaces, so
human-readable logs took two lines per entry instead of one.

The format string was `"@[<v 2>%a [%a] %s@,%a@]"`. A `@,` cut inside a vertical
box always breaks, so the newline and the box's indent were emitted before the
leftover metadata whether or not there was any. `extra` is empty for the two
commonest cases: a message with no metadata, and one whose every `$field` was
interpolated into the text.

The cut now lives in `pp_extra` and is emitted only for a non-empty list.
Records with leftover metadata are unchanged.

Affects every binary logging in human-readable mode — daemon, archive node,
replayer, snark worker, rosetta. Nothing parses this format; `logproc` reads the
JSON `Processor.raw` writes, which is untouched.

Two commits: the failing tests, then the fix.

Note: the same defect is present verbatim on `compatible` and will need a
backport or forward-merge.

Fixes #19336

https://claude.ai/code/session_01SqDrXcgoxduULdK7WfA2Fb
