### PR TITLE
archive: insert zkApp fields without depending on dropped unique constraints

### DIFF
--- a/changes/19395.md
+++ b/changes/19395.md
@@ -1,0 +1,5 @@
+Archive: zkApp events and actions can be written to a Mesa-migrated database
+
+The archive node writes `zkapp_field_array` rows without relying on the unique constraint over `element_ids`, which `upgrade_to_mesa.sql` drops. Blocks carrying zkApp events or actions can now be backfilled with the Berkeley archive into a database already migrated to the Mesa schema.
+
+Previously such a block was rejected by Postgres with `there is no unique or exclusion constraint matching the ON CONFLICT specification`.

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -1562,6 +1562,7 @@ module Zkapp_events = struct
         let%map field_array_map =
           Mina_caqti.insert_multi_into_col ~table_name:"zkapp_field_array"
             ~col:("element_ids", Mina_caqti.array_int_typ)
+            ~no_unique_constraint:"int[]"
             (module Conn)
             field_array_list
           >>| Field_array_map.of_alist_exn

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -413,29 +413,62 @@ let sep_by_comma ?(parenthesis = false) xs =
   List.map xs ~f:(if parenthesis then sprintf "('%s')" else sprintf "'%s'")
   |> String.concat ~sep:", "
 
+(* Insert the values that aren't in the table yet, then return the id of
+   every value, inserted or pre-existing.
+
+   Deduplication is normally left to the column's UNIQUE constraint, through
+   `ON CONFLICT DO NOTHING`. `no_unique_constraint` names the SQL type of a
+   column that may have none — `upgrade_to_mesa.sql` drops the one over
+   `zkapp_field_array.element_ids`, as a btree over an unbounded `int[]`
+   overflows Postgres' index row size limit, and Postgres rejects an
+   `ON CONFLICT` target with no matching constraint. Then the queries
+   deduplicate on their own, casting the values to that type to compare them
+   against the column.
+
+   ponytail: that comparison is a sequential scan with no index over the
+   column, as is already true of the `select_insert_into_cols` lookups over
+   the same columns. Give the column an index if backfill speed matters. *)
 let insert_multi_into_col ~(table_name : string)
-    ~(col : string * 'col Caqti_type.t) (module Conn : CONNECTION)
-    (values : string list) =
+    ~(col : string * 'col Caqti_type.t) ?no_unique_constraint
+    (module Conn : CONNECTION) (values : string list) =
   let open Deferred.Result.Let_syntax in
-  let insert =
-    sprintf
-      {sql| INSERT INTO %s (%s) VALUES %s
+  let insert, search =
+    match no_unique_constraint with
+    | None ->
+        ( sprintf
+            {sql| INSERT INTO %s (%s) VALUES %s
             ON CONFLICT (%s)
             DO NOTHING |sql}
-      table_name (fst col)
-      (sep_by_comma ~parenthesis:true values)
-      (fst col)
+            table_name (fst col)
+            (sep_by_comma ~parenthesis:true values)
+            (fst col)
+        , sprintf
+            {sql| SELECT %s, id FROM %s
+            WHERE %s in (%s) |sql}
+            (fst col) table_name (fst col) (sep_by_comma values) )
+    | Some tannot ->
+        let cast = "::" ^ tannot in
+        ( sprintf
+            {sql| INSERT INTO %s (%s)
+            SELECT DISTINCT vals.value%s FROM (VALUES %s) AS vals (value)
+            WHERE NOT EXISTS (SELECT 1 FROM %s WHERE %s = vals.value%s) |sql}
+            table_name (fst col) cast
+            (sep_by_comma ~parenthesis:true values)
+            table_name (fst col) cast
+          (* `DISTINCT ON` because without the constraint the table may
+             already hold duplicates of a value, and callers key a map by
+             value *)
+        , sprintf
+            {sql| SELECT DISTINCT ON (%s) %s, id FROM %s
+            WHERE %s in (%s)
+            ORDER BY %s, id |sql}
+            (fst col) (fst col) table_name (fst col) (sep_by_comma values)
+            (fst col) )
   in
   let%bind () =
     Conn.exec
       (Caqti_request.Infix.(Caqti_type.unit ->. Caqti_type.unit) insert)
       ()
-  in
-  let search =
-    sprintf
-      {sql| SELECT %s, id FROM %s
-            WHERE %s in (%s) |sql}
-      (fst col) table_name (fst col) (sep_by_comma values)
   in
   Conn.collect_list
     Caqti_request.Infix.(


### PR DESCRIPTION
Closes #19387. Closes #19380 — the Mesa archive will not learn the pre-Mesa block format (see the discussion there); this is the Berkeley-side defect that blocked the supported backfill path.

The Berkeley archive writes `zkapp_field` and `zkapp_field_array` through `Mina_caqti.insert_multi_into_col`, which emitted `ON CONFLICT (<col>) DO NOTHING`. `upgrade_to_mesa.sql` drops the unique constraint over `zkapp_field_array.element_ids` (a btree over an unbounded `int[]` overflows Postgres' 2704-byte index row limit), and Postgres rejects a conflict target with no matching constraint. So backfilling a pre-Mesa block that carries zkApp events or actions into an already-migrated database failed with `there is no unique or exclusion constraint matching the ON CONFLICT specification`.

The helper takes a `no_unique_constraint` argument naming the column's SQL type, passed at the one call site that writes `zkapp_field_array.element_ids`. There the deduplication is done by the query instead of by a constraint: insert `SELECT DISTINCT` of the values that aren't in the table yet, and read the ids back with `DISTINCT ON` so a table that already holds duplicate rows still yields one id per value. This works on the Berkeley schema and on a Mesa-migrated one alike, and keeps the content deduplication that Berkeley's own `UNIQUE` still requires. Every other caller — `zkapp_field`, whose constraint the migration keeps — is on the unchanged `ON CONFLICT` path.

Note on cost: where the constraint is gone the existence lookup is a sequential scan. That is not new to this path — the `select_insert_into_cols` lookups over the same columns already scan there — but it is worth an index if backfill throughput matters.

## Testing

Based on `prefork/berkeley`, branched from the `3.5.0-mainnet-stop-slot` tag.

Built `@src/app/archive/lib/check`, and ran the emitted SQL against a real Postgres 16 on both schemas (`create_schema.sql`, and the same plus `upgrade_to_mesa.sql`):

- the old statement reproduces the reported error on the migrated database;
- the new statement succeeds on both, deduplicates within a batch and against existing rows, is a no-op on replay, and returns one id per value even when the table already contains duplicates;
- the untouched `zkapp_field` path still behaves as before on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165z75mZRq8aveTnaHaU1qb