### PR TITLE
integration tests: pull images before deploying the swarm stack

### DIFF
--- a/src/lib/testing/integration_test_local_engine/mina_docker.ml
+++ b/src/lib/testing/integration_test_local_engine/mina_docker.ml
@@ -431,6 +431,7 @@ module Network_manager = struct
     ; services_by_id : Docker_network.Service_to_deploy.t Core.String.Map.t
     ; mutable deployed : bool
     ; genesis_keypairs : Network_keypair.t Core.String.Map.t
+    ; images : string list
     }
 
   let get_current_running_stacks =
@@ -691,6 +692,31 @@ module Network_manager = struct
                | _ ->
                    failwith "Unexpected format for docker service output" ) )
     in
+    (* `docker service ls` only ever says 0/1; the reason a task will not start
+       -- an unpullable image, an unschedulable constraint -- is carried by the
+       task, and only `docker service ps` prints it. Without this the deploy
+       fails after the full timeout with nothing to go on. *)
+    let log_service_tasks bad_service_statuses =
+      let open Deferred.Let_syntax in
+      Deferred.List.iter bad_service_statuses ~f:(fun (service_name, _) ->
+          match%map
+            Util.run_cmd_or_error "/" "docker"
+              [ "service"; "ps"; "--no-trunc"; service_name ]
+          with
+          | Ok output ->
+              [%log error] "Tasks of $service_name: $tasks"
+                ~metadata:
+                  [ ("service_name", `String service_name)
+                  ; ("tasks", `String output)
+                  ]
+          | Error error ->
+              [%log warn] "Could not inspect tasks of $service_name: $error"
+                ~metadata:
+                  [ ("service_name", `String service_name)
+                  ; ("error", `String (Error.to_string_hum error))
+                  ] )
+    in
+    let tasks_logged = ref false in
     let rec poll n =
       [%log debug] "Checking Docker service statuses, n=%d" n ;
       let%bind service_statuses = get_service_statuses () in
@@ -715,6 +741,13 @@ module Network_manager = struct
               )
             ] ;
         let%bind () =
+          if !tasks_logged then return ()
+          else (
+            tasks_logged := true ;
+            Deferred.bind ~f:Malleable_error.return
+              (log_service_tasks bad_service_statuses) )
+        in
+        let%bind () =
           after poll_interval |> Deferred.bind ~f:Malleable_error.return
         in
         poll (n - 1) )
@@ -726,6 +759,10 @@ module Network_manager = struct
                    [ ("service_name", `String service_name)
                    ; ("status", `String status)
                    ] ) )
+        in
+        let%bind () =
+          Deferred.bind ~f:Malleable_error.return
+            (log_service_tasks bad_service_statuses)
         in
         [%log fatal]
           "Not all services could be deployed in time: $bad_service_statuses"
@@ -792,16 +829,56 @@ module Network_manager = struct
       ; services_by_id
       ; deployed = false
       ; genesis_keypairs = network_config.genesis_keypairs
+      ; images =
+          Docker_compose.Dockerfile.StringMap.data
+            (Network_config.to_docker network_config).services
+          |> List.map ~f:(fun (service : Docker_compose.Dockerfile.Service.t) ->
+                 service.image )
+          |> List.dedup_and_sort ~compare:String.compare
       }
     in
     [%log info] "Initializing docker swarm" ;
     Malleable_error.return t
 
+  (* A swarm task's image is pulled by the node's own dockerd, not by the CLI
+     that ran `docker stack deploy`. dockerd does not read the CLI's
+     credHelpers, and on the CI agents it is not covered by the docker shim
+     that routes GAR pulls through the registry cache, so it cannot fetch a
+     private image at all: the task is Rejected with "No such image" and
+     retried forever, and the stack never converges.
+
+     Pulling through the CLI first removes the node's need for a registry: a
+     locally present image satisfies the task outright.
+
+     Best-effort on purpose. An image built locally and never pushed -- a
+     developer's own tag -- has no registry to be pulled from, and that must
+     not fail the run. When the pull fails the node may still have the image,
+     so log it and let the deploy proceed. *)
+  let pull_images ~logger images =
+    let open Deferred.Let_syntax in
+    Deferred.List.iter images ~f:(fun image ->
+        [%log info] "Pulling image $image"
+          ~metadata:[ ("image", `String image) ] ;
+        match%map Util.run_cmd_or_error "/" "docker" [ "pull"; image ] with
+        | Ok _ ->
+            ()
+        | Error error ->
+            [%log warn]
+              "Could not pull $image; continuing, the node must already have \
+               it locally: $error"
+              ~metadata:
+                [ ("image", `String image)
+                ; ("error", `String (Error.to_string_hum error))
+                ] )
+
   let deploy t =
     let logger = t.logger in
     if t.deployed then failwith "network already deployed" ;
-    [%log info] "Deploying stack '%s' from %s" t.stack_name t.docker_dir ;
     let open Malleable_error.Let_syntax in
+    let%bind () =
+      Deferred.bind ~f:Malleable_error.return (pull_images ~logger t.images)
+    in
+    [%log info] "Deploying stack '%s' from %s" t.stack_name t.docker_dir ;
     let%bind (_ : string) =
       Util.run_cmd_or_hard_error t.docker_dir "docker"
         [ "stack"; "deploy"; "-c"; t.docker_compose_file_path; t.stack_name ]


### PR DESCRIPTION
## The failure

Every local integration test on this lineage dies at deploy — `node-a`, `node-b` and the seed sit at `0/1` until the 15-minute timeout, with nothing in the log but repeated `Got bad service statuses`. Fifteen of fifteen failed in [nightly 4367](https://buildkite.com/o-1-labs-2/mina-end-to-end-nightlies/builds/4367).

Running `docker service ps --no-trunc` on the live CI agent gives the reason immediately:

```
Rejected  "No such image: europe-west3-docker.pkg.dev/o1labs-192920/euro-docker-repo/
           mina-daemon:4.0.0-devnet-mesa-…-bullseye-devnet-generic"
```

## Root cause

A swarm task's image is pulled by **the node's own dockerd**, not by the CLI that ran `docker stack deploy`. On the agents, dockerd cannot fetch a private GAR image:

- it does not read the CLI's credential helpers — `/root/.docker/config.json` maps `europe-west3-docker.pkg.dev` to the `gcloud` helper, and `stack deploy` forwards nothing;
- it is not covered by the agent's `/usr/local/bin/docker` shim, which rewrites GAR pulls through the `gar-cache-euro` registry cache and re-tags the result. The shim's own comment is explicit: *"Detect `docker pull` and `docker image pull`; pass everything else through."*

The CLI can reach the image perfectly well — `docker manifest inspect` on that exact tag returns OK. Only the node cannot, so the task is Rejected and retried every 5 seconds forever.

This is not specific to any branch; it only ever worked when the image happened to be present on the agent already.

## The fix

Pull each of the stack's images through the CLI before deploying. A locally present image satisfies the task without the node contacting a registry at all, and the pull goes through the shim, so it uses the GAR cache rather than direct GAR egress.

The pull is **best-effort by design**: an image built locally and never pushed — a developer's own tag — has no registry to be pulled from, and that must not fail the run. On failure the node may still have the image, so the code logs and lets the deploy proceed.

## Diagnostics

Also logs `docker service ps --no-trunc` for services that are not converging — once on the first failed poll, and again at the timeout. `docker service ls` only ever reports `0/1`, which is why this burned the full 15 minutes and left nothing to diagnose.

## Verification

- **On the live agent**, mid-failure: one `docker pull` of the rejected tag took all three stuck services from `0/1` to `1/1` within seconds, and the job continued past the point it had been dying at all night. Nothing else was changed.
- **Locally**, the same daemon build (the `mina-devnet-generic` deb for that commit, from the CI cache) with the image present passes `gossip-consis` end to end — consistency ratio 1.000000, exit 0. That confirms the daemon build was never at fault.

## Base

Targets `backport/19388-release-mesa` rather than `release/mesa`. That branch carries the other fixes this lineage needs — the EOL-bullseye apt-mirror work, the gcloud CLI unpin and the Google apt key dearmor — and the integration tests cannot go green on any one of them alone. Stacking here keeps the whole set testable in one nightly.

## Notes

- `develop` carries the identical `stack deploy` call (`mina_docker.ml:808`) and needs the same fix; happy to port once this is agreed.
- No changelog entry: this is test-harness only, with no user-visible change.
- I could not type-check locally (the build needs a full switch). The file parses cleanly under `ocamlformat` and the change uses only existing APIs, but CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015akBmzRi4Rsvm5sGbhJNon