### PR TITLE
archive: make zkApp content dedup atomic and constrain zkapp_states / zkapp_action_states / zkapp_accounts

### DIFF
--- a/changes/19404.md
+++ b/changes/19404.md
@@ -1,0 +1,9 @@
+archive: make the zkApp state dedup atomic and add UNIQUE constraints to `zkapp_states` and `zkapp_action_states`.
+
+`zkapp_states` had no UNIQUE constraint and was content-deduplicated by a non-atomic SELECT-then-INSERT (`Mina_caqti.select_insert_into_cols`). Two concurrent writers could both find no row and both insert; the resulting duplicate pair then made every later lookup of that content fail permanently with `Received 2 tuples, expected at most one`, because the lookup uses `Conn.find_opt`, which accepts 0 or 1 rows. This broke `mina-archive-hardfork-toolbox populate-genesis-accounts`, which ends in `Failure "Failed to add genesis accounts"` after all its retries fail identically. `zkapp_action_states` had the same defect.
+
+Both tables now carry a named UNIQUE constraint on their element columns, and `Zkapp_states.add_if_doesn't_exist` / `Zkapp_action_states.add_if_doesn't_exist` use `INSERT .. ON CONFLICT .. RETURNING id` instead. All columns of both tables are `NOT NULL`, so the constraint really does reject duplicates, and 32 `int` columns give a btree key far below Postgres' 2704-byte limit. The `?on_conflict` / `upsert_into_cols_returning` helpers are ported verbatim from `develop`.
+
+`upgrade_to_mesa.sql` merges the duplicate rows an affected archive already holds, repoints `zkapp_accounts.app_state_id` and `.action_state_id`, and then adds the constraints. It is idempotent and keeps migration version `0.0.6`, so operators can re-run it on an already-upgraded archive to repair it. `downgrade_to_berkeley.sql` drops both constraints.
+
+`zkapp_states_nullable` and the other zkApp tables with nullable columns are left unchanged: a plain unique index treats two NULLs as distinct, so deduplicating them needs `UNIQUE NULLS NOT DISTINCT`, which requires PostgreSQL 15 or later.

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -139,7 +139,11 @@ CREATE TABLE zkapp_field_array
 /* Fixed-width arrays of algebraic fields, given as id's from
    zkapp_field
 
-   Any element of the array may be NULL, per the NULL convention
+   Any element of the array may be NULL, per the NULL convention.
+
+   No UNIQUE constraint here: a unique index treats two NULLs as distinct, so it
+   would not deduplicate rows that contain NULL. Deduplicating this table needs
+   UNIQUE NULLS NOT DISTINCT, which requires PostgreSQL 15 or later.
 */
 CREATE TABLE zkapp_states_nullable
 ( id                       serial           PRIMARY KEY
@@ -177,7 +181,13 @@ CREATE TABLE zkapp_states_nullable
 , element31                 int		    REFERENCES zkapp_field(id)
 );
 
-/* like zkapp_states_nullable, but elements are not NULL */
+/* like zkapp_states_nullable, but elements are not NULL.
+   The UNIQUE constraint makes the content dedup atomic (INSERT .. ON CONFLICT)
+   instead of a racy SELECT-then-INSERT. All 32 columns are NOT NULL, so the
+   constraint really does reject duplicates. 32 int columns give a btree key of
+   about 132 bytes, far below Postgres' 2704-byte limit -- unlike the unbounded
+   int[] element_ids of zkapp_events/zkapp_field_array, whose UNIQUE had to be
+   dropped. */
 CREATE TABLE zkapp_states
 ( id                       serial           PRIMARY KEY
 , element0                 int              NOT NULL REFERENCES zkapp_field(id)
@@ -212,9 +222,10 @@ CREATE TABLE zkapp_states
 , element29                 int              NOT NULL REFERENCES zkapp_field(id)
 , element30                 int              NOT NULL REFERENCES zkapp_field(id)
 , element31                 int              NOT NULL REFERENCES zkapp_field(id)
+, CONSTRAINT zkapp_states_elements_key UNIQUE (element0, element1, element2, element3, element4, element5, element6, element7, element8, element9, element10, element11, element12, element13, element14, element15, element16, element17, element18, element19, element20, element21, element22, element23, element24, element25, element26, element27, element28, element29, element30, element31)
 );
 
-/* like zkapp_states, but for action states */
+/* like zkapp_states, but for action states (see zkapp_states on the UNIQUE) */
 CREATE TABLE zkapp_action_states
 ( id                       serial           PRIMARY KEY
 , element0                 int              NOT NULL REFERENCES zkapp_field(id)
@@ -222,6 +233,7 @@ CREATE TABLE zkapp_action_states
 , element2                 int              NOT NULL REFERENCES zkapp_field(id)
 , element3                 int              NOT NULL REFERENCES zkapp_field(id)
 , element4                 int              NOT NULL REFERENCES zkapp_field(id)
+, CONSTRAINT zkapp_action_states_elements_key UNIQUE (element0, element1, element2, element3, element4)
 );
 
 /* the element_ids are non-NULL, and refer to zkapp_field_array

--- a/src/app/archive/downgrade_to_berkeley.sql
+++ b/src/app/archive/downgrade_to_berkeley.sql
@@ -2,6 +2,9 @@
 -- Mina rollback: from mesa to berkeley
 -- + remove zkapp_states.element31..element8 (int)
 -- + remove zkapp_states_nullable.element31..element8 (int)
+-- + drop the zkapp_{states,action_states} element UNIQUE constraints
+--   (rows merged by the upgrade are NOT split back apart; that is not lossy,
+--   the duplicates carried no information)
 -- NOTE: the element_ids UNIQUE/index drop and the events_id/actions_id NULL change
 --   are intentionally NOT reversed here (lossy): post-fix data may hold duplicate
 --   element_ids arrays and NULL events_id/actions_id, and a btree over the
@@ -111,6 +114,14 @@ BEGIN
           latest_migration_version;
     END IF;
 END$$;
+
+-- 1b. Drop the zkapp state UNIQUE constraints added by the Mesa upgrade.
+-- Berkeley has no such constraints. zkapp_states' constraint would also be
+-- dropped implicitly by removing element8..element31 below, but drop it
+-- explicitly so the rollback is not order-dependent. zkapp_action_states keeps
+-- all its columns, so its constraint must be dropped here. Idempotent.
+ALTER TABLE zkapp_states DROP CONSTRAINT IF EXISTS zkapp_states_elements_key;
+ALTER TABLE zkapp_action_states DROP CONSTRAINT IF EXISTS zkapp_action_states_elements_key;
 
 -- 2. `zkapp_states`: Remove columns element31..element8
 

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -474,8 +474,13 @@ module Zkapp_states = struct
       Pickles_types.Vector.of_list_and_length_exn element_ids
         Mina_base.Zkapp_state.Max_state_size.n
     in
-    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
-      ~table_name ~cols:(names, typ)
+    (* Atomic upsert against [zkapp_states_elements_key]. A plain
+       SELECT-then-INSERT is not atomic: two writers can both find no row and
+       both insert, and the resulting duplicate pair makes every later content
+       lookup fail with "Received 2 tuples, expected at most one". *)
+    Mina_caqti.upsert_into_cols_returning
+      ~on_conflict:(String.concat ~sep:"," names)
+      ~returning:("id", Caqti_type.int) ~table_name ~cols:(names, typ)
       (module Conn)
       t
 
@@ -511,8 +516,11 @@ module Zkapp_action_states = struct
       Pickles_types.Vector.of_list_and_length_exn element_ids
         Pickles_types.Nat.N5.n
     in
-    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
-      ~table_name ~cols:(names, typ)
+    (* Atomic upsert against [zkapp_action_states_elements_key]; see
+       [Zkapp_states.add_if_doesn't_exist]. *)
+    Mina_caqti.upsert_into_cols_returning
+      ~on_conflict:(String.concat ~sep:"," names)
+      ~returning:("id", Caqti_type.int) ~table_name ~cols:(names, typ)
       (module Conn)
       t
 

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -418,6 +418,64 @@ let%test_module "Archive node unit tests" =
       | Error e ->
           failwith @@ Caqti_error.show e
 
+    (* Regression test for the duplicate [zkapp_states] rows that made
+       [mina-archive-hardfork-toolbox populate-genesis-accounts] fail with
+       "Received 2 tuples, expected at most one". The table had no UNIQUE
+       constraint and was content-deduplicated by a non-atomic
+       SELECT-then-INSERT, so two writers could both find no row and both
+       insert. The resulting duplicate pair then made every later lookup of
+       that content fail permanently. The dedup is now an atomic upsert against
+       [zkapp_states_elements_key], and the constraint makes the duplicate pair
+       impossible in the first place. *)
+    let%test_unit "Zkapp_states: dedup is idempotent and duplicate rows are \
+                   rejected" =
+      let conn = Lazy.force conn_lazy in
+      Thread_safe.block_on_async_exn
+      @@ fun () ->
+      (* Any valid app_state works: both assertions hold whether or not the row
+         already exists from an earlier run. *)
+      let app_state = Zkapp_account.default.app_state in
+      let%bind () =
+        match%map
+          let open Deferred.Result.Let_syntax in
+          let%bind id =
+            Processor.Zkapp_states.add_if_doesn't_exist conn app_state
+          in
+          let%map id' =
+            Processor.Zkapp_states.add_if_doesn't_exist conn app_state
+          in
+          [%test_result: int] ~expect:id id'
+        with
+        | Ok () ->
+            ()
+        | Error e ->
+            failwith @@ Caqti_error.show e
+      in
+      (* The pre-fix insert path: a bare INSERT of the same content. The UNIQUE
+         constraint must reject it. *)
+      match%map
+        let open Deferred.Result.Let_syntax in
+        let%bind element_ids =
+          Mina_caqti.deferred_result_list_map
+            (Zkapp_state.V.to_list app_state)
+            ~f:(Processor.Zkapp_field.add_if_doesn't_exist conn)
+        in
+        let t =
+          Pickles_types.Vector.of_list_and_length_exn element_ids
+            Zkapp_state.Max_state_size.n
+        in
+        Mina_caqti.insert_into_cols_returning ~returning:("id", Caqti_type.int)
+          ~table_name:"zkapp_states"
+          ~cols:(Processor.Zkapp_states.names, Processor.Zkapp_states.typ)
+          conn t
+      with
+      | Ok _ ->
+          failwith
+            "inserting a duplicate zkapp_states row succeeded; the \
+             zkapp_states_elements_key UNIQUE constraint is missing"
+      | Error _ ->
+          ()
+
     (* Regression test for the hardfork "fork genesis" bug that breaks Rosetta
        balance reconciliation at the fork boundary. A hard fork restarts the
        chain at a genesis block whose [blockchain_length] is [fork.blockchain_length

--- a/src/app/archive/upgrade_to_mesa.sql
+++ b/src/app/archive/upgrade_to_mesa.sql
@@ -5,6 +5,8 @@
 -- + drop UNIQUE/index on zkapp_{events,field_array}.element_ids (btree overflow
 --   for max-cost zkApps); these rows are no longer content-deduplicated
 -- + make zkapp_account_update_body.events_id/actions_id nullable (NULL = empty)
+-- + deduplicate zkapp_{states,action_states} and add a UNIQUE constraint on
+--   their element columns, so the content dedup becomes atomic
 -- + record status in migration_history
 -- =============================================================================
 
@@ -93,7 +95,7 @@ BEGIN
         ) VALUES (
             target_protocol_version,
             target_migration_version,
-            'Upgrade from Berkeley to Mesa. Add {zkapp_states,zkapp_states_nullable}.element8..element31 (int); drop zkapp_{events,field_array}.element_ids UNIQUE/index (no dedup); make zkapp_account_update_body.{events_id,actions_id} nullable (NULL=empty)',
+            'Upgrade from Berkeley to Mesa. Add {zkapp_states,zkapp_states_nullable}.element8..element31 (int); drop zkapp_{events,field_array}.element_ids UNIQUE/index (no dedup); make zkapp_account_update_body.{events_id,actions_id} nullable (NULL=empty); dedup zkapp_{states,action_states} and add UNIQUE on their element columns',
             'starting'::migration_status
         );
     ELSIF 
@@ -253,6 +255,77 @@ ALTER TABLE zkapp_events DROP CONSTRAINT IF EXISTS zkapp_events_element_ids_key;
 DROP INDEX IF EXISTS idx_zkapp_events_element_ids;
 ALTER TABLE zkapp_account_update_body ALTER COLUMN events_id DROP NOT NULL;
 ALTER TABLE zkapp_account_update_body ALTER COLUMN actions_id DROP NOT NULL;
+
+-- 3c. Deduplicate zkapp_states / zkapp_action_states and constrain them.
+-- Both tables were content-deduplicated by a non-atomic SELECT-then-INSERT and
+-- had no UNIQUE constraint, so two concurrent writers could both miss and both
+-- insert. Every later lookup of that content then failed permanently with
+-- "Received 2 tuples, expected at most one". Merge the existing duplicates,
+-- repoint the referencing rows, then add the UNIQUE constraint that makes the
+-- dedup atomic. All idempotent: with no duplicates and the constraint already
+-- present, this is a no-op.
+
+-- 3c.i  zkapp_states: zkapp_accounts.app_state_id is the only reference.
+CREATE TEMP TABLE zkapp_states_dups AS
+SELECT (array_agg(id ORDER BY id))[1]          AS keep_id
+     , unnest((array_agg(id ORDER BY id))[2:]) AS dup_id
+FROM zkapp_states t
+GROUP BY to_jsonb(t) - 'id'
+HAVING count(*) > 1;
+
+UPDATE zkapp_accounts a
+SET    app_state_id = d.keep_id
+FROM   zkapp_states_dups d
+WHERE  a.app_state_id = d.dup_id;
+
+DELETE FROM zkapp_states WHERE id IN (SELECT dup_id FROM zkapp_states_dups);
+
+DROP TABLE zkapp_states_dups;
+
+-- 3c.ii zkapp_action_states: zkapp_accounts.action_state_id is the only
+--       reference.
+CREATE TEMP TABLE zkapp_action_states_dups AS
+SELECT (array_agg(id ORDER BY id))[1]          AS keep_id
+     , unnest((array_agg(id ORDER BY id))[2:]) AS dup_id
+FROM zkapp_action_states t
+GROUP BY to_jsonb(t) - 'id'
+HAVING count(*) > 1;
+
+UPDATE zkapp_accounts a
+SET    action_state_id = d.keep_id
+FROM   zkapp_action_states_dups d
+WHERE  a.action_state_id = d.dup_id;
+
+DELETE FROM zkapp_action_states
+WHERE id IN (SELECT dup_id FROM zkapp_action_states_dups);
+
+DROP TABLE zkapp_action_states_dups;
+
+-- 3c.iii Add the UNIQUE constraints. ALTER TABLE ADD CONSTRAINT is not
+--        idempotent on its own, so guard on pg_constraint. Building the index
+--        takes an ACCESS EXCLUSIVE lock; the statement_timeout above bounds it.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'zkapp_states_elements_key'
+    ) THEN
+        ALTER TABLE zkapp_states
+          ADD CONSTRAINT zkapp_states_elements_key UNIQUE (element0, element1, element2, element3, element4, element5, element6, element7, element8, element9, element10, element11, element12, element13, element14, element15, element16, element17, element18, element19, element20, element21, element22, element23, element24, element25, element26, element27, element28, element29, element30, element31);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'zkapp_action_states_elements_key'
+    ) THEN
+        ALTER TABLE zkapp_action_states
+          ADD CONSTRAINT zkapp_action_states_elements_key UNIQUE (element0, element1, element2, element3, element4);
+    END IF;
+EXCEPTION
+    WHEN OTHERS THEN
+        PERFORM pg_temp.set_migration_status('failed'::migration_status);
+        RAISE EXCEPTION 'An error occurred while adding the zkapp state UNIQUE constraints: %', SQLERRM;
+END
+$$;
 
 -- 4. Update schema_history
 

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -376,16 +376,29 @@ let select_cols_from_id ~(table_name : string) ~(cols : string list) : string =
    The optional `tannot` function maps column names to type annotations.
    No type annotation is included if `tannot` returns an empty string. *)
 let insert_into_cols ~(returning : string) ~(table_name : string)
-    ?(tannot : string -> string option = Fn.const None) ~(cols : string list) ()
-    : string =
+    ?(tannot : string -> string option = Fn.const None) ~(cols : string list)
+    ?(on_conflict : string option) () : string =
   let values =
     List.map cols ~f:(fun col ->
         match tannot col with None -> "?" | Some tannot -> "?::" ^ tannot )
     |> String.concat ~sep:", "
   in
-  sprintf "INSERT INTO %s (%s) VALUES (%s) RETURNING %s" table_name
-    (String.concat ~sep:", " cols)
-    values returning
+  let insert =
+    sprintf "INSERT INTO %s (%s) VALUES (%s)" table_name
+      (String.concat ~sep:", " cols)
+      values
+  in
+  match on_conflict with
+  | Some col ->
+      let assignments =
+        String.split col ~on:',' |> List.map ~f:String.strip
+        |> List.map ~f:(fun col -> sprintf "%s = EXCLUDED.%s" col col)
+        |> String.concat ~sep:", "
+      in
+      sprintf "%s ON CONFLICT (%s) DO UPDATE SET %s RETURNING %s" insert col
+        assignments returning
+  | None ->
+      sprintf "%s RETURNING %s" insert returning
 
 (* run `select_cols` and return the result, if found
    if not found, run `insert_into_cols` and return the result
@@ -453,6 +466,32 @@ let insert_into_cols_returning ~(returning : string * 'r Caqti_type.t)
     ( Caqti_request.Infix.(snd cols ->! snd returning)
     @@ insert_into_cols ~returning:(fst returning) ~table_name ?tannot
          ~cols:(fst cols) () )
+    value
+
+(* Like [insert_into_cols] but generates an upsert:
+   INSERT INTO table (cols) VALUES (params)
+   ON CONFLICT (on_conflict) DO UPDATE SET on_conflict = EXCLUDED.on_conflict
+   RETURNING returning.
+   The DO UPDATE is a no-op that returns the existing row's id when a conflict
+   occurs, preventing UNIQUE violation errors under concurrent insertion. *)
+let upsert_into_cols ~(on_conflict : string) ~(returning : string)
+    ~(table_name : string) ?(tannot : string -> string option = Fn.const None)
+    ~(cols : string list) () : string =
+  insert_into_cols ~returning ~table_name ~tannot ~cols ~on_conflict ()
+
+(* Upsert with ON CONFLICT, returning the id of either the newly inserted row
+   or the existing row that caused the conflict. Unlike
+   [select_insert_into_cols] this is atomic: it needs no separate content
+   lookup, so concurrent writers cannot both miss and both insert. It requires
+   a UNIQUE constraint (or unique index) on [on_conflict]. *)
+let upsert_into_cols_returning ~(on_conflict : string)
+    ~(returning : string * 'r Caqti_type.t) ~(table_name : string) ?tannot
+    ~(cols : string list * 'cols Caqti_type.t) (module Conn : CONNECTION)
+    (value : 'cols) =
+  Conn.find
+    ( Caqti_request.Infix.(snd cols ->! snd returning)
+    @@ upsert_into_cols ~on_conflict ~returning:(fst returning) ~table_name
+         ?tannot ~cols:(fst cols) () )
     value
 
 (* No-dedup multi-row insert of one column's pre-rendered SQL literals, returning


### PR DESCRIPTION
## Problem

`mina-archive-hardfork-toolbox populate-genesis-accounts` fails on a Mesa archive:

```
35 batches failed with
  Received 2 tuples, expected at most one.
  Query: "SELECT id FROM zkapp_states WHERE (element0 = $1 OR (element0 IS NULL AND $1 IS ..."
...
monitor.ml.Error (Failure "Failed to add genesis accounts")
```

`zkapp_states` has **no UNIQUE constraint** — `create_schema.sql` gives it only `id serial PRIMARY KEY`. Its content dedup is a **non-atomic SELECT-then-INSERT** (`Mina_caqti.select_insert_into_cols`): the code first looks for a row with the same content and inserts only if it finds none.

Two writers can therefore both find no row and both insert. Once that duplicate pair exists, the `Conn.find_opt` in the lookup — which accepts 0 or 1 rows — fails for that content **permanently**. This is why 35 batches failed, why all 3 retries failed identically, and why the run then raised `failwith "Failed to add genesis accounts"` (`processor.ml:4836`).

The toolbox run itself is fully sequential (`Deferred.List.mapi` and `Deferred.List.map` both default to `` `Sequential ``), so it cannot create the duplicate inside one run. The duplicates were already in the database, written by a second concurrent writer — an archive node started with `--config-file` (which runs the same `add_genesis_accounts`), a parallel `mina-archive-blocks` backfill, or two overlapping toolbox runs.

`zkapp_action_states` has the identical shape and the identical defect.

## Fix

**Schema** (`create_schema.sql`)
- `CONSTRAINT zkapp_states_elements_key UNIQUE (element0 .. element31)`
- `CONSTRAINT zkapp_action_states_elements_key UNIQUE (element0 .. element4)`

All columns of both tables are `NOT NULL`, so the constraint really does reject duplicates. 32 `int` columns give a btree key of about 132 bytes, far below Postgres' 2704-byte limit — unlike the unbounded `int[] element_ids` of `zkapp_events` / `zkapp_field_array`, whose UNIQUE had to be dropped. The constraint also turns the present 32-predicate sequential scan into an index scan.

**Code** (`processor.ml`, `mina_caqti.ml`)
- `Zkapp_states.add_if_doesn't_exist` and `Zkapp_action_states.add_if_doesn't_exist` now use `INSERT .. ON CONFLICT (elements) DO UPDATE .. RETURNING id`, which is atomic and needs no separate lookup.
- `insert_into_cols ?on_conflict`, `upsert_into_cols` and `upsert_into_cols_returning` are ported **verbatim from `develop`**, where they already exist and are already used for `public_keys`, `zkapp_commands`, `blocks` and others. This keeps future `develop` merges clean.

**Migration** (`upgrade_to_mesa.sql`, new section 3c)
- Merges existing duplicate rows in both tables, repoints `zkapp_accounts.app_state_id` / `.action_state_id` (the only references), deletes the surplus rows, then adds the two constraints.
- Idempotent, and the migration version stays at `0.0.6` on purpose: the guard's `ELSIF` branch lets an already-upgraded database re-run the script ("Previous migration in progress/completed, reapplying"). Bumping the version would instead make it abort. Operators of an already-upgraded archive can therefore just re-run this script to repair it.

**Rollback** (`downgrade_to_berkeley.sql`)
- Drops both constraints. Berkeley has none. `zkapp_action_states` keeps all its columns, so its constraint must be dropped explicitly.

## Not changed, on purpose

`zkapp_states_nullable` and the other zkApp tables with nullable columns (`zkapp_accounts`, `zkapp_permissions`, `zkapp_updates`, the bound tables) keep the racy pattern. A plain unique index treats two NULLs as distinct, so it would not deduplicate them; that needs `UNIQUE NULLS NOT DISTINCT`, which requires PostgreSQL 15 or later. This is recorded as a comment in `create_schema.sql`.

## Test

`src/app/archive/lib/test.ml`: asserts that `Zkapp_states.add_if_doesn't_exist` returns the same id when called twice, and that the pre-fix bare INSERT of the same content is rejected by the constraint.

## Operational note

`ALTER TABLE .. ADD CONSTRAINT UNIQUE` takes an `ACCESS EXCLUSIVE` lock while it builds the index. The script's existing `lock_timeout = '10s'` and `statement_timeout = '10min'` bound it, so stop the archive writers before running the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnxNWEr7BaSnbTp3DrvJGV