### PR TITLE
Signature_lib: add regtest + documentation (port of #17629)

### DIFF
--- a/src/lib/crypto/signature_lib/schnorr.ml
+++ b/src/lib/crypto/signature_lib/schnorr.ml
@@ -1,15 +1,54 @@
+(** Schnorr Digital Signature Implementation
+
+    This module implements Schnorr signatures for the Mina protocol, providing
+    both legacy and chunked message variants. Schnorr signatures are used for
+    transaction authorization and other cryptographic operations in the
+    protocol.
+
+    Message formats:
+    - Legacy: Uses bitstring arrays (older format for backward compatibility)
+    - Chunked: Packs small values into field elements (more efficient)
+
+    The implementation supports:
+    - Mainnet, testnet, and custom network signatures
+    - Both unchecked (native) and checked (constraint system) verification
+    - Legacy and chunked message formats for backward compatibility
+    - Elliptic curve operations over the Pasta curves used in Mina
+
+    For detailed specification, see:
+    https://github.com/MinaProtocol/mina/tree/compatible/docs/specs/signatures
+*)
+
 module Bignum_bigint = Bigint
 open Core_kernel
 
+(** Message interface for Schnorr signature operations.
+
+    This interface defines how messages are processed for signature generation
+    and verification, including key derivation and hashing operations.
+*)
 module type Message_intf = sig
+  (** Base field element type *)
   type field
 
+  (** Message type to be signed *)
   type t
 
+  (** Elliptic curve point type *)
   type curve
 
+  (** Curve scalar field element type *)
   type curve_scalar
 
+  (** Derive a scalar value from message, private key, and public key.
+      Used for generating the ephemeral key k in signature generation.
+
+      @param signature_kind Network type (Mainnet/Testnet/Other)
+      @param t Message to be signed
+      @param private_key Signer's private key
+      @param public_key Signer's public key
+      @return Derived scalar value for signature generation
+  *)
   val derive :
        signature_kind:Mina_signature_kind.t
     -> t
@@ -17,12 +56,24 @@ module type Message_intf = sig
     -> public_key:curve
     -> curve_scalar
 
+  (** Mainnet-specific derivation function *)
   val derive_for_mainnet :
     t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
 
+  (** Testnet-specific derivation function *)
   val derive_for_testnet :
     t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
 
+  (** Hash function for signature verification.
+      Computes the challenge value e = H(m || pk || r) used in signature
+      verification.
+
+      @param signature_kind Network type
+      @param t Message being verified
+      @param public_key Signer's public key
+      @param r R component of the signature
+      @return Challenge scalar for verification
+  *)
   val hash :
        signature_kind:Mina_signature_kind.t
     -> t
@@ -30,10 +81,13 @@ module type Message_intf = sig
     -> r:field
     -> curve_scalar
 
+  (** Mainnet-specific hash function *)
   val hash_for_mainnet : t -> public_key:curve -> r:field -> curve_scalar
 
+  (** Testnet-specific hash function *)
   val hash_for_testnet : t -> public_key:curve -> r:field -> curve_scalar
 
+  (** Circuit variable types for checked computation *)
   type field_var
 
   type boolean_var
@@ -46,6 +100,8 @@ module type Message_intf = sig
 
   type _ checked
 
+  (** Checked (in-circuit) version of hash function for constraint system
+      verification *)
   val hash_checked :
        signature_kind:Mina_signature_kind.t
     -> var
@@ -54,19 +110,31 @@ module type Message_intf = sig
     -> curve_scalar_var checked
 end
 
+(** Main Schnorr signature module signature.
+
+    This signature defines the complete interface for Schnorr signature
+    operations including key types, signature operations, and both native and
+    constraint system verification.
+*)
 module type S = sig
+  (** The underlying constraint system implementation *)
   module Impl : Snarky_backendless.Snark_intf.S
 
   open Impl
 
+  (** Elliptic curve point type *)
   type curve
 
+  (** Circuit variable type for curve points *)
   type curve_var
 
+  (** Scalar field element type *)
   type curve_scalar
 
+  (** Circuit variable type for scalars *)
   type curve_scalar_var
 
+  (** Module for shifted curve representations used in circuits *)
   module Shifted : sig
     module type S =
       Snarky_curves.Shifted_intf
@@ -75,6 +143,7 @@ module type S = sig
          and type 'a checked := 'a Checked.t
   end
 
+  (** Message module instance conforming to Message_intf *)
   module Message :
     Message_intf
       with type boolean_var := Boolean.var
@@ -86,27 +155,40 @@ module type S = sig
        and type field := Field.t
        and type field_var := Field.Var.t
 
+  (** Schnorr signature representation *)
   module Signature : sig
+    (** A signature is a pair (r, s) where r is a field element and s is a
+        scalar *)
     type t = field * curve_scalar [@@deriving sexp]
 
+    (** Circuit variable version of signature *)
     type var = Field.Var.t * curve_scalar_var
 
+    (** Type conversion for constraint system circuits *)
     val typ : (var, t) Typ.t
   end
 
   module Private_key : sig
+    (** Private key is a curve scalar *)
     type t = curve_scalar [@@deriving sexp]
   end
 
+  (** Public key representation *)
   module Public_key : sig
+    (** Public key is a curve point *)
     type t = curve [@@deriving sexp]
 
+    (** Circuit variable version *)
     type var = curve_var
   end
 
+  (** Constraint system checked computation functions *)
   module Checked : sig
+    (** Compress a curve point to its bit representation *)
     val compress : curve_var -> Boolean.var list Checked.t
 
+    (** Verify a signature in a constraint system circuit, returning boolean
+        result *)
     val verifies :
          signature_kind:Mina_signature_kind.t
       -> (module Shifted.S with type t = 't)
@@ -115,6 +197,8 @@ module type S = sig
       -> Message.var
       -> Boolean.var Checked.t
 
+    (** Assert that a signature verifies in a constraint system circuit (fails
+        if invalid) *)
     val assert_verifies :
          signature_kind:Mina_signature_kind.t
       -> (module Shifted.S with type t = 't)
@@ -124,14 +208,30 @@ module type S = sig
       -> unit Checked.t
   end
 
+  (** Compress a curve point to its bit representation (native version) *)
   val compress : curve -> bool list
 
+  (** Sign a message with a private key
+
+      @param signature_kind Network type for signature
+      @param private_key Signer's private key
+      @param message Message to sign
+      @return Schnorr signature (r, s)
+  *)
   val sign :
        signature_kind:Mina_signature_kind.t
     -> Private_key.t
     -> Message.t
     -> Signature.t
 
+  (** Verify a signature
+
+      @param signature_kind Network type
+      @param signature The signature to verify
+      @param public_key Signer's public key
+      @param message Original message
+      @return true if signature is valid, false otherwise
+  *)
   val verify :
        signature_kind:Mina_signature_kind.t
     -> Signature.t
@@ -140,48 +240,77 @@ module type S = sig
     -> bool
 end
 
+(** Functor to create a Schnorr signature implementation.
+
+    This functor takes a constraint system implementation and curve
+    specification to create a concrete Schnorr signature module. It implements
+    the complete signature interface including signing, verification, and
+    constraint system circuit operations.
+
+    @param Impl The constraint system implementation (typically Tick)
+    @param Curve Elliptic curve specification with required operations
+    @param Message Message processing module for this signature instance
+*)
 module Make
     (Impl : Snarky_backendless.Snark_intf.S) (Curve : sig
       open Impl
 
+      (** Curve scalar field operations *)
       module Scalar : sig
+        (** Scalar field element type *)
         type t [@@deriving sexp, equal]
 
+        (** Circuit variable for scalars *)
         type var
 
+        (** Type conversion for constraint systems *)
         val typ : (var, t) Typ.t
 
+        (** Zero element *)
         val zero : t
 
+        (** Scalar multiplication *)
         val ( * ) : t -> t -> t
 
+        (** Scalar addition *)
         val ( + ) : t -> t -> t
 
+        (** Scalar negation *)
         val negate : t -> t
 
+        (** Constraint system checked operations *)
         module Checked : sig
+          (** Convert scalar to bit representation for circuit use *)
           val to_bits : var -> Boolean.var Bitstring_lib.Bitstring.Lsb_first.t
         end
       end
 
+      (** Elliptic curve point type *)
       type t [@@deriving sexp]
 
+      (** Circuit variable for curve points (affine coordinates) *)
       type var = Field.Var.t * Field.Var.t
 
+      (** Constraint system checked curve operations *)
       module Checked :
         Snarky_curves.Weierstrass_checked_intf
           with module Impl := Impl
            and type t = var
            and type unchecked := t
 
+      (** Curve generator point *)
       val one : t
 
+      (** Point addition *)
       val ( + ) : t -> t -> t
 
+      (** Point negation *)
       val negate : t -> t
 
+      (** Scalar multiplication: scale point by scalar *)
       val scale : t -> Scalar.t -> t
 
+      (** Convert point to affine coordinates (x, y) *)
       val to_affine_exn : t -> Field.t * Field.t
     end)
     (Message : Message_intf
@@ -222,17 +351,29 @@ module Make
   end =
     Curve
 
+  (** Compress a curve point to its x-coordinate in bit representation *)
   let compress (t : Curve.t) =
     let x, _ = Curve.to_affine_exn t in
     Field.unpack x
 
+  (** Check if a field element is even (used for point compression) *)
   let is_even (t : Field.t) = not (Bigint.test_bit (Bigint.of_field t) 0)
 
+  (** Sign a message using Schnorr signatures.
+
+      Implementation follows the standard Schnorr signature algorithm:
+      1. Derive ephemeral key k from message, private key, and public key
+      2. Compute R = k * G (ensure R has even y-coordinate)
+      3. Compute challenge e = H(m || pk || r)
+      4. Compute s = k + e * d
+      5. Return signature (r, s)
+  *)
   let sign ~signature_kind (d_prime : Private_key.t) (m : Message.t) =
     let public_key =
       (* TODO: Don't recompute this. *) Curve.scale Curve.one d_prime
     in
-    (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
+    (* TODO: Once we switch to implicit sign-bit we'll have to conditionally
+       negate d_prime. *)
     let d = d_prime in
     let derive = Message.derive ~signature_kind in
     let k_prime = derive m ~public_key ~private_key:d in
@@ -244,6 +385,19 @@ module Make
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
+  (** Verify a Schnorr signature.
+
+      Implementation follows standard Schnorr verification:
+      1. Compute challenge e = H(m || pk || r)
+      2. Compute R' = s * G - e * pk
+      3. Check that R'.x == r and R'.y is even
+
+      @param signature_kind Network type for signature verification
+      @param signature The (r, s) signature pair to verify
+      @param pk The signer's public key
+      @param m The original message
+      @return true if signature is valid, false otherwise
+  *)
   let verify ~signature_kind ((r, s) : Signature.t) (pk : Public_key.t)
       (m : Message.t) =
     let hash = Message.hash ~signature_kind in
@@ -265,8 +419,8 @@ module Make
       let%map bs = Field.Checked.unpack_full y in
       Bitstring_lib.Bitstring.Lsb_first.to_list bs |> List.hd_exn |> Boolean.not
 
-    (* returning r_point as a representable point ensures it is nonzero so the nonzero
-     * check does not have to explicitly be performed *)
+    (* returning r_point as a representable point ensures it is nonzero so the
+     * nonzero check does not have to explicitly be performed *)
 
     let%snarkydef_ verifier (type s) ~signature_kind ~equal ~final_check
         ((module Shifted) as shifted :
@@ -304,13 +458,24 @@ end
 
 open Snark_params
 
+(** Message processing for Schnorr signatures.
+
+    This module provides concrete implementations of the Message_intf for
+    different input formats: Legacy (uses bitstrings) and Chunked (uses packed
+    field elements). Both variants support network-specific signatures through
+    domain separation.
+*)
 module Message = struct
+  (** Network identifier for mainnet (character with value 1) *)
   let network_id_mainnet = String.of_char @@ Char.of_int_exn 1
 
+  (** Network identifier for testnet (character with value 0) *)
   let network_id_testnet = String.of_char @@ Char.of_int_exn 0
 
+  (** Network identifier for custom networks (uses chain name directly) *)
   let network_id_other chain_name = chain_name
 
+  (** Get network identifier string based on signature kind *)
   let network_id ~(signature_kind : Mina_signature_kind.t) =
     match signature_kind with
     | Mainnet ->
@@ -320,11 +485,30 @@ module Message = struct
     | Other_network chain_name ->
         network_id_other chain_name
 
+  (** Legacy message format using bitstrings.
+
+      This variant uses the older Random_oracle.Input.Legacy format which
+      represents packed data as arrays of bitstrings. It's maintained for
+      backward compatibility with older parts of the protocol.
+  *)
   module Legacy = struct
     open Tick
 
+    (** Message type using legacy input format *)
     type t = (Field.t, bool) Random_oracle.Input.Legacy.t [@@deriving sexp]
 
+    (** Derive ephemeral key for signature generation.
+
+        Combines message, public key, private key, and network ID through
+        Blake2 hashing to produce a deterministic but unpredictable scalar for
+        signing.
+
+        @param network_id Network-specific domain separator
+        @param t Message to be signed
+        @param private_key Signer's private key
+        @param public_key Signer's public key
+        @return Derived scalar for signature generation
+    *)
     let make_derive ~network_id t ~private_key ~public_key =
       let input =
         let x, y = Tick.Inner_curve.to_affine_exn public_key in
@@ -394,11 +578,30 @@ module Message = struct
           |> Bitstring_lib.Bitstring.Lsb_first.of_list )
   end
 
+  (** Chunked message format using packed field elements.
+
+      This is the newer message format that uses Random_oracle.Input.Chunked,
+      which efficiently packs small values together into field elements rather
+      than using bitstrings. This format is more efficient in constraint
+      systems and is used for newer protocol features.
+  *)
   module Chunked = struct
     open Tick
 
+    (** Message type using chunked input format *)
     type t = Field.t Random_oracle.Input.Chunked.t [@@deriving sexp]
 
+    (** Derive ephemeral key for signature generation using chunked format.
+
+        Similar to Legacy.make_derive but uses the more efficient chunked input
+        format for better constraint system performance.
+
+        @param network_id Network-specific domain separator
+        @param t Message to be signed
+        @param private_key Signer's private key
+        @param public_key Signer's public key
+        @return Derived scalar for signature generation
+    *)
     let make_derive ~network_id t ~private_key ~public_key =
       let input =
         let x, y = Tick.Inner_curve.to_affine_exn public_key in
@@ -469,20 +672,35 @@ module Message = struct
   end
 end
 
+(** Legacy Schnorr signature implementation using bitstring message format *)
 module Legacy = Make (Tick) (Tick.Inner_curve) (Message.Legacy)
+
+(** Chunked Schnorr signature implementation using packed field element
+    message format *)
 module Chunked = Make (Tick) (Tick.Inner_curve) (Message.Chunked)
 
+(** Generator for testing Legacy signatures.
+    Creates random private key and message pairs for property-based testing.
+*)
 let gen_legacy =
   let open Quickcheck.Let_syntax in
   let%map pk = Private_key.gen and msg = Tick.Field.gen in
   (pk, Random_oracle.Input.Legacy.field_elements [| msg |])
 
+(** Generator for testing Chunked signatures.
+    Creates random private key and message pairs for property-based testing.
+*)
 let gen_chunked =
   let open Quickcheck.Let_syntax in
   let%map pk = Private_key.gen and msg = Tick.Field.gen in
   (pk, Random_oracle.Input.Chunked.field_elements [| msg |])
 
-(* Use for reading only. *)
+(** Type descriptor for Legacy messages in constraint systems.
+    Used for reading Legacy message variables in circuits (read-only).
+
+    @return Type descriptor for converting between Legacy message values and
+            circuit variables
+*)
 let legacy_message_typ () : (Message.Legacy.var, Message.Legacy.t) Tick.Typ.t =
   let to_hlist { Random_oracle.Input.Legacy.field_elements; bitstrings } =
     H_list.[ field_elements; bitstrings ]
@@ -498,7 +716,12 @@ let legacy_message_typ () : (Message.Legacy.var, Message.Legacy.t) Tick.Typ.t =
     ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
     ~value_of_hlist:of_hlist
 
-(* Use for reading only. *)
+(** Type descriptor for Chunked messages in constraint systems.
+    Used for reading Chunked message variables in circuits (read-only).
+
+    @return Type descriptor for converting between Chunked message values and
+            circuit variables
+*)
 let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
     =
   let open Tick.Typ in
@@ -527,7 +750,7 @@ let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
     ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
     ~value_of_hlist:of_hlist
 
-let%test_unit "schnorr checked + unchecked" =
+let%test_unit "schnorr legacy checked + unchecked" =
   let signature_kind = Mina_signature_kind.Testnet in
   Quickcheck.test ~trials:5 gen_legacy ~f:(fun (pk, msg) ->
       let s = Legacy.sign ~signature_kind pk msg in
@@ -549,7 +772,7 @@ let%test_unit "schnorr checked + unchecked" =
          (fun _ -> true) )
         (pubkey, msg, s) )
 
-let%test_unit "schnorr checked + unchecked" =
+let%test_unit "schnorr chunked checked + unchecked" =
   let signature_kind = Mina_signature_kind.Testnet in
   Quickcheck.test ~trials:5 gen_chunked ~f:(fun (pk, msg) ->
       let s = Chunked.sign ~signature_kind pk msg in

--- a/src/lib/crypto/signature_lib/test/signature_lib_tests.ml
+++ b/src/lib/crypto/signature_lib/test/signature_lib_tests.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 open Signature_lib
 
 let signature_kind = Mina_signature_kind.Testnet
@@ -46,28 +47,56 @@ let test_signature_of_signature_matches () =
     && Snark_params.Tock.Field.equal (snd signature_expected)
          (snd signature_got) )
 
-let test_signature_of_fields_123_matches () =
-  let signature_got =
-    Schnorr.Chunked.sign ~signature_kind secondPrivkey
-      (Random_oracle_input.Chunked.field_elements
-         [| Snark_params.Tick.Field.of_int 1
-          ; Snark_params.Tick.Field.of_int 2
-          ; Snark_params.Tick.Field.of_int 3
-         |] )
+(* Test vectors generated from commit 25c79e98fd15381846e00567ddc9400f230d8778
+   from the repository MinaProtocol/Mina *)
+let test_regtest_chunked () =
+  let inputs =
+    [ ( Signature_lib.Private_key.to_string secondPrivkey
+      , Mina_signature_kind_type.Testnet )
+    ; ("1", Mina_signature_kind_type.Mainnet)
+    ; ("1", Mina_signature_kind_type.Testnet)
+    ; ( "28948022309329048855892746252171976963363056481941560715954676764349967630337"
+      , Mina_signature_kind_type.Mainnet )
+      (* Base field modulus *)
+    ; ( "28948022309329048855892746252171976963363056481941560715954676764349967630337"
+      , Mina_signature_kind_type.Testnet )
+    ]
   in
-  (* The expected value has been generated using the commit [19872b9] of [MinaProtocol/mina] *)
-  let signature_expected =
-    ( Snark_params.Tick.Field.of_string
-        "20765817320000234273433345899587917625188885976914380365037035465312392849949"
-    , Snark_params.Tock.Field.of_string
-        "1002418623751815063744079415040141105602079382674393704838141255389705661040"
-    )
+  let msg =
+    Random_oracle_input.Chunked.field_elements
+      [| Snark_params.Tick.Field.of_int 1
+       ; Snark_params.Tick.Field.of_int 2
+       ; Snark_params.Tick.Field.of_int 3
+      |]
   in
-  Alcotest.(check bool)
-    "signature of fields 1,2,3 matches" true
-    ( Snark_params.Tick.Field.equal (fst signature_expected) (fst signature_got)
-    && Snark_params.Tock.Field.equal (snd signature_expected)
-         (snd signature_got) )
+  let exp_output =
+    [ ( "20765817320000234273433345899587917625188885976914380365037035465312392849949"
+      , "1002418623751815063744079415040141105602079382674393704838141255389705661040"
+      )
+    ; ( "22084905263324308757092642598591805622573916921561788090659474572435157367756"
+      , "19351823962922404057512863823076292367935996544780933374359034777579697928791"
+      )
+    ; ( "9365513903930360449644312393516794745401878006145737752476277731408665582105"
+      , "25029729239256401411302994504645804731976878506233839446932935931753134854805"
+      )
+    ; ( "3890977793460169902305887102356482479854802649034532884871979460203652413420"
+      , "25140248108090398907635874689391071833885492936425767745987569696262252218127"
+      )
+    ; ( "12268314766517726787805258774127631264381993554526011548580430759754975404851"
+      , "26841473229575636953810554015462845452716272093792258959066037460219188384031"
+      )
+    ]
+  in
+  let l = List.zip_exn inputs exp_output in
+  List.iter l ~f:(fun ((sk, signature_kind), (exp_r_str, exp_s_str)) ->
+      let sk = Private_key.of_string_exn sk in
+      let r, s = Schnorr.Chunked.sign ~signature_kind sk msg in
+      Alcotest.(check string)
+        "r matches" exp_r_str
+        (Snark_params.Tock.Inner_curve.Scalar.to_string r) ;
+      Alcotest.(check string)
+        "s matches" exp_s_str
+        (Snark_params.Tick.Inner_curve.Scalar.to_string s) )
 
 let () =
   let open Alcotest in
@@ -77,7 +106,7 @@ let () =
             test_signature_of_empty_random_oracle_input_matches
         ; test_case "signature of signature matches" `Quick
             test_signature_of_signature_matches
-        ; test_case "signature of fields 1,2,3 matches" `Quick
-            test_signature_of_fields_123_matches
         ] )
+    ; ( "Regtest test vectors"
+      , [ test_case "chunked" `Quick test_regtest_chunked ] )
     ]

--- a/src/lib/crypto/string_sign/README.md
+++ b/src/lib/crypto/string_sign/README.md
@@ -1,8 +1,16 @@
 # String Sign
 
-A library for signing and verifying strings using Schnorr signatures in the Mina
+**DEPRECATED: This library should not be used anymore.**
+
+The implementation has been moved to `signature_lib`. Please use
+`signature_lib.Schnorr.Legacy` or `signature_lib.Schnorr.Chunked` directly
+for signing operations.
+
+---
+
+~~A library for signing and verifying strings using Schnorr signatures in the Mina
 protocol. This library simplifies the process of signing arbitrary strings and
-verifying those signatures, with support for different network types.
+verifying those signatures, with support for different network types.~~
 
 ## Overview
 

--- a/src/lib/crypto/string_sign/string_sign.ml
+++ b/src/lib/crypto/string_sign/string_sign.ml
@@ -1,4 +1,9 @@
-(* string_sign.ml -- signatures for strings *)
+(* string_sign.ml -- signatures for strings
+
+   DEPRECATED: This library should not be used anymore. The implementation
+   has been moved to signature_lib. Please use signature_lib.Schnorr.Legacy
+   or signature_lib.Schnorr.Chunked directly for signing operations.
+*)
 
 module Inner_curve = Snark_params.Tick.Inner_curve
 open Signature_lib


### PR DESCRIPTION
Port of #17629 by @dannywillems to current `compatible`. Authorship is preserved on the commit.

## Why a port rather than a rebase

#17629 forked at `0eb273bffd` (2025-08-21); `compatible` has gained 3,439 commits since, and **all four files it touches were moved**:

| #17629 path | path today |
|---|---|
| `src/lib/signature_lib/schnorr.ml` | `src/lib/crypto/signature_lib/schnorr.ml` |
| `src/lib/signature_lib/test/signature_lib_tests.ml` | `src/lib/crypto/signature_lib/test/signature_lib_tests.ml` |
| `src/lib/string_sign/README.md` | `src/lib/crypto/string_sign/README.md` |
| `src/lib/string_sign/string_sign.ml` | `src/lib/crypto/string_sign/string_sign.ml` |

A rebase reports the four files as deleted and drops the change on the floor. Relocating the diff is what actually preserves it.

## The port is exact

Three of the four files are **byte-identical** to their fork-point versions — only the directory changed. The fourth, `string_sign.ml`, drifted by 10 lines (`?signature_kind` → `~signature_kind` at lines 56-68), and this change only touches the header comment at lines 1-4, so the two do not overlap.

I diffed the relocated change against the original and they match line for line:

```
IDENTICAL to the original PR diff (modulo paths)
 4 files changed, 297 insertions(+), 32 deletions(-)
```

which is the same 297/32 #17629 reports.

## Content

- `schnorr.ml`: documentation for the Schnorr scheme (+230)
- `signature_lib_tests.ml`: regression test for a secret key above the base field modulus, and the Legacy and Chunked suites merged
- `string_sign.{ml,README.md}`: marked deprecated, pointing at `signature_lib.Schnorr.{Legacy,Chunked}`

## Checks

`ocamlformat` clean on all three OCaml files. The test `dune` is unchanged across the move and still lists `pickles`, `random_oracle`, `random_oracle_input`, `signature_lib`, `snark_params`; `src/dune-project` sets `implicit_transitive_deps true`, so the `Mina_signature_kind_type` reference in the new test resolves as it did before.

Not compiled locally — this machine is at 99% disk and a cold build needs a full submodule clone. CI is the gate.

Once this is green, #17629 can be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6SAS5bpSRerwhF5FQPaLw