### PR TITLE
Fix benchmark comparator: it never checked thresholds

### DIFF
--- a/scripts/benchmarks/__main__.py
+++ b/scripts/benchmarks/__main__.py
@@ -47,6 +47,13 @@ compare_bench.add_argument("--red-threshold",help="defines how many percent curr
                            type=float,
                            choices=[Range(0.0, 1.0)],
                            default=0.2)
+compare_bench.add_argument("--policy",
+                               help="which directions of change count against a measurement: "
+                                    "upward fails only on a rise, upward-warn-on-drop also warns on a steep fall, "
+                                    "symmetric fails on any move outside the band",
+                               type=Policy,
+                               choices=list(Policy),
+                               default=Policy.upward)
 
 upload_bench = subparsers.add_parser('upload')
 upload_bench.add_argument("--infile")
@@ -68,6 +75,13 @@ test_bench.add_argument("--red-threshold",
                         type=float,
                         choices=[Range(0.0, 1.0)],
                         default=0.2)
+test_bench.add_argument("--policy",
+                            help="which directions of change count against a measurement: "
+                                 "upward fails only on a rise, upward-warn-on-drop also warns on a steep fall, "
+                                 "symmetric fails on any move outside the band",
+                            type=Policy,
+                            choices=list(Policy),
+                            default=Policy.upward)
 test_bench.add_argument("--branch", help="branch which was used in tests")
 test_bench.add_argument("--genesis-ledger-path", default="./genesis_ledgers/devnet.json", help="Applicable only for ledger-export benchmark. Location of genesis config file")
 test_bench.add_argument('-m','--mainline-branches', action='append', help='Defines mainline branch. If values of \'--branch\' parameter is among mainline branches then result will be uploaded')
@@ -133,7 +147,8 @@ if args.cmd == "parse":
 
 
 if args.cmd == "compare":
-    bench.compare(args.infile, args.yellow_threshold, args.red_threshold)
+    bench.compare(args.infile, args.yellow_threshold, args.red_threshold,
+                  args.policy)
 
 if args.cmd == "upload":
     bench.upload(args.infile)
@@ -151,7 +166,8 @@ if args.cmd == "test":
             branch=args.branch)
 
     [
-        bench.compare(file, args.yellow_threshold, args.red_threshold)
+        bench.compare(file, args.yellow_threshold, args.red_threshold,
+                      args.policy)
         for file in files
     ]
 

--- a/scripts/benchmarks/lib/__init__.py
+++ b/scripts/benchmarks/lib/__init__.py
@@ -1,3 +1,4 @@
+from .comparison import *
 from .influx import *
 from .bench import *
 from .utils import *

--- a/scripts/benchmarks/lib/bench.py
+++ b/scripts/benchmarks/lib/bench.py
@@ -8,7 +8,8 @@ import json
 import os
 from enum import Enum
 import logging
-from lib.utils import isclose, assert_cmd
+from lib.utils import assert_cmd
+from lib.comparison import Policy, Verdict, compare_measurement
 from lib.influx import *
 
 import csv
@@ -92,7 +93,8 @@ class Benchmark(abc.ABC):
         """
         pass
 
-    def compare(self, result_file, yellow_threshold, red_threshold):
+    def compare(self, result_file, yellow_threshold, red_threshold,
+                policy=Policy.upward):
         """
          Compares actual measurements against thresholds (yellow,red)
 
@@ -101,7 +103,9 @@ class Benchmark(abc.ABC):
          - implements influx csv format:
            https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/extended/
 
-         It gets moving average from influx db and adds grace values (yellow,red) to handle measurements skew.
+         It gets moving average from influx db and hands each measurement to
+         lib.comparison, which decides the verdict. Policy selects which
+         directions of change count against a measurement.
 
         """
         with open(result_file, newline='') as csvfile:
@@ -116,8 +120,6 @@ class Benchmark(abc.ABC):
                     result = self.influx_client.query_moving_average(
                         name, branch, str(field), self.branch_header())
 
-                    print(f"result: {result}")
-                    
                     records = result[-1].records if (result is not None) and (len(result) > 0) else []
 
                     if len(records) < self.influx_client.moving_average_size :
@@ -125,28 +127,25 @@ class Benchmark(abc.ABC):
                             f"Skipping comparison for {name} as there are no enough ({self.influx_client.moving_average_size}) historical data available yet"
                         )
                     else:
-                        average = float(records[-1]["_value"])
-
-                        current_red_threshold = average * red_threshold
-                        current_yellow_threshold = average * yellow_threshold
+                        comparison = compare_measurement(
+                            name=name,
+                            value=value,
+                            average=float(records[-1]["_value"]),
+                            yellow_ratio=yellow_threshold,
+                            red_ratio=red_threshold,
+                            policy=policy)
 
                         logger.debug(
-                            f"calculated thresholds: [red={current_red_threshold},yellow={current_yellow_threshold}]"
+                            f"calculated thresholds: [red={comparison.red_delta},yellow={comparison.yellow_delta}]"
                         )
 
-                        if isclose(value + red_threshold, average):
-                            logger.error(
-                                f"{name} measurement exceeds time greatly ({value + current_red_threshold} against {average}). failing the build"
-                            )
+                        if comparison.verdict is Verdict.red:
+                            logger.error(comparison.message)
                             exit(1)
-                        elif isclose(value + yellow_threshold, average):
-                            logger.warning(
-                                f"WARNING: {name} measurement exceeds expected time ({value + current_yellow_threshold} against {average})"
-                            )
+                        elif comparison.verdict is Verdict.yellow:
+                            logger.warning(comparison.message)
                         else:
-                            logger.info(
-                                f"comparison succesful for {name}. {value} is less than threshold [yellow={average + current_yellow_threshold},red={average + current_red_threshold}]"
-                            )
+                            logger.info(comparison.message)
 
     def upload(self, file):
         self.influx_client.upload_csv(file)

--- a/scripts/benchmarks/lib/bench.py
+++ b/scripts/benchmarks/lib/bench.py
@@ -133,7 +133,8 @@ class Benchmark(abc.ABC):
                             average=float(records[-1]["_value"]),
                             yellow_ratio=yellow_threshold,
                             red_ratio=red_threshold,
-                            policy=policy)
+                            policy=policy,
+                            unit=field.display_unit)
 
                         logger.debug(
                             f"calculated thresholds: [red={comparison.red_delta},yellow={comparison.yellow_delta}]"
@@ -171,11 +172,11 @@ class JaneStreetBenchmark(Benchmark, ABC):
 
     """
     name = MeasurementColumn("Name", 0)
-    time_per_runs = FieldColumn("Time/Run", 1, "us")
-    cycles_per_runs = FieldColumn("Cycls/Run", 2, "kc")
-    minor_words_per_runs = FieldColumn("mWd/Run", 3, "w")
-    major_words_per_runs = FieldColumn("mjWd/Run", 4, "w")
-    promotions_per_runs = FieldColumn("Prom/Run", 5, "w")
+    time_per_runs = FieldColumn("Time/Run", 1, "us", display_unit="microseconds")
+    cycles_per_runs = FieldColumn("Cycls/Run", 2, "kc", display_unit="kilocycles")
+    minor_words_per_runs = FieldColumn("mWd/Run", 3, "w", display_unit="words")
+    major_words_per_runs = FieldColumn("mjWd/Run", 4, "w", display_unit="words")
+    promotions_per_runs = FieldColumn("Prom/Run", 5, "w", display_unit="words")
     category = TagColumn("category", 6)
     branch = TagColumn("gitbranch", 7)
 
@@ -391,7 +392,7 @@ class LedgerApplyBenchmark(Benchmark):
     """
 
     name = MeasurementColumn("Name", 0)
-    time = FieldColumn("time",  1, "ms")
+    time = FieldColumn("time",  1, "ms", display_unit="milliseconds")
     preps_mean = FieldColumn("preps mean",  2, "")
     category = TagColumn("category", 3)
     branch = TagColumn("gitbranch", 4)
@@ -455,7 +456,7 @@ class ArchiveBenchmark(Benchmark):
     """
 
     name = MeasurementColumn("Name", 0)
-    time = FieldColumn("time",  1, "ms")
+    time = FieldColumn("time",  1, "ms", display_unit="milliseconds")
     category = TagColumn("category", 2)
     branch = TagColumn("gitbranch", 3)
 
@@ -614,8 +615,8 @@ class SnarkBenchmark(Benchmark):
     proofs_updates = FieldColumn("proofs updates", 1, "")
     nonproofs_pairs = FieldColumn("non-proof pairs", 2, "")
     nonproofs_singles = FieldColumn("non-proof singles", 3, "")
-    verification_time = FieldColumn("verification time", 4, "[s]")
-    proving_time = FieldColumn("value", 5, "[s]")
+    verification_time = FieldColumn("verification time", 4, "[s]", display_unit="seconds")
+    proving_time = FieldColumn("value", 5, "[s]", display_unit="seconds")
     category = TagColumn("category", 6)
     branch = TagColumn("gitbranch", 7)
 
@@ -710,8 +711,8 @@ class HeapUsageBenchmark(Benchmark):
     """
 
     name = MeasurementColumn("Name", 0)
-    heap_words = FieldColumn("heap words", 1, "")
-    bytes = FieldColumn("bytes", 2, "")
+    heap_words = FieldColumn("heap words", 1, "", display_unit="words")
+    bytes = FieldColumn("bytes", 2, "", display_unit="bytes")
     category = TagColumn("category", 3)
     branch = TagColumn("gitbranch", 4)
 

--- a/scripts/benchmarks/lib/comparison.py
+++ b/scripts/benchmarks/lib/comparison.py
@@ -50,6 +50,7 @@ class Comparison:
     yellow_delta: float
     red_delta: float
     verdict: Verdict
+    unit: str = ""
 
     @property
     def deviation(self):
@@ -64,18 +65,31 @@ class Comparison:
         delta = self.red_delta if self.verdict is Verdict.red else self.yellow_delta
         return self.average + delta if self.deviation >= 0 else self.average - delta
 
+    def quantity(self, value):
+        """
+         Renders a number in the unit it was measured in, when there is one.
+
+         Limits carry the float noise of a ratio applied to a moving average,
+         which no reader of a benchmark log needs, so they are rounded.
+        """
+        rounded = round(value, 2)
+        return f"{rounded} {self.unit}" if self.unit else f"{rounded}"
+
     @property
     def message(self):
         moved = "exceeds" if self.deviation >= 0 else "dropped below"
         if self.verdict is Verdict.red:
             return (f"{self.name} {moved} red threshold "
-                    f"({self.value} against {self.limit}). failing the build")
+                    f"({self.quantity(self.value)} against "
+                    f"{self.quantity(self.limit)}). failing the build")
         if self.verdict is Verdict.yellow:
             return (f"WARNING: {self.name} {moved} yellow threshold "
-                    f"({self.value} against {self.limit})")
-        return (f"comparison succesful for {self.name}. {self.value} is within "
-                f"threshold [yellow={self.average + self.yellow_delta},"
-                f"red={self.average + self.red_delta}]")
+                    f"({self.quantity(self.value)} against "
+                    f"{self.quantity(self.limit)})")
+        return (f"comparison succesful for {self.name}. "
+                f"{self.quantity(self.value)} is within threshold "
+                f"[yellow={self.quantity(self.average + self.yellow_delta)},"
+                f"red={self.quantity(self.average + self.red_delta)}]")
 
 
 def _grade(excess, yellow_delta, red_delta):
@@ -98,12 +112,13 @@ def _demote(verdict):
 
 
 def compare_measurement(name, value, average, yellow_ratio, red_ratio,
-                        policy=Policy.upward):
+                        policy=Policy.upward, unit=""):
     """
      Weighs a measurement against the moving average of its history.
 
      The ratios are fractions of the average, so 0.3 allows a 30% move before
-     the red verdict.
+     the red verdict. Unit names what was measured so messages can report it,
+     and never affects the verdict.
     """
     yellow_delta = abs(average) * yellow_ratio
     red_delta = abs(average) * red_ratio
@@ -123,4 +138,5 @@ def compare_measurement(name, value, average, yellow_ratio, red_ratio,
                       average=average,
                       yellow_delta=yellow_delta,
                       red_delta=red_delta,
-                      verdict=verdict)
+                      verdict=verdict,
+                      unit=unit)

--- a/scripts/benchmarks/lib/comparison.py
+++ b/scripts/benchmarks/lib/comparison.py
@@ -1,0 +1,126 @@
+"""
+ Decides whether a benchmark measurement has regressed against its history.
+
+ This module is deliberately free of influx, files and process exit, so the
+ decision can be tested on its own. Callers do the logging and the exiting.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class Policy(Enum):
+    """
+     Which directions of change count against a measurement.
+
+     Benchmarks here measure times, counts, words and bytes, so a rise is a
+     regression and a fall is usually an improvement. A steep fall can also
+     mean the benchmark broke, hence the middle policy.
+    """
+
+    upward = "upward"
+    upward_warn_on_drop = "upward-warn-on-drop"
+    symmetric = "symmetric"
+
+    def __str__(self):
+        return self.value
+
+
+class Verdict(Enum):
+    ok = "ok"
+    yellow = "yellow"
+    red = "red"
+
+    def __str__(self):
+        return self.value
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """
+     One measurement weighed against the moving average of its history.
+
+     yellow_delta and red_delta are absolute allowances, already scaled from
+     the ratios the caller passed in.
+    """
+
+    name: str
+    value: float
+    average: float
+    yellow_delta: float
+    red_delta: float
+    verdict: Verdict
+
+    @property
+    def deviation(self):
+        return self.value - self.average
+
+    @property
+    def limit(self):
+        """
+         The limit this measurement broke, on the side it broke it. Meaningless
+         for an ok verdict, where it reports the yellow limit it stayed within.
+        """
+        delta = self.red_delta if self.verdict is Verdict.red else self.yellow_delta
+        return self.average + delta if self.deviation >= 0 else self.average - delta
+
+    @property
+    def message(self):
+        moved = "exceeds" if self.deviation >= 0 else "dropped below"
+        if self.verdict is Verdict.red:
+            return (f"{self.name} {moved} red threshold "
+                    f"({self.value} against {self.limit}). failing the build")
+        if self.verdict is Verdict.yellow:
+            return (f"WARNING: {self.name} {moved} yellow threshold "
+                    f"({self.value} against {self.limit})")
+        return (f"comparison succesful for {self.name}. {self.value} is within "
+                f"threshold [yellow={self.average + self.yellow_delta},"
+                f"red={self.average + self.red_delta}]")
+
+
+def _grade(excess, yellow_delta, red_delta):
+    """
+     Grades how far a one-directional excess ran past the two allowances.
+    """
+    if excess > red_delta:
+        return Verdict.red
+    if excess > yellow_delta:
+        return Verdict.yellow
+    return Verdict.ok
+
+
+def _demote(verdict):
+    """
+     Downgrades a breach to a warning, so a policy can flag a move without
+     failing the build over it.
+    """
+    return Verdict.yellow if verdict is Verdict.red else verdict
+
+
+def compare_measurement(name, value, average, yellow_ratio, red_ratio,
+                        policy=Policy.upward):
+    """
+     Weighs a measurement against the moving average of its history.
+
+     The ratios are fractions of the average, so 0.3 allows a 30% move before
+     the red verdict.
+    """
+    yellow_delta = abs(average) * yellow_ratio
+    red_delta = abs(average) * red_ratio
+    deviation = value - average
+
+    if policy is Policy.symmetric:
+        verdict = _grade(abs(deviation), yellow_delta, red_delta)
+    elif deviation >= 0:
+        verdict = _grade(deviation, yellow_delta, red_delta)
+    elif policy is Policy.upward_warn_on_drop:
+        verdict = _demote(_grade(-deviation, yellow_delta, red_delta))
+    else:
+        verdict = Verdict.ok
+
+    return Comparison(name=name,
+                      value=value,
+                      average=average,
+                      yellow_delta=yellow_delta,
+                      red_delta=red_delta,
+                      verdict=verdict)

--- a/scripts/benchmarks/lib/influx.py
+++ b/scripts/benchmarks/lib/influx.py
@@ -33,13 +33,23 @@ class MeasurementColumn(HeaderColumn):
 class FieldColumn(HeaderColumn):
     """
         Column header which represents influx field header.
-        It has additional unit field which can be formatted as part of name
         Currently field is always a double (there was no need so far for different type)
+
+        Two units live here and they are not interchangeable:
+
+        - unit is baked into the influx field name by __str__, which is what
+          queries filter on, so changing it on an existing column orphans every
+          historical sample of that series
+        - display_unit is only ever shown to a reader, so it is safe to add or
+          correct at any time. Spell it out in full, "words" rather than "w",
+          so no one has to guess what a benchmark log is counting. It falls
+          back to unit when not given.
     """
 
-    def __init__(self, name, pos, unit=None):
+    def __init__(self, name, pos, unit=None, display_unit=None):
         HeaderColumn.__init__(self, name, influx_kind="double", pos=pos)
         self.unit = unit
+        self.display_unit = unit if display_unit is None else display_unit
 
     def __str__(self):
         if self.unit:

--- a/scripts/benchmarks/lib/utils.py
+++ b/scripts/benchmarks/lib/utils.py
@@ -5,10 +5,6 @@ from enum import Enum
 logger = logging.getLogger(__name__)
 
 
-def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
-    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
-
-
 def assert_cmd(cmd, envs=None):
     logger.debug(f"running command {cmd}")
     result = subprocess.run(cmd,

--- a/scripts/benchmarks/tests/test_columns.py
+++ b/scripts/benchmarks/tests/test_columns.py
@@ -1,0 +1,58 @@
+import unittest
+
+from lib.bench import (ArchiveBenchmark, HeapUsageBenchmark,
+                       JaneStreetBenchmark, LedgerApplyBenchmark,
+                       MinaBaseBenchmark, SnarkBenchmark,
+                       ZkappLimitsBenchmark)
+from lib.influx import FieldColumn
+
+
+class TestFieldColumn(unittest.TestCase):
+    """
+     Guards the split between the unit that names an influx series and the
+     unit that is only ever shown to a reader.
+    """
+
+    def test_display_unit_falls_back_to_unit(self):
+        column = FieldColumn("time", 1, "ms")
+        self.assertEqual("ms", column.display_unit)
+
+    def test_display_unit_stays_out_of_the_influx_field_name(self):
+        column = FieldColumn("heap words", 1, "", display_unit="words")
+        self.assertEqual("heap words", str(column))
+
+    def test_unit_still_names_the_influx_field(self):
+        self.assertEqual("Time/Run [us]", str(MinaBaseBenchmark.time_per_runs))
+
+    def test_heap_usage_fields_report_words_and_bytes(self):
+        self.assertEqual("words", HeapUsageBenchmark.heap_words.display_unit)
+        self.assertEqual("bytes", HeapUsageBenchmark.bytes.display_unit)
+
+    def test_heap_usage_series_names_are_unchanged(self):
+        self.assertEqual("heap words", str(HeapUsageBenchmark.heap_words))
+        self.assertEqual("bytes", str(HeapUsageBenchmark.bytes))
+
+    def test_snark_timings_display_without_the_doubled_bracket(self):
+        self.assertEqual("seconds",
+                         SnarkBenchmark.verification_time.display_unit)
+        self.assertEqual("verification time [[s]]",
+                         str(SnarkBenchmark.verification_time))
+
+    def test_every_declared_display_unit_is_spelled_out(self):
+        """
+         Abbreviations belong in the influx field name, not in a message a
+         person reads.
+        """
+        abbreviations = {"w", "B", "s", "ms", "us", "kc"}
+        holders = (JaneStreetBenchmark, SnarkBenchmark, HeapUsageBenchmark,
+                   LedgerApplyBenchmark, ArchiveBenchmark,
+                   ZkappLimitsBenchmark)
+        for holder in holders:
+            for name, column in vars(holder).items():
+                if isinstance(column, FieldColumn):
+                    self.assertNotIn(column.display_unit, abbreviations,
+                                     f"{holder.__name__}.{name}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/tests/test_compare.py
+++ b/scripts/benchmarks/tests/test_compare.py
@@ -1,0 +1,102 @@
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+
+from lib.bench import HeapUsageBenchmark
+from lib.comparison import Policy
+
+
+class FakeRecord(dict):
+    pass
+
+
+class FakeTable:
+
+    def __init__(self, average, size):
+        self.records = [FakeRecord(_value=average) for _ in range(size)]
+
+
+class FakeInflux:
+    """
+     Stands in for Influx so comparison can be exercised without a database.
+     Answers with a flat history at the average recorded for each field.
+    """
+
+    def __init__(self, averages, moving_average_size=10):
+        self.averages = averages
+        self.moving_average_size = moving_average_size
+
+    def query_moving_average(self, name, branch, field, branch_header):
+        return [FakeTable(self.averages[str(field)], self.moving_average_size)]
+
+
+def write_result(directory, heap_words):
+    """
+     Writes one heap usage row in the influx annotated csv layout compare reads.
+    """
+    result = Path(directory) / "result.csv"
+    result.write_text("#datatype ignored\n"
+                      "Name,heap words,bytes,category,gitbranch\n"
+                      f"Parallel_scan.Merge.t,{heap_words},{heap_words * 8},"
+                      "heap_usage,compatible\n")
+    return str(result)
+
+
+class TestBenchmarkCompare(unittest.TestCase):
+    """
+     Exercises the shell around the comparator: csv reading, influx lookup,
+     log level per verdict and the exit code.
+    """
+
+    average = 8696.0
+    yellow = 0.1
+    red = 0.3
+
+    def compare(self, heap_words, policy=Policy.upward):
+        bench = HeapUsageBenchmark()
+        bench.influx_client = FakeInflux({
+            "heap words": self.average,
+            "bytes": self.average * 8
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            bench.compare(write_result(tmp, heap_words), self.yellow, self.red,
+                          policy)
+
+    def test_measurement_at_baseline_logs_success(self):
+        with self.assertLogs("lib.bench", level=logging.INFO) as logs:
+            self.compare(self.average)
+        self.assertTrue(
+            any("comparison succesful" in line for line in logs.output))
+
+    def test_measurement_above_yellow_warns(self):
+        with self.assertLogs("lib.bench", level=logging.WARNING) as logs:
+            self.compare(self.average * 1.2)
+        self.assertTrue(
+            any("exceeds yellow threshold" in line for line in logs.output))
+
+    def test_measurement_above_red_fails_the_build(self):
+        with self.assertLogs("lib.bench", level=logging.ERROR):
+            with self.assertRaises(SystemExit) as exit_code:
+                self.compare(self.average * 1.5)
+        self.assertEqual(1, exit_code.exception.code)
+
+    def test_policy_reaches_the_comparator(self):
+        with self.assertLogs("lib.bench", level=logging.ERROR):
+            with self.assertRaises(SystemExit):
+                self.compare(self.average * 0.5, Policy.symmetric)
+
+    def test_short_history_is_skipped(self):
+        bench = HeapUsageBenchmark()
+        bench.influx_client = FakeInflux({})
+        bench.influx_client.query_moving_average = (
+            lambda *args: [FakeTable(self.average, 3)])
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertLogs("lib.bench", level=logging.WARNING) as logs:
+                bench.compare(write_result(tmp, 99999), self.yellow, self.red)
+        self.assertTrue(
+            any("Skipping comparison" in line for line in logs.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/tests/test_comparison.py
+++ b/scripts/benchmarks/tests/test_comparison.py
@@ -1,0 +1,89 @@
+import unittest
+
+from lib.comparison import Policy, Verdict, compare_measurement
+
+
+class TestCompareMeasurement(unittest.TestCase):
+    """
+     Exercises the verdict on its own, with no influx and no csv in the way.
+    """
+
+    average = 1000.0
+    yellow = 0.1
+    red = 0.3
+
+    def verdict(self, value, policy=Policy.upward):
+        return compare_measurement(name="Parallel_scan.Merge.t",
+                                   value=value,
+                                   average=self.average,
+                                   yellow_ratio=self.yellow,
+                                   red_ratio=self.red,
+                                   policy=policy).verdict
+
+    def test_measurement_on_the_baseline_is_ok(self):
+        self.assertIs(Verdict.ok, self.verdict(self.average))
+
+    def test_measurement_marginally_below_baseline_is_ok(self):
+        """
+         Shape of the false failure in build 42209, where a history averaging
+         0.3 above the measurement was read as a regression.
+        """
+        comparison = compare_measurement(name="Parallel_scan.Merge.t",
+                                         value=8696.0,
+                                         average=8696.3,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red)
+        self.assertIs(Verdict.ok, comparison.verdict)
+
+    def test_rise_within_yellow_is_ok(self):
+        self.assertIs(Verdict.ok, self.verdict(1099.0))
+
+    def test_rise_past_yellow_warns(self):
+        self.assertIs(Verdict.yellow, self.verdict(1200.0))
+
+    def test_rise_past_red_fails(self):
+        self.assertIs(Verdict.red, self.verdict(1500.0))
+
+    def test_threshold_is_exclusive(self):
+        self.assertIs(Verdict.ok, self.verdict(self.average * 1.1))
+        self.assertIs(Verdict.yellow, self.verdict(self.average * 1.3))
+
+    def test_upward_policy_ignores_any_drop(self):
+        self.assertIs(Verdict.ok, self.verdict(1.0))
+
+    def test_warn_on_drop_policy_warns_instead_of_failing(self):
+        policy = Policy.upward_warn_on_drop
+        self.assertIs(Verdict.ok, self.verdict(950.0, policy))
+        self.assertIs(Verdict.yellow, self.verdict(800.0, policy))
+        self.assertIs(Verdict.yellow, self.verdict(1.0, policy))
+        self.assertIs(Verdict.red, self.verdict(1500.0, policy))
+
+    def test_symmetric_policy_fails_on_a_steep_drop(self):
+        policy = Policy.symmetric
+        self.assertIs(Verdict.ok, self.verdict(950.0, policy))
+        self.assertIs(Verdict.yellow, self.verdict(800.0, policy))
+        self.assertIs(Verdict.red, self.verdict(1.0, policy))
+        self.assertIs(Verdict.red, self.verdict(1500.0, policy))
+
+    def test_message_names_the_limit_that_was_broken(self):
+        comparison = compare_measurement(name="Parallel_scan.Merge.t",
+                                         value=1500.0,
+                                         average=self.average,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red)
+        self.assertIn("exceeds red threshold", comparison.message)
+        self.assertIn("1500.0 against 1300.0", comparison.message)
+
+    def test_message_reports_the_direction_of_a_drop(self):
+        comparison = compare_measurement(name="Parallel_scan.Merge.t",
+                                         value=500.0,
+                                         average=self.average,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red,
+                                         policy=Policy.symmetric)
+        self.assertIn("dropped below red threshold", comparison.message)
+        self.assertIn("500.0 against 700.0", comparison.message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/benchmarks/tests/test_comparison.py
+++ b/scripts/benchmarks/tests/test_comparison.py
@@ -74,6 +74,33 @@ class TestCompareMeasurement(unittest.TestCase):
         self.assertIn("exceeds red threshold", comparison.message)
         self.assertIn("1500.0 against 1300.0", comparison.message)
 
+    def test_message_reports_the_unit_when_there_is_one(self):
+        comparison = compare_measurement(name="Parallel_scan.Merge.t",
+                                         value=1500.0,
+                                         average=self.average,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red,
+                                         unit="words")
+        self.assertIn("1500.0 words against 1300.0 words", comparison.message)
+
+    def test_message_reports_the_unit_on_success_too(self):
+        comparison = compare_measurement(name="Parallel_scan.Merge.t",
+                                         value=1000.0,
+                                         average=self.average,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red,
+                                         unit="bytes")
+        self.assertIn("1000.0 bytes is within threshold", comparison.message)
+        self.assertIn("yellow=1100.0 bytes", comparison.message)
+
+    def test_message_omits_the_unit_for_a_bare_count(self):
+        comparison = compare_measurement(name="proofs updates",
+                                         value=1500.0,
+                                         average=self.average,
+                                         yellow_ratio=self.yellow,
+                                         red_ratio=self.red)
+        self.assertIn("1500.0 against 1300.0", comparison.message)
+
     def test_message_reports_the_direction_of_a_drop(self):
         comparison = compare_measurement(name="Parallel_scan.Merge.t",
                                          value=500.0,


### PR DESCRIPTION
Fixes #19424.

## The bug

`Benchmark.compare` never compared a measurement against a threshold. It tested `isclose(value + red_threshold, average)`, which adds the raw ratio to the measurement and then asks whether the result equals the moving average. Two consequences:

- A build fails when a measurement sits a hair *below* its baseline. This is what took down `Perf: Heap Usage` on https://buildkite.com/o-1-labs-2/mina-o-1-labs/builds/42209, where `Parallel_scan.Merge.t` measured 8696 heap words against a moving average of 8696.3 and `isclose(8696.0 + 0.3, 8696.3)` returned true.
- A genuine regression takes the success branch and is reported as "comparison succesful".

All seven `Perf:` steps have been running without an effective check since the benchmarks moved into the python app in October 2024. The error text was wrong too: it said "exceeds time greatly" for a benchmark measuring heap words, and printed `value + current_red_threshold`, a number the check manufactured rather than either the measurement or the limit.

## What changed

**The decision moved into `lib/comparison.py`.** `compare_measurement` is free of influx, csv and process exit, so it can be tested on its own. `Benchmark.compare` is now the shell around it: read the row, query the history, pick a log level from the verdict, exit on red.

**Direction is a policy, not a hardcoded branch.** These benchmarks measure times, counts, words and bytes, so a rise is a regression and a fall is usually an improvement. A steep fall can also mean the benchmark itself broke, which nothing currently catches. Rather than pick for everyone, `--policy` selects, on the `compare` and `test` subcommands:

- `upward` fails only on a rise. This is the default and matches what the `--red-threshold` help has always documented.
- `upward-warn-on-drop` fails on a rise and warns on a steep fall, so a broken benchmark is visible without blocking an optimization.
- `symmetric` fails on any move outside the band.

**Measurements report their unit.** A failure reading `8696.0 against 11305.19` said nothing about whether those were words, bytes or seconds. `FieldColumn` already carried a unit, but `__str__` bakes it into the influx field name and that name is what queries filter on, so filling one in for `heap words` would have orphaned the whole historical series. The reader-facing unit is therefore a separate `display_unit`, spelled out in full, `words` rather than `w`, so nobody has to decode a benchmark log or guess whether `B` means bytes or bits. Every field that measures something declares one: `words`, `bytes`, `seconds`, `milliseconds`, `microseconds` and `kilocycles`. The dimensionless counts in the zkApp and ledger-apply benchmarks stay bare, and a test holds the line against abbreviations creeping back in. Limits are rounded, since a ratio applied to a moving average otherwise prints fifteen digits of float noise.

Before:

```
ERROR:lib.bench:Parallel_scan.Merge.t measurement exceeds time greatly (11304.89 against 8696.3). failing the build
```

After, for a measurement that really has regressed:

```
ERROR:lib.bench:Parallel_scan.Merge.t exceeds red threshold (13000.0 words against 11305.19 words). failing the build
```

Also drops the hand-rolled `isclose`, now unused, and a stray `print` that dumped a `FluxTable` repr into every CI log.

## Tests

26 cases, the first tests this app has had. Run them from `scripts/benchmarks`:

```
python3 -m unittest tests.test_comparison tests.test_compare tests.test_columns
```

- `test_comparison.py`, 14 cases, drives the verdict directly: all three policies, both directions, threshold exclusivity, message text and units, and the exact build 42209 shape of a measurement 0.3 below its average.
- `test_compare.py`, 5 cases, covers the shell with a stubbed influx client: csv reading, log level per verdict, exit code, policy pass-through, short-history skip.
- `test_columns.py`, 7 cases, pins the unit split. The display unit never reaches the influx field name, the heap usage series names stay byte-identical to what history holds, and no field declares an abbreviation as its display unit.

Nothing in Buildkite runs these yet. Worth a follow-up step so they do not rot.

## Notes for review

- Fixing the comparison turns on a check that has been inert for a year, so it may surface regressions hiding in the historical data of the other six `Perf:` jobs. Worth a look at the Influx series alongside this.
- `compare` still calls `exit(1)` on the first red, so later metrics in a run stay unevaluated. In build 42209 that hid the last three of thirty comparisons. Left alone here; it is a small change in the shell now if wanted.
- Targets Python 3.9, since the toolchain image is bullseye. No `match`, no `assert_never`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152GQbvCM5jRhmeAdh9xn1P


