### PR TITLE
bench: tag runs with their own branch, upload only from mainline

### DIFF
--- a/buildkite/scripts/bench/run.sh
+++ b/buildkite/scripts/bench/run.sh
@@ -4,7 +4,7 @@ set -eox pipefail
 
 YELLOW_THRESHOLD="0.1"
 RED_THRESHOLD="0.3"
-BRANCH="${BRANCH:-BUILDKITE_BRANCH}"
+BRANCH="${BRANCH:-${BUILDKITE_BRANCH:-local}}"
 
 while [[ "$#" -gt 0 ]]; do case $1 in
   heap-usage) BENCHMARK="heap-usage"; ;;
@@ -124,18 +124,28 @@ fi
 
 # Feed the bench data to mina-bench-upload: it parses the output, uploads the
 # records to InfluxDB (creds from the INFLUX_* env set by Benchmarks.toEnvList)
-# and runs the historical-mean regression check against the union of the
-# mainline branches (a wider, more stable baseline than a single branch, which
-# matters for noisy timing benches). A red regression exits non-zero.
-compare_flags=()
-for b in develop compatible master; do compare_flags+=(--compare-branch "$b"); done
+# and runs the historical-mean regression check against develop's history. A
+# red regression exits non-zero.
+#
+# Only mainline branches upload: a pull request build is tagged with its own
+# branch name and checked against develop, but never written to InfluxDB.
+#
+# The baseline is develop alone. compatible and master are still written by the
+# Python harness in different units (ns 1e6x, cycles 1e3x), so a union with
+# them averages incompatible values. Widen it again once those are corrected.
+upload_flags=()
+case "$BRANCH" in
+  develop|compatible|master) upload_flags=(--upload) ;;
+  *) echo "run.sh: branch '$BRANCH' is not mainline; skipping upload" ;;
+esac
+compare_flags=(--compare-branch develop)
 if [[ -n "$UPLOAD_INPUT" ]]; then
   # Parse-only bench: read the file the job's preCommands generated.
   mina-bench-upload \
     --format "$UPLOAD_FORMAT" \
     --input "$UPLOAD_INPUT" \
     --branch "$BRANCH" \
-    --upload \
+    "${upload_flags[@]}" \
     --check-regression \
     --yellow "$YELLOW_THRESHOLD" \
     --red "$RED_THRESHOLD" \
@@ -144,7 +154,7 @@ else
   run_ported_bench | mina-bench-upload \
     --format "$UPLOAD_FORMAT" \
     --branch "$BRANCH" \
-    --upload \
+    "${upload_flags[@]}" \
     --check-regression \
     --yellow "$YELLOW_THRESHOLD" \
     --red "$RED_THRESHOLD" \

--- a/buildkite/src/Command/Bench/Base.dhall
+++ b/buildkite/src/Command/Bench/Base.dhall
@@ -65,7 +65,7 @@ let command
                   spec.preCommands
                 # RunInToolchain.runInDefaultToolchain
                     (   Benchmarks.toEnvList Benchmarks.Type::{=}
-                      # [ "BRANCH=\\\${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-BUILDKITE_BRANCH}"
+                      # [ "BRANCH=\\\${BUILDKITE_BRANCH}"
                         ]
                       # DebianVersions.overrideEnvs
                     )


### PR DESCRIPTION
Since the benches moved to `mina-bench-upload`, benchmark data on develop has three problems. This PR fixes all three.

**1. Literal branch name.** `run.sh` and `Command/Bench/Base.dhall` fell back to the string `BUILDKITE_BRANCH` instead of the variable's value. InfluxDB now holds points tagged `gitbranch="BUILDKITE_BRANCH"`. Runs are now tagged with `$BUILDKITE_BRANCH`, or `local` when run outside CI.

**2. Pull request builds uploaded as their base branch.** `BRANCH` resolved to `BUILDKITE_PULL_REQUEST_BASE_BRANCH`, and `--upload` was passed unconditionally. As a result, every PR into develop wrote unmerged measurements from arbitrary agents under `develop`. The old Python harness only uploaded from mainline branches. This PR restores that: runs upload only when the branch is `develop`, `compatible` or `master`. PR builds still run the regression check.

**3. The baseline mixed unit scales.** The regression check averaged history from develop, compatible and master. compatible and master are still written by the Python harness, which stores nanosecond values 1e6 too large and plain cycle counts 1e3 too large. develop's baseline for those measurements (`State_hash * encode`, `parse_runtime_config`, `convert_accounts_for_config`, `serialize_runtime_config`) was therefore meaningless. The check now compares against develop alone. It can be widened again once compatible and master store correct units.

Not in this PR: existing bad points already in InfluxDB (`BUILDKITE_BRANCH`-tagged ones and PR data under `develop`) are not cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMcQ7q81XW9z9XFoyVsghb
