### PR TITLE
[develop] ci: build minimina on noble toolchain (port of #19465)

### DIFF
--- a/scripts/version-linter.py
+++ b/scripts/version-linter.py
@@ -240,10 +240,6 @@ def check_type_shapes(pr_branch_dict,base_branch,base_type_dict,release_branch,r
         set_error()
     # not an error if the type was introduced in the base branch, and the type changed in PR branch
 
-def assert_commit(commit, desc):
-  if not commit:
-    f"Empty commit detected when evaluating commit of {desc}"
-
 if __name__ == "__main__":
   if len(sys.argv) != 4 :
         print("Usage: %s pr-branch base-branch release-branch" % sys.argv[0], file=sys.stderr)

--- a/src/app/trace-tool/Cargo.toml
+++ b/src/app/trace-tool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "trace-tool"
 version = "0.1.0"
 authors = ["Corey Richardson <cmr@o1labs.org>"]
+edition = "2021"
 
 [dependencies]
 clap = "2.32.0"


### PR DESCRIPTION
Port of #19465 to `develop`.

## Why there is no net minimina diff

The minimina change originated on `develop`: `38db60d519` ("ci(arm64): keep only Bookworm devnet/toolchain on arm64, run via QEMU on amd64", port of #18878) already made the step amd64-only on noble. #19465 brings that shape to `compatible`. So `develop` needs the **merge**, not the content — without it the next `compatible` ↔ `develop` sync conflicts on the minimina files.

## Conflict resolved

`buildkite/src/Command/Minimina.dhall` — both branches add the file:

| side | call |
|---|---|
| `compatible` (#19465) | `RunInToolchain.runInToolchainNoble [ "ARCHITECTURE=amd64" ] script` |
| `develop` (HEAD) | `RunInToolchain.runInToolchain RunInToolchain.Config::{ image = ..., environment = ..., innerScript = ... }` |

Kept develop's side. `runInToolchainNoble` no longer exists on `develop` — its RunInToolchain refactor removed it — so the compatible side would not compile here. The rest of the file is identical on both sides: same script, same `noble` codename, same amd64-only step, same `Size.Small`.

## What else the merge brings

`compatible` commits that were still missing from `develop`:

- #18602 — remove the unused `assert_commit` helper (`scripts/version-linter.py`)
- #17727 — add `edition = "2021"` to `src/app/trace-tool/Cargo.toml`

Net diff vs `develop` is those two files, +1/-4.

## Verification

- `make all` in `buildkite/` returns 0; 18 tests, 48 passed, 0 failed
- `python3 -m py_compile scripts/version-linter.py` passes
- `compatible` and the #19465 branch are both ancestors of this branch

Merge after #19465 lands on `compatible`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QruWpDAMCGc3aSgvcacNCd
